### PR TITLE
Fixed Remove reporting success on failed model deletion

### DIFF
--- a/sdk/tools/models/remove.go
+++ b/sdk/tools/models/remove.go
@@ -13,7 +13,7 @@ import (
 // Remove remove the specified file from the models directory.
 func (m *Models) Remove(mp Path, log applog.Logger) (err error) {
 	defer func() {
-		if errDfr := m.BuildIndex(log, false); err != nil {
+		if errDfr := m.BuildIndex(log, false); errDfr != nil && err == nil {
 			err = errDfr
 		}
 	}()

--- a/sdk/tools/models/remove_test.go
+++ b/sdk/tools/models/remove_test.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRemove_ErrorOnFailedDelete(t *testing.T) {
+	m := newTestModels(t)
+
+	mp := Path{
+		ModelFiles: []string{filepath.Join(t.TempDir(), "does-not-exist.gguf")},
+	}
+
+	if err := m.Remove(mp, testLog); err == nil {
+		t.Fatal("Remove returned nil error after a failed deletion; want non-nil error")
+	}
+}


### PR DESCRIPTION
`Models.Remove` runs `BuildIndex` in a deferred func that gated the error
assignment on the named return `err` instead of the rebuild result `errDfr`:

    // before
    if errDfr := m.BuildIndex(log, false); err != nil {
        err = errDfr
    }

When `os.Remove` failed, `err` was non-nil so the branch ran and overwrote it
with `errDfr` (normally nil) — `Remove` returned nil for a model that was never
deleted. The server delete endpoint (`toolapp/models.go`) and the CLI
(`cmd/kronk/.../model/remove`) then reported success. Conversely, on a clean
removal a `BuildIndex` failure was silently dropped.

    // after — surface rebuild error only when there's no prior error
    if errDfr := m.BuildIndex(log, false); errDfr != nil && err == nil {
        err = errDfr
    }

Regression introduced in #550. Added a hermetic test that fails on the old code
and passes on the fix.