### PR TITLE
Enable CLI completion of commands

### DIFF
--- a/cmd/kronk/main.go
+++ b/cmd/kronk/main.go
@@ -35,7 +35,6 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.Version = version
 
 	rootCmd.PersistentFlags().String("base-path", "", "Base path for kronk data (models, templates, catalog)")


### PR DESCRIPTION
This turns back on the CLI completion to allow users to discover/use the CLI faster.