### PR TITLE
fix: allow Devices config

### DIFF
--- a/sdk/kronk/model/config.go
+++ b/sdk/kronk/model/config.go
@@ -445,10 +445,6 @@ func validateConfig(ctx context.Context, cfg Config, log applog.Logger) error {
 		return fmt.Errorf("validate-config: model file is required")
 	}
 
-	if len(cfg.Devices) > 0 {
-		return fmt.Errorf("validate-config: Device and Devices are mutually exclusive; use Devices only (Device is deprecated)")
-	}
-
 	if len(cfg.TensorSplit) > 0 && len(cfg.Devices) > 0 && len(cfg.TensorSplit) != len(cfg.Devices) {
 		return fmt.Errorf("validate-config: TensorSplit length (%d) must match Devices length (%d)", len(cfg.TensorSplit), len(cfg.Devices))
 	}

--- a/sdk/kronk/model/config_test.go
+++ b/sdk/kronk/model/config_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 )
 
@@ -73,5 +74,31 @@ func TestParseGGMLType(t *testing.T) {
 				t.Errorf("ParseGGMLType() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	discardLogger := func(ctx context.Context, msg string, args ...any) {}
+
+	tests := []struct {
+		want    string
+		cfg     Config
+		wantErr bool
+	}{
+		{"multi GPU setup is valid", NewConfig(
+			WithDevices([]string{"CUDA0", "CUDA1"}),
+			WithModelFiles([]string{"dummy.gguf"}),
+		), false},
+	}
+	{
+		for _, tt := range tests {
+			t.Run(tt.want, func(t *testing.T) {
+				err := validateConfig(context.Background(), tt.cfg, discardLogger)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Kronk raises an error if the configuration contains devices. This seems to be a stale check from a former refactoring from a `Config.Device` (string) to `Config.Devices` (slice of strings) and a migration phase, where both were present but mutually exclusive. Today, there is only `Devices` and it must be set on multi GPU configurations, but errors out:

```acquire-model: unable to create inference model: validate-config: unable to validate config: validate-config: Device and Devices are mutually exclusive; use Devices only (Device is deprecated)```

I wrote a test case to validate what I saw in production and fixed it by removing the check. Tests pass and I am able to distribute tensors now.

## Concrete use case

I am running kronk on a multi NVIDIA GPU setup (3090 with 24 GB VRAM and 3080 with 10 GB VRAM). Both GPUs are being detected and named CUDA0 and CUDA1. To use both, I need to configure `devices`, otherwise there were `null`.
Tensor split is uneven due to the different VRAM sizes, split mode is `row` for the MoE model.

This is my model config:

```yaml
Qwen3.6-35B-A3B-UD-Q4_K_M:
  context-window: 65536
  nseq-max: 1
  cache-type-k: f16
  cache-type-v: f16
  flash-attention: enabled
  devices: [CUDA0, CUDA1]
  tensor-split: [0.75, 0.25]
  split-mode: row
  sampling-parameters:
    temperature: 0.6
    top_k: 20
    top_p: 0.95
```

When kronk tries to load the model, this error appears:
```json
{
  "time": "2026-05-10T12:54:46.256370764+02:00",
  "level": "INFO",
  "file": "pool.go:469",
  "msg": "acquire-model",
  "service": "KRONK",
  "status": "load-failed-reservation-released",
  "key": "Qwen3.6-35B-A3B-UD-Q4_K_M",
  "ERROR": "validate-config: unable to validate config: validate-config: Device and Devices are mutually exclusive; use Devices only (Device is deprecated)",
  "trace_id": "4b10b75c-0672-4b13-ad1f-16b5e2a24d32"
}
```

The line above is part of this full sequence:
```json
{"time":"2026-05-10T12:54:45.950847919+02:00","level":"INFO","file":"logging.go:26","msg":"request started","service":"KRONK","method":"POST","path":"/v1/chat/completions","remoteaddr":"100.64.0.8:64160","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:45.95164993+02:00","level":"INFO","file":"authapp.go:53","msg":"***> auth","service":"KRONK","status":"authentication disabled","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:45.95178979+02:00","level":"INFO","file":"pool.go:417","msg":"acquire-model","service":"KRONK","status":"cache-miss","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256254944+02:00","level":"INFO","file":"plan.go:73","msg":"plan-request","service":"KRONK","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","model-id":"Qwen3.6-35B-A3B-UD-Q4_K_M","source":"calculate-vram","predicted-total":"33.2GB","predicted-vram":"33.2GB","predicted-system":"0B","context-window":131072,"slots":1,"bytes-per-element":2,"experts-on-gpu":2147483647,"vram":"33.2GB","ram":"0B","devices":["CUDA0","CUDA1"],"tensor-split":[0.75,0.25],"trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256314694+02:00","level":"INFO","file":"pool.go:727","msg":"reserve","service":"KRONK","status":"begin","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","vram":"33.2GB","ram":"0B","devices":["CUDA0","CUDA1"],"items-in-pool":0,"max-models-in-pool":10,"trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256328344+02:00","level":"INFO","file":"pool.go:782","msg":"reserve","service":"KRONK","status":"success","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","attempt":0,"trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256340044+02:00","level":"INFO","file":"pool.go:460","msg":"acquire-model","service":"KRONK","status":"reserved","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","plan-vram":"33.2GB","plan-ram":"0B","alloc[0]":"device=CUDA0 bytes=24.9GB","alloc[1]":"device=CUDA1 bytes=8.3GB","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256354754+02:00","level":"INFO","file":"logging.go:63","msg":"pool","service":"KRONK","status":"resman-usage","op":"post-reserve","reservations":1,"ram-used":"0B","ram-budget":"67.3GB","gpu[0]":"name=CUDA0 used=24.9GB/25.0GB (134.8MB free)","gpu[1]":"name=CUDA1 used=8.3GB/10.1GB (1.8GB free)","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256370764+02:00","level":"INFO","file":"pool.go:469","msg":"acquire-model","service":"KRONK","status":"load-failed-reservation-released","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","ERROR":"validate-config: unable to validate config: validate-config: Device and Devices are mutually exclusive; use Devices only (Device is deprecated)","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256384494+02:00","level":"INFO","file":"logging.go:63","msg":"pool","service":"KRONK","status":"resman-usage","op":"post-failed-load","reservations":0,"ram-used":"0B","ram-budget":"67.3GB","gpu[0]":"name=CUDA0 used=0B/25.0GB (25.0GB free)","gpu[1]":"name=CUDA1 used=0B/10.1GB (10.1GB free)","key":"Qwen3.6-35B-A3B-UD-Q4_K_M","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256429914+02:00","level":"INFO","file":"main.go:47","msg":"******* SEND ALERT *******","service":"KRONK","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256426294+02:00","level":"ERROR","file":"errors.go:35","msg":"handled error during request","service":"KRONK","err":"acquire-model: unable to create inference model: validate-config: unable to validate config: validate-config: Device and Devices are mutually exclusive; use Devices only (Device is deprecated)","source_err_file":"chatapp.go:47","source_err_func":"chatapp.(*app).chatCompletions","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
{"time":"2026-05-10T12:54:46.256444724+02:00","level":"INFO","file":"logging.go:40","msg":"request completed","service":"KRONK","method":"POST","path":"/v1/chat/completions","remoteaddr":"100.64.0.8:64160","statuscode":"invalid_argument","since":"305.599945ms","trace_id":"4b10b75c-0672-4b13-ad1f-16b5e2a24d32"}
```