### PR TITLE
Pipeline improvements

### DIFF
--- a/.github/actions/setup-kronk/action.yml
+++ b/.github/actions/setup-kronk/action.yml
@@ -1,16 +1,29 @@
 name: Set up Kronk test environment
 description: >
-  Frees disk space, installs Go pinned to go.mod, restores the shared
-  models cache, builds the kronk CLI, installs the llama.cpp + whisper.cpp
-  libraries and (on cache miss) pulls every model required by the
-  integration tests. Re-used from the parallel test jobs in linux.yml so
-  api-tests and sdk-tests start from an identical environment and share
-  setup-go's Go module + build cache via the common cache key.
+  Frees disk space, installs Go pinned to .go-version, restores the
+  shared libraries + models caches, builds the kronk CLI, installs the
+  llama.cpp + whisper.cpp libraries and (on cache miss) pulls every
+  model listed in .github/test-models.txt. Re-used from the parallel
+  test jobs in linux.yml so api-tests and sdk-tests start from an
+  identical environment and share setup-go's Go module + build cache
+  via the common cache key.
+
+inputs:
+  models-cache-key:
+    description: >
+      The cache key for the kronk + bucky model directories. Callers
+      should bake hashFiles('.github/test-models.txt') into the key so
+      that adding or changing a required model automatically
+      invalidates the cache instead of silently reusing a stale set.
+    required: true
 
 outputs:
-  cache-hit:
+  models-cache-hit:
     description: "Whether the models cache was a hit."
     value: ${{ steps.cache-models.outputs.cache-hit }}
+  models-cache-key:
+    description: "The resolved models-cache key (echoed back so the caller can re-use it for the save step)."
+    value: ${{ inputs.models-cache-key }}
 
 runs:
   using: composite
@@ -29,20 +42,34 @@ runs:
     # version for govulncheck. The .go-version file is also picked up
     # automatically by asdf, mise, goenv, gvm, and direnv's use_go.
     # setup-go's cache key includes the resolved Go version, so all jobs
-    # using this file share the same cache.
+    # using this file share the same Go module + build cache.
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
       with:
         go-version-file: .go-version
 
+    # Native llama.cpp + whisper.cpp library cache. Keyed on the version
+    # constants in their installer packages, so a defaultVersion bump in
+    # code invalidates this cache without bumping any cache-key suffix
+    # by hand. Separate from the models cache because libs change far
+    # less often.
+    - name: Restore libraries cache
+      id: cache-libs
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+      with:
+        path: |
+          ~/.kronk/libraries
+          ~/.kronk/bucky-libraries
+        key: ${{ runner.os }}-kronk-libs-${{ hashFiles('sdk/tools/libs/libs.go', 'sdk/tools/bucky/libs/**/*.go') }}
+
     - name: Restore models cache
       id: cache-models
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
       with:
         path: |
           ~/.kronk/models
           ~/.kronk/bucky-models
-        key: ${{ runner.os }}-models-v4
+        key: ${{ inputs.models-cache-key }}
 
     - name: Install kronk command
       shell: bash
@@ -57,6 +84,9 @@ runs:
       # `kronk bucky libs --local` does the same for the whisper.cpp
       # backend used by the bucky pool and the
       # /v1/audio/transcriptions endpoint.
+      #
+      # Both commands are idempotent: on a libraries cache hit they
+      # re-detect the on-disk version and short-circuit.
       shell: bash
       run: |
         mkdir -p $HOME/.kronk/libraries
@@ -66,10 +96,29 @@ runs:
     - name: Download test models
       if: steps.cache-models.outputs.cache-hit != 'true'
       shell: bash
+      # The model list lives in .github/test-models.txt (one
+      # `<backend> <model-id>` per line). The same file is hashed into
+      # the cache key by the caller, so any change here forces a
+      # download on the next run instead of silently reusing a stale
+      # cache that's missing the new entry.
       run: |
+        set -euo pipefail
         mkdir -p $HOME/.kronk/models
-        kronk model pull --local unsloth/Qwen3.5-0.8B-Q8_0
-        kronk model pull --local Qwen/Qwen3-8B-Q8_0
-        kronk model pull --local ggml-org/embeddinggemma-300m-qat-Q8_0
-        kronk model pull --local gpustack/bge-reranker-v2-m3-Q8_0
-        kronk bucky model pull --local tiny.en
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Strip comments / blanks.
+          line="${line%%#*}"
+          line="${line#"${line%%[![:space:]]*}"}"
+          line="${line%"${line##*[![:space:]]}"}"
+          [[ -z "$line" ]] && continue
+          # shellcheck disable=SC2086  # intentional word-splitting on the space.
+          set -- $line
+          backend="$1"; model="$2"
+          case "$backend" in
+            kronk) kronk model pull --local "$model" ;;
+            bucky) kronk bucky model pull --local "$model" ;;
+            *)
+              echo "::error file=.github/test-models.txt::Unknown backend '$backend' (expected 'kronk' or 'bucky')"
+              exit 1
+              ;;
+          esac
+        done <.github/test-models.txt

--- a/.github/test-models.txt
+++ b/.github/test-models.txt
@@ -1,0 +1,20 @@
+# Models pulled by the setup-kronk composite action for CI integration
+# tests (api/service tests and sdk tests in linux.yml). Each line is:
+#
+#   <backend> <model-id>
+#
+# where backend is `kronk` (LLM/embed/rerank, pulled via `kronk model pull`)
+# or `bucky` (audio transcription, pulled via `kronk bucky model pull`).
+#
+# Blank lines and lines starting with `#` are ignored.
+#
+# This file is hashed into the models-cache key — adding, removing, or
+# renaming a model automatically invalidates the cache on the next run,
+# so the test environment never silently goes stale against the test
+# expectations. Do NOT add comments at the end of model lines.
+
+kronk unsloth/Qwen3.5-0.8B-Q8_0
+kronk Qwen/Qwen3-8B-Q8_0
+kronk ggml-org/embeddinggemma-300m-qat-Q8_0
+kronk gpustack/bge-reranker-v2-m3-Q8_0
+bucky tiny.en

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -136,13 +136,19 @@ jobs:
           # --paginate` follows `Link: next` headers automatically and
           # emits ONE top-level JSON array PER PAGE on stdout — `jq -s
           # 'add // []'` slurps the resulting stream of arrays and
-          # concatenates them into a single flat array (and yields `[]`
-          # when the package doesn't exist yet — first run, before any
-          # cache has been pushed — so the downstream jq filters work
-          # uniformly).
-          all="$(gh api --paginate \
+          # concatenates them into a single flat array.
+          #
+          # `gh api` itself exits non-zero on 404 (e.g. first run, before
+          # any cache has been pushed and the package therefore doesn't
+          # exist yet) — `set -euo pipefail` would otherwise abort the
+          # workflow. Treat any error from the listing as "nothing to
+          # prune" and continue with an empty array.
+          if ! all="$(gh api --paginate \
             "/orgs/${ORG}/packages/container/${BUILDCACHE_PACKAGE}/versions?per_page=100" \
-            2>/dev/null | jq -s 'add // []')"
+            2>/dev/null | jq -s 'add // []')"; then
+            echo "Package versions API returned an error — assuming no cache to prune yet."
+            all='[]'
+          fi
 
           stale="$(echo "${all}" | jq -c --argjson cutoff "${cutoff_epoch}" '
             [ .[] | select((.updated_at | fromdateiso8601) < $cutoff) ]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -461,8 +461,8 @@ jobs:
           && matrix.variant == 'cpu'
           && matrix.arch == 'amd64'
         run: |
-          docker run --rm kronk-smoke:latest kronk --version
-          docker run --rm kronk-smoke:latest kronk --help
+          docker run --rm --entrypoint kronk kronk-smoke:latest --version
+          docker run --rm --entrypoint kronk kronk-smoke:latest --help
 
       # Push event path: build & push by digest only. Final tags get
       # applied by the `merge` job once both arches are available.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Docker
 
 # Build (and on push: publish) the kronk container image variants defined in
-# zarf/docker/kronk/Dockerfile. Six variants are produced:
+# zarf/docker/kronk/Dockerfile. Five variants are produced:
 #
 #   cpu      — minimal, runs on any host (all arches)
 #   cuda     — NVIDIA CUDA runtime baked in
@@ -19,8 +19,10 @@ name: Docker
 # Multi-arch images (cpu / cuda / vulkan / all) are built natively on
 # `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) runners, then
 # stitched into a single manifest with `docker buildx imagetools create`.
-# This avoids the ~5x slowdown of QEMU emulation for arm64 builds. Rocm
-# skips the manifest merge step because they're single-arch.
+# This avoids the ~5x slowdown of QEMU emulation for arm64 builds. The
+# single-arch `rocm` variant still goes through `merge`; `imagetools
+# create` happily wraps a single platform manifest under the same tag
+# scheme so consumers can pull `rocm` by tag without caring about arch.
 #
 # ┌────────────────────┬─────────────────────────────────────────────────────┐
 # │ Event              │ Behaviour                                           │
@@ -112,7 +114,7 @@ jobs:
     steps:
       # Needed for the tag-vs-constant guard below. Sparse to keep the
       # planner cheap — only the script and the one file it inspects.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           sparse-checkout: |
             .github/scripts
@@ -136,6 +138,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_LABEL_NAME: ${{ github.event.label.name }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_ACTOR: ${{ github.event.sender.login }}
           DISPATCH_VARIANTS: ${{ github.event.inputs.variants }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -227,11 +230,51 @@ jobs:
               PR_FILES="$(gh api --paginate \
                 "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
                 --jq '.[].filename')"
-              if ! grep -Eq '(\.go$|^go\.(mod|sum)$|^cmd/server/api/frontends/bui/|^zarf/docker/kronk/|^zarf/kms/|^\.github/workflows/docker\.yml$)' <<<"$PR_FILES"; then
+              if ! grep -Eq '(\.go$|^go\.(mod|sum)$|^\.go-version$|^\.dockerignore$|^cmd/server/api/frontends/bui/|^zarf/docker/kronk/|^zarf/kms/|^\.github/workflows/docker\.yml$)' <<<"$PR_FILES"; then
                 echo "Skipping: PR diff touches no Docker-relevant paths"
                 PR_RELEVANT=false
               fi
             fi
+          fi
+
+          # -------------------------------------------------------------------
+          # Build-label permission gate
+          #
+          # `build *` labels expand the matrix to expensive multi-arch
+          # variants, so they're restricted to users with `write`,
+          # `maintain`, or `admin` permission on the repo. The
+          # label-guard.yml workflow handles the user-visible cleanup
+          # (removes the label, posts a comment), but its cleanup
+          # actions use GITHUB_TOKEN, which does NOT trigger downstream
+          # workflow runs — so we can't rely on it to cancel an
+          # in-flight build via an `unlabeled` event. Instead, replicate
+          # the check here and strip the unauthorized label from
+          # PR_LABELS so the matrix never sees it.
+          #
+          # Only the `labeled` action needs to be gated: every other
+          # `build *` label on the PR was already vetted when it was
+          # applied (each label application fires its own `labeled`
+          # event, including labels applied at PR-creation time).
+          # -------------------------------------------------------------------
+          if [[ "$EVENT" == "pull_request" \
+             && "$ACTION" == "labeled" \
+             && "$PR_LABEL_NAME" == build\ * \
+             && "$PR_ACTOR" != "github-actions[bot]" ]]; then
+            ENCODED_ACTOR="$(jq -rn --arg s "$PR_ACTOR" '$s|@uri')"
+            PERMISSION="$(gh api \
+              "/repos/$GITHUB_REPOSITORY/collaborators/$ENCODED_ACTOR/permission" \
+              --jq '.permission' 2>/dev/null || echo none)"
+            PERMISSION="${PERMISSION:-none}"
+            case "$PERMISSION" in
+              admin|maintain|write)
+                echo "Authorized build label '$PR_LABEL_NAME' from $PR_ACTOR (permission=$PERMISSION)"
+                ;;
+              *)
+                echo "::warning::Ignoring unauthorized build label '$PR_LABEL_NAME' from '$PR_ACTOR' (permission=$PERMISSION)"
+                PR_LABELS="$(jq -c --arg n "$PR_LABEL_NAME" \
+                  'map(select(. != $n))' <<<"$PR_LABELS")"
+                ;;
+            esac
           fi
 
           # -------------------------------------------------------------------
@@ -351,10 +394,10 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h /
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 
       # Always log in to GHCR — even on the PR / workflow_dispatch path,
       # so the registry-backed BuildKit cache (BUILDCACHE_IMAGE) can be
@@ -362,7 +405,7 @@ jobs:
       # has package:read; PRs from forks will silently miss the cache
       # and rebuild from scratch (still correct, just slower).
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -370,7 +413,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: needs.plan.outputs.push == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -378,25 +421,48 @@ jobs:
       # PR / workflow_dispatch path: build, no push. Validates the
       # Dockerfile compiles and produces a runnable image for this arch.
       #
+      # The cpu/amd64 PR build additionally loads the resulting image
+      # into the local Docker daemon so the smoke-test step below can
+      # `docker run` it. Loading is restricted to a single (variant,
+      # arch) pair so we don't pay the cost on every matrix entry — cpu
+      # is the most-shared Dockerfile path and amd64 is the only arch
+      # whose local daemon matches the runner's host arch.
+      #
       # READ from the registry cache but do NOT write to it on this path.
       # PR validation builds don't need to refresh the cache, and writing
       # them would mean any PR could overwrite the trunk-seeded layers.
       # Push builds (below) seed the cache for future PRs to consume.
       - name: Build (no push)
         if: needs.plan.outputs.push != 'true'
-        uses: docker/build-push-action@v7
+        id: build_nopush
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: zarf/docker/kronk/Dockerfile
           platforms: ${{ matrix.platform }}
           target: ${{ matrix.target }}
           push: false
-          load: false
+          load: ${{ matrix.variant == 'cpu' && matrix.arch == 'amd64' }}
+          tags: ${{ matrix.variant == 'cpu' && matrix.arch == 'amd64' && 'kronk-smoke:latest' || '' }}
           build-args: |
             LLAMA_PROCESSORS=${{ matrix.processors }}
             BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
             KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
+
+      # Smoke test: prove the cpu/amd64 image actually starts and the
+      # entrypoint resolves the kronk binary. Catches breakage like a
+      # missing shared library or a bad ENTRYPOINT path that the build
+      # alone would not detect. Runs only on the (cpu, amd64, no-push)
+      # path — see `load:` above.
+      - name: Smoke test cpu/amd64 image
+        if: >-
+          needs.plan.outputs.push != 'true'
+          && matrix.variant == 'cpu'
+          && matrix.arch == 'amd64'
+        run: |
+          docker run --rm kronk-smoke:latest kronk --version
+          docker run --rm kronk-smoke:latest kronk --help
 
       # Push event path: build & push by digest only. Final tags get
       # applied by the `merge` job once both arches are available.
@@ -426,7 +492,7 @@ jobs:
       - name: Build & push by digest to GHCR
         if: needs.plan.outputs.push == 'true'
         id: build_ghcr
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: zarf/docker/kronk/Dockerfile
@@ -443,7 +509,7 @@ jobs:
       - name: Build & push by digest to Docker Hub
         if: needs.plan.outputs.push == 'true'
         id: build_dh
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: zarf/docker/kronk/Dockerfile
@@ -473,7 +539,7 @@ jobs:
 
       - name: Upload GHCR digest
         if: needs.plan.outputs.push == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: digests-ghcr-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/ghcr/*
@@ -482,7 +548,7 @@ jobs:
 
       - name: Upload Docker Hub digest
         if: needs.plan.outputs.push == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: digests-dh-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/dh/*
@@ -493,9 +559,11 @@ jobs:
   # merge
   #
   # Per-variant: assemble the multi-arch manifest from the per-arch digests
-  # uploaded by `build`, and apply the human-readable tags. Single-arch
-  # variants (rocm) still go through here — `imagetools create`
-  # happily wraps a single platform.
+  # uploaded by `build`, apply the human-readable tags, and then sign
+  # every published tag with cosign keyless (OIDC). The single-arch
+  # `rocm` variant still goes through here — `imagetools create` happily
+  # wraps a single platform under the same tag scheme so consumers can
+  # pull `rocm` without caring about arch.
   # ---------------------------------------------------------------------------
   merge:
     needs: [plan, build]
@@ -508,36 +576,54 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write   # cosign keyless signing exchanges this OIDC token for a Fulcio cert
     steps:
+      # `merge-multiple: true` extracts every matching artifact's
+      # contents flat into `path/`, regardless of how many artifacts
+      # match. Without it, download-artifact@v8 has an asymmetry that
+      # bit us once already: with 2+ matches it creates per-artifact
+      # subdirectories (path/<artifact_name>/<file>), but with exactly
+      # 1 match it silently extracts straight into path/ (no subdir,
+      # see actions/download-artifact src/download-artifact.ts: the
+      # `artifacts.length === 1` branch). The single-arch rocm variant
+      # has only one matching artifact, so the merge step then found
+      # nothing under the expected subdir and called `imagetools
+      # create` with an empty source ref. Flattening everything makes
+      # the layout uniform across variants — collisions can't happen
+      # because each artifact's only file is named with its unique
+      # image digest.
       - name: Download GHCR digests for this variant
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: /tmp/digests/ghcr
           pattern: digests-ghcr-${{ matrix.variant }}-*
+          merge-multiple: true
 
       - name: Download Docker Hub digests for this variant
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: /tmp/digests/dh
           pattern: digests-dh-${{ matrix.variant }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push manifests
+        id: merge_manifests
         env:
           VERSION: ${{ needs.plan.outputs.version }}
           VARIANT: ${{ matrix.variant }}
@@ -545,32 +631,27 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Build per-registry lists of per-arch digest references. Each
-          # registry was pushed to in its own buildx invocation (see the
-          # `build` job), so the digests are different per registry —
-          # the artifacts are split accordingly:
-          #   /tmp/digests/ghcr/digests-ghcr-<variant>-<arch>/<hexdigest>
-          #   /tmp/digests/dh/digests-dh-<variant>-<arch>/<hexdigest>
+          # Build per-registry lists of per-arch digest references.
+          # Layout (flattened by `merge-multiple: true` on the download
+          # steps above):
+          #   /tmp/digests/ghcr/<hexdigest>   (one file per arch)
+          #   /tmp/digests/dh/<hexdigest>     (one file per arch)
           collect_refs() {
-            local root="$1" image="$2" pattern="$3"
-            local refs=()
-            local dir f d
-            for dir in "$root"/$pattern; do
-              [[ -d "$dir" ]] || continue
-              for f in "$dir"/*; do
-                [[ -e "$f" ]] || continue
-                d=$(basename "$f")
-                refs+=("${image}@sha256:${d}")
-              done
+            local dir="$1" image="$2"
+            local f d
+            for f in "$dir"/*; do
+              [[ -f "$f" ]] || continue
+              d=$(basename "$f")
+              printf '%s@sha256:%s\n' "$image" "$d"
             done
-            printf '%s\n' "${refs[@]}"
           }
 
-          mapfile -t GHCR_REFS < <(collect_refs /tmp/digests/ghcr "$GHCR_IMAGE" "digests-ghcr-${VARIANT}-*")
-          mapfile -t DH_REFS   < <(collect_refs /tmp/digests/dh   "$DH_IMAGE"   "digests-dh-${VARIANT}-*")
+          mapfile -t GHCR_REFS < <(collect_refs /tmp/digests/ghcr "$GHCR_IMAGE")
+          mapfile -t DH_REFS   < <(collect_refs /tmp/digests/dh   "$DH_IMAGE")
 
-          if [[ ${#GHCR_REFS[@]} -eq 0 || ${#DH_REFS[@]} -eq 0 ]]; then
+          if (( ${#GHCR_REFS[@]} == 0 || ${#DH_REFS[@]} == 0 )); then
             echo "::error::No digests found for variant=${VARIANT} (ghcr=${#GHCR_REFS[@]}, dh=${#DH_REFS[@]})"
+            ls -laR /tmp/digests || true
             exit 1
           fi
 
@@ -594,15 +675,56 @@ jobs:
           printf '  DH   ref: %s\n' "${DH_REFS[@]}"
           echo "::endgroup::"
 
+          # Write the published-tag list to GITHUB_OUTPUT so the cosign
+          # step below can iterate exactly the same set of tags without
+          # re-deriving them.
+          SIGN_REFS=()
           for TAG in "${TAGS[@]}"; do
             echo ">>> ${GHCR_IMAGE}:${TAG}"
             docker buildx imagetools create \
               -t "${GHCR_IMAGE}:${TAG}" "${GHCR_REFS[@]}"
+            SIGN_REFS+=("${GHCR_IMAGE}:${TAG}")
 
             echo ">>> ${DH_IMAGE}:${TAG}"
             docker buildx imagetools create \
               -t "${DH_IMAGE}:${TAG}" "${DH_REFS[@]}"
+            SIGN_REFS+=("${DH_IMAGE}:${TAG}")
           done
+          # Newline-separated for the GITHUB_OUTPUT multiline syntax.
+          {
+            echo 'sign_refs<<EOF'
+            printf '%s\n' "${SIGN_REFS[@]}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
+
+      # Install cosign for keyless signing. Pinned to the v3 commit SHA
+      # so a malicious tag rewrite upstream can't substitute a hostile
+      # binary into a signing-capable workflow.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
+
+      # Keyless sign every <registry>:<tag> we just published. cosign
+      # exchanges the workflow's OIDC token (id-token: write granted on
+      # this job) for a short-lived Fulcio cert tied to the workflow
+      # identity, signs the manifest, and records the signature +
+      # rekor transparency-log entry in the same registry as the image.
+      # Consumers verify with:
+      #
+      #   cosign verify <ref> \
+      #     --certificate-identity-regexp \
+      #       'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Sign published manifests (cosign keyless)
+        env:
+          SIGN_REFS: ${{ steps.merge_manifests.outputs.sign_refs }}
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          while IFS= read -r ref; do
+            [[ -z "$ref" ]] && continue
+            echo ">>> cosign sign $ref"
+            cosign sign --recursive "$ref"
+          done <<<"$SIGN_REFS"
 
       - name: Inspect published images
         env:

--- a/.github/workflows/label-guard.yml
+++ b/.github/workflows/label-guard.yml
@@ -1,0 +1,157 @@
+name: Label Guard
+
+# Polices `build *` labels, which expand the Docker workflow's build
+# matrix (see .github/workflows/docker.yml) and trigger expensive
+# multi-arch image builds.
+#
+# Two rules:
+#
+#   1. On PRs — only users with `write`, `maintain`, or `admin`
+#      permission may apply a `build *` label. Unauthorized applications
+#      are removed with an explanatory comment.
+#   2. On issues — `build *` labels are PR-only. Any application is
+#      removed regardless of who applied it, with a comment explaining
+#      the label is meant for pull requests.
+#
+# IMPORTANT: this workflow is a cleanup pass — it removes the offending
+# label and notifies the user — but it does NOT itself stop the Docker
+# build that the unauthorized label kicked off. GitHub Actions does not
+# fire downstream workflow runs for events caused by `GITHUB_TOKEN`, so
+# the label removal here will NOT trigger an `unlabeled` event on
+# docker.yml. The authoritative gate lives in docker.yml's planner,
+# which performs the same permission check and strips unauthorized
+# `build *` labels from the variant list before expanding the matrix.
+#
+# `pull_request_target` (not `pull_request`) is required so the PR job
+# runs in the BASE repo's context with write permissions, which lets it
+# police labels on PRs from forks. We never check out or execute
+# PR-author code here — only call GitHub APIs with `github.event.label`
+# / `github.event.sender` data — so the usual `pull_request_target`
+# pwn-the-CI risk doesn't apply.
+
+on:
+  pull_request_target:
+    types: [labeled]
+  issues:
+    types: [labeled]
+
+# Both PR labels and PR comments are exposed via the `issues` REST
+# endpoints (gh's `pr comment` and `pr edit --add-label` both call
+# /repos/:owner/:repo/issues/:n/...). `issues: write` is therefore
+# sufficient for everything this workflow does — `pull-requests: write`
+# would be a strict superset and is intentionally NOT granted.
+permissions:
+  issues: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # guard-pr
+  #
+  # Removes `build *` labels applied by users who don't have at least
+  # `write` permission on the repo.
+  # ---------------------------------------------------------------------------
+  guard-pr:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      startsWith(github.event.label.name, 'build ')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce label permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          ACTOR: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+
+          # GitHub Actions itself can apply labels via workflows (e.g.
+          # automation that promotes a draft PR). Don't fight bots — the
+          # `github-actions[bot]` actor is implicitly trusted because it
+          # can only act through workflows that already require write
+          # access to merge.
+          if [[ "$ACTOR" == "github-actions[bot]" ]]; then
+            echo "Allowing label from github-actions[bot]"
+            exit 0
+          fi
+
+          # The collaborators/permission endpoint reports a legacy base
+          # permission of `admin`, `write`, `read`, or `none`. `maintain`
+          # maps to `write` and `triage` maps to `read`, so we only need
+          # to whitelist `admin` and `write` — but we keep `maintain` in
+          # the case for defence-in-depth in case the API ever surfaces
+          # the finer-grained role.
+          #
+          # Fail-closed: if the API call fails (e.g. 404 for a
+          # non-collaborator fork contributor, transient error), treat
+          # the actor as having `none` so the label is removed.
+          ENCODED_ACTOR="$(jq -rn --arg s "$ACTOR" '$s|@uri')"
+          PERMISSION="$(gh api \
+            "/repos/$REPO/collaborators/$ENCODED_ACTOR/permission" \
+            --jq '.permission' 2>/dev/null || echo none)"
+          PERMISSION="${PERMISSION:-none}"
+
+          echo "Actor=$ACTOR  permission=$PERMISSION  label=$LABEL_NAME"
+
+          case "$PERMISSION" in
+            admin|maintain|write)
+              echo "Authorized — leaving label in place."
+              exit 0
+              ;;
+          esac
+
+          echo "::warning::Removing '$LABEL_NAME' applied by '$ACTOR' (permission=$PERMISSION)"
+
+          # URL-encode spaces in the label name — `build cpu` becomes
+          # `build%20cpu` on the REST path.
+          ENCODED_LABEL="$(jq -rn --arg s "$LABEL_NAME" '$s|@uri')"
+          gh api --method DELETE \
+            "/repos/$REPO/issues/$PR_NUMBER/labels/$ENCODED_LABEL"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "🚫 The \`$LABEL_NAME\` label triggers expensive multi-arch Docker
+          builds and is restricted to repository maintainers (write
+          permission or higher). The label has been removed.
+
+          If you need this build variant exercised on your PR, please
+          ping a maintainer to apply the label for you."
+
+  # ---------------------------------------------------------------------------
+  # guard-issue
+  #
+  # `build *` labels are PR-only. Remove them from any issue regardless
+  # of who applied them — no permission check needed.
+  #
+  # `!github.event.issue.pull_request` defensively skips PR-shaped
+  # issue payloads — GitHub generally separates the events but the
+  # extra guard is cheap and prevents accidental PR label removal if
+  # payload behaviour ever changes.
+  # ---------------------------------------------------------------------------
+  guard-issue:
+    if: >-
+      github.event_name == 'issues' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.label.name, 'build ')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove build label from issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          ACTOR: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+
+          echo "::warning::Removing '$LABEL_NAME' from issue #$ISSUE_NUMBER (applied by '$ACTOR')"
+
+          ENCODED_LABEL="$(jq -rn --arg s "$LABEL_NAME" '$s|@uri')"
+          gh api --method DELETE \
+            "/repos/$REPO/issues/$ISSUE_NUMBER/labels/$ENCODED_LABEL"
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+            "🚫 The \`$LABEL_NAME\` label controls Docker build variants
+          and only applies to pull requests. It has been removed from
+          this issue."

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,12 @@ on:
       - "**.go"
       - "go.mod"
       - "go.sum"
+      - ".go-version"
+      - ".goreleaser.yaml"
+      - ".github/workflows/linux.yml"
+      - ".github/actions/setup-kronk/**"
+      - ".github/scripts/check-go-version.sh"
+      - ".github/test-models.txt"
   pull_request:
     branches:
       - main
@@ -14,6 +20,12 @@ on:
       - "**.go"
       - "go.mod"
       - "go.sum"
+      - ".go-version"
+      - ".goreleaser.yaml"
+      - ".github/workflows/linux.yml"
+      - ".github/actions/setup-kronk/**"
+      - ".github/scripts/check-go-version.sh"
+      - ".github/test-models.txt"
   workflow_dispatch:
 
 # Cancel any in-progress run for the same branch when a new commit
@@ -24,6 +36,14 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
+# Minimum-required token scopes per job. Nothing in this workflow
+# writes to the repo, modifies issues/PRs, publishes packages, or
+# talks to OIDC. The api-tests / sdk-tests jobs need `actions: write`
+# only to be able to save the models cache (actions/cache/save uses
+# the actions API).
+permissions:
+  contents: read
 
 # The workflow runs three independent jobs in parallel. They all use
 # `actions/setup-go@v6` pinned to `go-version-file: .go-version`, which
@@ -36,23 +56,32 @@ concurrency:
 # silently dragged into a toolchain auto-download by the build system.
 # go.mod's `go` directive declares the minimum language version only.
 #
-#   static     — vet / staticcheck / govulncheck / go fix -diff.
+#   static     — vet / staticcheck / govulncheck / go fix / gofmt /
+#                go mod tidy / goreleaser check / -race unit tests.
 #                No models, no kronk binary, no libs. Finishes fast.
 #   api-tests  — full kronk + libs + models setup, runs cmd/server/...
-#                Also owns the models-cache save (and main-branch
-#                cache delete) so the two test jobs don't race on save.
+#                Owns the models-cache save so the two test jobs don't
+#                race on save.
 #   sdk-tests  — full kronk + libs + models setup, runs sdk/...
 #
 # On the rare cache miss both test jobs download the models in parallel.
 # That's wasted CPU but no wall-clock penalty, and avoids a serial
 # "prepare-models" job that would slow the common cache-hit case.
+#
+# GOTOOLCHAIN=local is set on every job so a transitive dependency that
+# bumps its `go` directive above .go-version cannot silently force a
+# toolchain auto-download in CI — better to fail loudly and bump
+# .go-version + check-go-version.sh together.
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   static:
     name: Static checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       # Guard: catch the case where someone bumps the `go` directive in
       # go.mod (or .go-version) but forgets the other file. Patch-level
@@ -61,26 +90,85 @@ jobs:
         run: ./.github/scripts/check-go-version.sh
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: .go-version
 
+      # Pinned to specific tags (not @latest) so a tool release that
+      # raises its required Go version doesn't silently bump our CI
+      # toolchain or, with GOTOOLCHAIN=local, fail the install. Renovate
+      # / Dependabot bumps these intentionally.
       - name: Install static analysis tools
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
-      - name: Run vet, linter, vuln, diff checks
+      - name: gofmt
+        # `git ls-files '*.go'` ignores generated files that are
+        # gitignored. We deliberately don't run gofmt on vendored or
+        # generated code.
         run: |
-          go vet ./...
-          staticcheck -checks=all ./...
-          govulncheck ./...
-          go fix -diff ./...
+          fmt="$(gofmt -l $(git ls-files '*.go'))"
+          if [[ -n "$fmt" ]]; then
+            printf '%s\n' "$fmt"
+            echo "::error::Go files need gofmt -s -w"
+            exit 1
+          fi
+
+      - name: go mod tidy
+        # If `tidy` mutates go.mod or go.sum, the diff is non-empty and
+        # the step exits non-zero. Keeps the module graph honest.
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: staticcheck
+        run: staticcheck -checks=all ./...
+
+      - name: govulncheck
+        run: govulncheck ./...
+
+      - name: go fix
+        # `go fix -diff` only prints; it does not fail. Capture the diff
+        # and fail if it would have rewritten anything.
+        run: |
+          fix_diff="$(go fix -diff ./...)"
+          if [[ -n "$fix_diff" ]]; then
+            printf '%s\n' "$fix_diff"
+            echo "::error::go fix would modify files"
+            exit 1
+          fi
+
+      # Validates .goreleaser.yaml on every PR/main run, instead of
+      # discovering syntax errors only when cutting a release tag.
+      # No artifacts are produced — pure config lint.
+      - name: goreleaser check
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
+        with:
+          version: "~> v2"
+          args: check
+
+      # Race detector pass on the SDK packages that don't spin up the
+      # full inference stack (those tests are owned by sdk-tests).
+      # Restricted to fast/unit-style packages by walking the same
+      # package list sdk-tests uses, with -short and -race. Catches
+      # concurrency bugs in parsers, kvstorage, pool primitives, etc.
+      # without doubling the wall-clock cost of the model-heavy tests.
+      - name: go test -race -short (sdk unit packages)
+        run: |
+          go test -race -short -count=1 -timeout 10m \
+            $(go list ./sdk/... | grep -v '/sdk/kronk/tests')
 
   api-tests:
     name: api/service tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write   # actions/cache/save uses the actions API
     steps:
       - name: Runner specs
         run: |
@@ -89,33 +177,36 @@ jobs:
           cat /proc/cpuinfo | grep "model name" | head -1
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Kronk
         id: setup
         uses: ./.github/actions/setup-kronk
+        with:
+          # The models cache key is bound to the model manifest's hash
+          # so adding/removing a model in .github/test-models.txt
+          # automatically invalidates the cache. Old keys age out via
+          # GHA's 7-day-unused eviction policy (also see
+          # cache-cleanup.yml).
+          models-cache-key: ${{ runner.os }}-models-${{ hashFiles('.github/test-models.txt') }}
 
       - name: Run api/service tests
         run: |
           export RUN_IN_PARALLEL=no
           go test -v -p=1 -count=1 -timeout 20m ./cmd/server/...
 
-      - name: Delete existing models cache
-        if: github.ref == 'refs/heads/main' && steps.setup.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh cache delete "${{ runner.os }}-models-v4" --repo ${{ github.repository }} || true
-
+      # Only one of the two test jobs (api-tests) saves the cache so
+      # they can't race. Save only on main branch and only on a cache
+      # miss — PR builds and cache hits don't need to re-save.
       - name: Save models cache
-        if: github.ref == 'refs/heads/main' && steps.setup.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.setup.outputs.models-cache-hit != 'true'
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.kronk/models
             ~/.kronk/bucky-models
-          key: ${{ runner.os }}-models-v4
+          key: ${{ steps.setup.outputs.models-cache-key }}
 
   sdk-tests:
     name: sdk tests
@@ -123,10 +214,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Kronk
         uses: ./.github/actions/setup-kronk
+        with:
+          models-cache-key: ${{ runner.os }}-models-${{ hashFiles('.github/test-models.txt') }}
 
       - name: Run sdk tests
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions:
   contents: read
 
-# The workflow runs three independent jobs in parallel. They all use
+# The workflow runs four independent jobs in parallel. They all use
 # `actions/setup-go@v6` pinned to `go-version-file: .go-version`, which
 # gives them an identical setup-go cache key (OS + Go version + go.sum
 # hash) so the Go module download cache and the build cache ($GOCACHE)
@@ -57,8 +57,13 @@ permissions:
 # go.mod's `go` directive declares the minimum language version only.
 #
 #   static     — vet / staticcheck / govulncheck / go fix / gofmt /
-#                go mod tidy / goreleaser check / -race unit tests.
-#                No models, no kronk binary, no libs. Finishes fast.
+#                go mod tidy / goreleaser check. No models, no kronk
+#                binary, no libs, no test run. Finishes fast.
+#   race       — `go test -race -short` on the SDK unit packages.
+#                Uses setup-kronk so unit tests that read real GGUFs
+#                (e.g. sdk/tools/models) can run under -race. Split out
+#                from static so a flaky/slow race run never gates fast
+#                lint feedback.
 #   api-tests  — full kronk + libs + models setup, runs cmd/server/...
 #                Owns the models-cache save so the two test jobs don't
 #                race on save.
@@ -151,17 +156,31 @@ jobs:
           version: "~> v2"
           args: check
 
-      # Race detector pass on the SDK packages that don't spin up the
-      # full inference stack (those tests are owned by sdk-tests). The
-      # excluded packages all require the kronk libraries (libllama,
-      # libwhisper, …) and/or downloaded models to even start, which
-      # this job intentionally does not provision:
+  race:
+    name: Race detector (sdk unit packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      # Same setup as api-tests / sdk-tests so unit tests that read real
+      # GGUFs on disk (e.g. sdk/tools/models TestModelMetadata) can
+      # exercise their full code path under the race detector. The libs
+      # + models caches are shared across all three jobs, so on a cache
+      # hit this adds only seconds.
+      - name: Set up Kronk
+        uses: ./.github/actions/setup-kronk
+        with:
+          models-cache-key: ${{ runner.os }}-models-${{ hashFiles('.github/test-models.txt') }}
+
+      # Race detector pass on SDK unit packages. The model/library-heavy
+      # integration suites still belong to sdk-tests; this job stays
+      # scoped to fast unit tests so the race walltime doesn't approach
+      # the integration job's:
       #   /sdk/kronk/tests     — integration suite owned by sdk-tests.
       #   /sdk/kronk/pool      — boots the llama runtime + real models.
       #   /sdk/bucky/tests     — boots the whisper runtime + real models.
-      # Catches concurrency bugs in parsers, kvstorage, pool primitives,
-      # etc. without doubling the wall-clock cost of the model-heavy
-      # tests.
       - name: go test -race -short (sdk unit packages)
         run: |
           go test -race -short -count=1 -timeout 10m \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,15 +152,23 @@ jobs:
           args: check
 
       # Race detector pass on the SDK packages that don't spin up the
-      # full inference stack (those tests are owned by sdk-tests).
-      # Restricted to fast/unit-style packages by walking the same
-      # package list sdk-tests uses, with -short and -race. Catches
-      # concurrency bugs in parsers, kvstorage, pool primitives, etc.
-      # without doubling the wall-clock cost of the model-heavy tests.
+      # full inference stack (those tests are owned by sdk-tests). The
+      # excluded packages all require the kronk libraries (libllama,
+      # libwhisper, …) and/or downloaded models to even start, which
+      # this job intentionally does not provision:
+      #   /sdk/kronk/tests     — integration suite owned by sdk-tests.
+      #   /sdk/kronk/pool      — boots the llama runtime + real models.
+      #   /sdk/bucky/tests     — boots the whisper runtime + real models.
+      # Catches concurrency bugs in parsers, kvstorage, pool primitives,
+      # etc. without doubling the wall-clock cost of the model-heavy
+      # tests.
       - name: go test -race -short (sdk unit packages)
         run: |
           go test -race -short -count=1 -timeout 10m \
-            $(go list ./sdk/... | grep -v '/sdk/kronk/tests')
+            $(go list ./sdk/... \
+              | grep -v '/sdk/kronk/tests' \
+              | grep -v '/sdk/kronk/pool' \
+              | grep -v '/sdk/bucky/tests')
 
   api-tests:
     name: api/service tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,19 +5,44 @@ on:
     tags:
       - "v*"
 
+# Tag pushes only — branch protection on `v*` tags + the `production`
+# environment below mean the HOMEBREW_TAP_GITHUB_TOKEN can only ever
+# fire under maintainer-approved circumstances.
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Gated environment so the Homebrew tap PAT only unlocks for
+    # maintainer-approved runs. Configure required reviewers + tag
+    # pattern restrictions on this environment in the repo's
+    # Settings > Environments page.
+    environment: release
     permissions:
-      contents: write
+      contents: write      # goreleaser publishes GitHub release assets
+      id-token: write      # actions/attest-build-provenance (SLSA OIDC)
+      attestations: write  # actions/attest-build-provenance (write attestations)
+    env:
+      GOTOOLCHAIN: local
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      # Same drift guard the linux.yml `static` job runs — catches the
+      # case where someone bumps go.mod/.go-version without the other.
+      # Cheap to run again here so a tag push can never publish binaries
+      # built against an unintended toolchain.
+      - name: Check Go version pin
+        run: ./.github/scripts/check-go-version.sh
+
+      # CI's pinned toolchain (matches the linux.yml static + test jobs
+      # so the release binary is built with the same compiler we tested
+      # against).
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
-          go-version-file: go.mod
+          go-version-file: .go-version
 
       # Guard: the pushed tag must match `const Version` in
       # sdk/kronk/kronk.go. Fails the release before any artifacts are
@@ -25,10 +50,30 @@ jobs:
       - name: Check tag matches sdk/kronk.Version
         run: ./.github/scripts/check-version.sh
 
-      - uses: goreleaser/goreleaser-action@v7
+      # syft is installed up-front so goreleaser's `sboms:` section can
+      # invoke it as its SBOM generator (see .goreleaser.yaml).
+      - name: Install syft (SBOM generator)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610  # v0
+
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
+        id: goreleaser
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      # SLSA build provenance for every artifact GoReleaser produced.
+      # `actions/attest-build-provenance` resolves to a glob over
+      # dist/checksums.txt-listed paths; we pass the binary tarballs/zips
+      # and the checksums file itself so any consumer can verify with
+      # `gh attestation verify` or `cosign verify-attestation`.
+      - name: Attest release artifacts (SLSA)
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+            dist/*.sbom.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,17 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+# Generate an SBOM (CycloneDX-flavored SPDX JSON) for every archive
+# GoReleaser produces. The release workflow installs syft up-front and
+# attaches SLSA build provenance over both the archives AND these SBOM
+# files, so a consumer can verify the SBOM provenance via
+# `gh attestation verify dist/<archive>.sbom.json`.
+sboms:
+  - id: archive
+    artifacts: archive
+    documents:
+      - "${artifact}.sbom.json"
+
 # NOTE: GoReleaser deprecated `brews:` in favor of `homebrew_casks:` (v2.10).
 # Per the GoReleaser maintainer, casks generated this way work on both macOS
 # and Linuxbrew, so this is the recommended path going forward.

--- a/.manual/chapter-19-developer-guide.md
+++ b/.manual/chapter-19-developer-guide.md
@@ -41,8 +41,14 @@
   - [19.13.6 Tests](#19136-tests)
 - [19.14 Continuous Integration](#1914-continuous-integration)
   - [19.14.1 Workflows](#19141-workflows)
-  - [19.14.2 Container Image Build & Publish](#19142-container-image-build--publish)
-  - [19.14.3 Version Stamping](#19143-version-stamping)
+  - [19.14.2 Go Toolchain Pin (`go.mod` vs `.go-version`)](#19142-go-toolchain-pin-gomod-vs-go-version)
+  - [19.14.3 Linux Pipeline Layout (`linux.yml`)](#19143-linux-pipeline-layout-linuxyml)
+  - [19.14.4 Shared Setup Action & Caches](#19144-shared-setup-action--caches)
+  - [19.14.5 `test-models.txt` — Test Model Manifest](#19145-test-modelstxt--test-model-manifest)
+  - [19.14.6 Release Workflow (`release.yaml`)](#19146-release-workflow-releaseyaml)
+  - [19.14.7 Container Image Build & Publish (`docker.yml`)](#19147-container-image-build--publish-dockeryml)
+  - [19.14.8 Support Workflows (`cache-cleanup.yml`, `label-guard.yml`)](#19148-support-workflows-cache-cleanupyml-label-guardyml)
+  - [19.14.9 Version Constant & Release Guard](#19149-version-constant--release-guard)
 
 ---
 
@@ -97,6 +103,15 @@ target depends on `install-libraries` and `install-test-models`, so the
 llama.cpp libraries and test GGUF models are downloaded automatically the
 first time you run it.
 
+> **CI parity note:** CI doesn't use these make targets directly. It
+> reads its model list from
+> [`.github/test-models.txt`](../.github/test-models.txt) (one
+> `<backend> <model-id>` per line) so the cache key for the models
+> cache can be tied to that file's hash. If you add a test that
+> requires a new model, you MUST add it to `test-models.txt` AND to
+> the local install path (`install-test-models`) or CI will silently
+> skip the dependency. See [§19.14.5](#19145-test-modelstxt--test-model-manifest).
+
 For fast iteration (skip `lint`, `vuln-check`, and `diff`):
 
 ```shell
@@ -140,6 +155,21 @@ make install-tooling     # brew: protobuf, grpcurl, node (only needed for codege
 
 A fresh checkout that skips `install-gotooling` will fail the `lint` and
 `vuln-check` steps of `make test` and the post-edit checks listed in §19.1.
+
+**Go toolchain version:**
+
+The repo carries two Go-version files with different roles:
+
+| File           | Role                                                              | Value          |
+| -------------- | ----------------------------------------------------------------- | -------------- |
+| [`go.mod`](../go.mod)      | Minimum language version. Floor for downstream consumers.         | `go 1.26.0`    |
+| [`.go-version`](../.go-version) | Exact toolchain CI / dev managers install (asdf, mise, goenv, gvm, direnv). | `1.26.3`       |
+
+They are allowed to differ on the *patch* component but must agree on
+`<major>.<minor>`. The Linux + Release workflows run
+[`.github/scripts/check-go-version.sh`](../.github/scripts/check-go-version.sh)
+to enforce this — bump both files together or CI fails. See
+[§19.14.2](#19142-go-toolchain-pin-gomod-vs-go-version).
 
 ### 19.4 Project Architecture
 
@@ -1866,19 +1896,230 @@ disk, so contributors without a pulled model still get a green run.
 
 #### 19.14.1 Workflows
 
-Three GitHub Actions workflows live under [`.github/workflows/`](../.github/workflows/):
+Five GitHub Actions workflows live under [`.github/workflows/`](../.github/workflows/):
 
-| Workflow             | Triggers                                  | Purpose                                                                              |
-| -------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
-| [`linux.yml`](../.github/workflows/linux.yml)     | PRs + push to `main` (Go/mod paths)       | `go vet`, `staticcheck`, `govulncheck`, `go fix -diff`, plus the SDK and HTTP tests against pulled models (cached across runs). |
-| [`release.yaml`](../.github/workflows/release.yaml)  | Push of tag `v*`                          | Runs `goreleaser` to produce per-OS/arch archives, checksums, and refresh the Homebrew cask in `ardanlabs/homebrew-kronk`. |
-| [`docker.yml`](../.github/workflows/docker.yml)    | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds (and on push events: publishes) the six container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). Every variant bakes in both llama.cpp and matching whisper.cpp (bucky) shared libraries plus `ffmpeg` for transcription. |
+| Workflow             | Triggers                                                   | Purpose                                                                                                                                                |
+| -------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`linux.yml`](../.github/workflows/linux.yml)             | PRs + push to `main` (Go/mod/CI paths)                     | Three parallel jobs: `static` (vet/staticcheck/govulncheck/gofmt/gofix/tidy/goreleaser-check/-race unit tests), `api-tests` (`cmd/server/...`), `sdk-tests` (`sdk/...`). |
+| [`release.yaml`](../.github/workflows/release.yaml)       | Push of tag `v*`                                           | Pinned-toolchain `goreleaser release --clean`, SBOM generation via syft, SLSA build-provenance attestation, Homebrew cask refresh.                     |
+| [`docker.yml`](../.github/workflows/docker.yml)           | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds (and on push: publishes + cosign-signs) the **five** container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). |
+| [`cache-cleanup.yml`](../.github/workflows/cache-cleanup.yml) | Daily cron + manual                                        | Prunes stale GHA cache entries and stale `kronk-buildcache` GHCR tags older than the cutoff.                                                            |
+| [`label-guard.yml`](../.github/workflows/label-guard.yml) | Label events on PRs/issues                                 | Removes unauthorized `build *` labels (PRs from non-maintainers; any application on an issue).                                                          |
 
-#### 19.14.2 Container Image Build & Publish
+The three Linux jobs run in parallel and all use
+[`actions/setup-go`](https://github.com/actions/setup-go) keyed on
+[`.go-version`](../.go-version), so they share one Go module +
+build cache (`setup-go`'s key encodes OS + Go version + `go.sum` hash).
+That's also why bumping `.go-version` invalidates the `go install ./cmd/kronk`
+step's cache exactly once per Go-version bump.
 
-The Docker workflow is matrix-driven; the `plan` job synthesises the build
-matrix at runtime from the event type (and from any `build <variant>` PR
-labels). Six variants are produced:
+#### 19.14.2 Go Toolchain Pin (`go.mod` vs `.go-version`)
+
+Two files, two roles:
+
+```diagram
+╭──────────────╮      minimum language version (floor)
+│   go.mod     │ ───► `go 1.26.0`
+╰──────────────╯      used by downstream consumers of the modules
+                      and by `GOTOOLCHAIN=auto` resolution
+
+╭──────────────╮      exact toolchain CI + dev managers install
+│ .go-version  │ ───► `1.26.3`
+╰──────────────╯      picked up by asdf, mise, goenv, gvm, direnv,
+                      and actions/setup-go's `go-version-file:` input
+```
+
+[`.github/scripts/check-go-version.sh`](../.github/scripts/check-go-version.sh)
+parses the `go` directive from `go.mod` and the bare version from
+`.go-version`, then fails the workflow when their `<major>.<minor>`
+components disagree. Patch-level drift is allowed (and expected: CI
+typically pins a patched toolchain ahead of the language minimum) —
+minor-level drift means someone bumped one file and forgot the other.
+
+Where the guard runs:
+
+- `linux.yml` → the `static` job, as the first step after checkout.
+- `release.yaml` → before `goreleaser`, so a release can never be cut
+  with a mismatched toolchain.
+
+All CI jobs export `GOTOOLCHAIN=local`. A transitive dependency that
+bumps its `go` directive above `.go-version` therefore fails loudly
+instead of silently triggering a toolchain auto-download — the correct
+fix is to bump `.go-version` (and re-run `check-go-version.sh`).
+
+The Docker build performs the same pin: the
+[Dockerfile](../zarf/docker/kronk/Dockerfile) reads `.go-version` at
+build time and downloads exactly that toolchain, so binaries published
+to registries are built with the same compiler CI tested against.
+
+#### 19.14.3 Linux Pipeline Layout (`linux.yml`)
+
+`linux.yml` runs three jobs in parallel after the `paths:` filter
+matches. There is no `lint` / `test` serialisation — the heavyweight
+`api-tests` / `sdk-tests` jobs start at the same time as the lightweight
+`static` job.
+
+```diagram
+                       push / pull_request
+                              │
+                              ▼
+              ╭───────── paths filter ─────────╮
+              │ **.go, go.mod, go.sum,         │
+              │ .go-version, .goreleaser.yaml, │
+              │ .github/workflows/linux.yml,   │
+              │ .github/actions/setup-kronk/**,│
+              │ .github/scripts/check-go-...,  │
+              │ .github/test-models.txt        │
+              ╰────────────────┬───────────────╯
+                               │
+        ┌──────────────────────┼──────────────────────┐
+        ▼                      ▼                      ▼
+ ╭────────────╮         ╭─────────────╮        ╭─────────────╮
+ │   static   │         │ api-tests   │        │ sdk-tests   │
+ │            │         │             │        │             │
+ │ check-go-  │         │ setup-kronk │        │ setup-kronk │
+ │ version    │         │ (composite) │        │ (composite) │
+ │ gofmt -l   │         │             │        │             │
+ │ go mod tidy│         │ cmd/server/ │        │ sdk/...     │
+ │ go vet     │         │ (RUN_IN_    │        │ (excluding  │
+ │ staticcheck│         │  PARALLEL=  │        │  /sdk/kronk/│
+ │ govulncheck│         │  no)        │        │  tests)     │
+ │ go fix     │         │             │        │             │
+ │ goreleaser │         │ saves       │        │             │
+ │ check      │         │ models      │        │             │
+ │ -race      │         │ cache on    │        │             │
+ │ unit tests │         │ main + miss │        │             │
+ ╰────────────╯         ╰─────────────╯        ╰─────────────╯
+```
+
+Key design decisions:
+
+- **Concurrency group** keyed on `${{ github.head_ref || github.ref }}`
+  cancels in-progress runs when a PR is force-pushed, collapsing
+  duplicate `push` + `pull_request` runs on the same branch.
+- **Minimum permissions** (`contents: read` workflow-wide); `api-tests`
+  alone gets `actions: write` so it can save the models cache.
+- **Only `api-tests` saves the models cache** (`actions/cache/save`)
+  and only on a cache miss on `main`. Two save jobs would race on the
+  same key; PR runs and cache hits don't need to save at all.
+- The `static` job also runs `-race -short` over the SDK packages that
+  don't spin up the full inference stack — catches concurrency bugs in
+  parsers, kvstorage, pool primitives without doubling test wall-clock.
+- The `paths:` filter explicitly includes CI infra files
+  (`.go-version`, `setup-kronk/**`, `check-go-version.sh`,
+  `test-models.txt`, `.goreleaser.yaml`) so changes to CI itself
+  trigger CI.
+
+#### 19.14.4 Shared Setup Action & Caches
+
+Both test jobs delegate to
+[`.github/actions/setup-kronk`](../.github/actions/setup-kronk/action.yml),
+a composite action that:
+
+1. Frees ~25 GB on the runner (drops dotnet, android, ghc, CodeQL).
+2. Installs Go via `actions/setup-go` with `go-version-file: .go-version`.
+3. Restores two **independent** caches:
+
+   | Cache         | Path                                 | Key                                                                         | Why separate                                                    |
+   | ------------- | ------------------------------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------- |
+   | Libraries     | `~/.kronk/libraries`, `~/.kronk/bucky-libraries` | `${{ runner.os }}-kronk-libs-${{ hashFiles('sdk/tools/libs/libs.go', 'sdk/tools/bucky/libs/**/*.go') }}` | Libs change far less often than models; keep them hot.          |
+   | Models        | `~/.kronk/models`, `~/.kronk/bucky-models`       | `${{ runner.os }}-models-${{ hashFiles('.github/test-models.txt') }}`        | Tied to the test-model manifest — see [§19.14.5](#19145-test-modelstxt--test-model-manifest). |
+
+4. `go install ./cmd/kronk` — fast because the Go module + build cache
+   restored by `setup-go` is shared with the `static` job (same Go
+   version, same `go.sum`).
+5. `kronk libs --local` + `kronk bucky libs --local` to install the
+   llama.cpp + whisper.cpp native libraries (idempotent on a cache hit).
+6. On models-cache miss only, walks `.github/test-models.txt` and pulls
+   every listed model via `kronk model pull --local` or
+   `kronk bucky model pull --local`.
+
+The composite emits `models-cache-hit` and `models-cache-key` as
+outputs so the caller can decide whether to re-save the cache.
+
+#### 19.14.5 `test-models.txt` — Test Model Manifest
+
+> ⚠️ **MAINTAIN THIS FILE.** [`.github/test-models.txt`](../.github/test-models.txt) is the
+> **single source of truth** for the models CI pulls into its test
+> environment. The file's hash is mixed into the models-cache key, so
+> adding / removing / renaming a model automatically invalidates the
+> cache on the next run and forces a fresh download. Forgetting to
+> update this file when a test gains a new model dependency means CI
+> will silently restore a stale cache and the new test will fail with
+> a "model not found" error.
+
+Format — one entry per line:
+
+```
+<backend> <model-id>
+```
+
+- `backend` is `kronk` (LLM/embed/rerank, pulled with `kronk model pull`)
+  or `bucky` (audio transcription, pulled with `kronk bucky model pull`).
+- Blank lines and lines starting with `#` are ignored.
+- **Do not add inline comments at the end of model lines** — the
+  parser word-splits each entry and treats the third field as garbage.
+
+Current manifest:
+
+| Backend | Model                                |
+| ------- | ------------------------------------ |
+| `kronk` | `unsloth/Qwen3.5-0.8B-Q8_0`          |
+| `kronk` | `Qwen/Qwen3-8B-Q8_0`                 |
+| `kronk` | `ggml-org/embeddinggemma-300m-qat-Q8_0` |
+| `kronk` | `gpustack/bge-reranker-v2-m3-Q8_0`   |
+| `bucky` | `tiny.en`                            |
+
+Checklist when adding a test that needs a new model:
+
+1. Add the `<backend> <model-id>` line to `.github/test-models.txt`.
+2. Also wire it into the local `install-test-models` make target so
+   `make test` keeps working for contributors who don't go through CI.
+3. Push — the cache key changes automatically, CI pulls the new model
+   once, then everyone else picks it up from cache.
+
+#### 19.14.6 Release Workflow (`release.yaml`)
+
+Triggered only by `v*` tag pushes. Runs inside a maintainer-gated
+`release` GitHub environment (configure required reviewers + tag
+patterns in **Settings → Environments**), so the `HOMEBREW_TAP_GITHUB_TOKEN`
+PAT and signing capabilities can never fire from an unattended branch
+push.
+
+Sequence:
+
+1. **`check-go-version.sh`** — same drift guard as `linux.yml`.
+2. **`actions/setup-go` with `.go-version`** — same pinned toolchain
+   as the test jobs, so the release binary is built with the compiler
+   CI tested against.
+3. **`check-version.sh`** — pushed tag must match `const Version` in
+   `sdk/kronk/kronk.go` (see [§19.14.9](#19149-version-constant--release-guard)).
+4. **Install syft** (`anchore/sbom-action/download-syft`) — GoReleaser's
+   `sboms:` section in [`.goreleaser.yaml`](../.goreleaser.yaml) shells
+   out to it to produce a CycloneDX-flavoured SPDX SBOM per archive
+   (e.g. `kronk_Linux_x86_64.tar.gz.sbom.json`).
+5. **`goreleaser release --clean`** — produces per-OS/arch archives,
+   `checksums.txt`, the SBOMs, and refreshes the Homebrew cask in
+   `ardanlabs/homebrew-kronk`.
+6. **`actions/attest-build-provenance`** — attaches SLSA build
+   provenance to every archive, the checksums file, and every SBOM.
+   Consumers can verify with:
+
+   ```shell
+   gh attestation verify dist/kronk_<...>.tar.gz --repo ardanlabs/kronk
+   gh attestation verify dist/kronk_<...>.tar.gz.sbom.json --repo ardanlabs/kronk
+   ```
+
+Permissions are limited to exactly what's needed: `contents: write`
+(release assets), `id-token: write` + `attestations: write` (SLSA OIDC).
+
+#### 19.14.7 Container Image Build & Publish (`docker.yml`)
+
+The Docker workflow is matrix-driven. The `plan` job synthesises the
+build matrix at runtime from the event type (and from any `build <variant>`
+PR labels — see [§19.14.8](#19148-support-workflows-cache-cleanupyml-label-guardyml)).
+**Five** variants are produced (the previous `jetson` variant was
+removed; reintroduce it only on user demand):
 
 | Variant  | `LLAMA_PROCESSORS`     | `BUCKY_PROCESSORS` | Platforms                    | Dockerfile target |
 | -------- | ---------------------- | ------------------ | ---------------------------- | ----------------- |
@@ -1886,7 +2127,6 @@ labels). Six variants are produced:
 | `cuda`   | `cuda`                 | `cuda`             | `linux/amd64`, `linux/arm64` | `runtime`         |
 | `vulkan` | `vulkan`               | `vulkan`           | `linux/amd64`, `linux/arm64` | `runtime`         |
 | `rocm`   | `rocm`                 | `vulkan` ¹         | `linux/amd64` only           | `runtime`         |
-| `jetson` | `cuda`                 | `cuda`             | `linux/arm64` only           | `runtime-jetson`  |
 | `all`    | `cpu cuda vulkan rocm` | `cpu cuda vulkan`  | `linux/amd64`, `linux/arm64` | `runtime`         |
 
 ¹ Upstream whisper.cpp has no rocm build target
@@ -1896,31 +2136,155 @@ variant ships the vulkan bucky bundle and the container entrypoint
 `KRONK_BUCKY_LIB_PATH` to point at it on ROCm hosts so transcription stays
 GPU-accelerated via the RADV Vulkan driver.
 
-Multi-arch images are built **natively** on `ubuntu-24.04` (amd64) and
-`ubuntu-24.04-arm` (arm64) runners — never under QEMU. Each per-arch job
-pushes its image to GHCR + Docker Hub by **digest only** (no human-readable
-tag yet) and uploads a tiny artifact containing that digest. A downstream
-`merge` job per variant collects the arch-specific digests and stitches them
-into the final multi-arch manifest with `docker buildx imagetools create`,
-applying the human-readable tags at that step.
+**Native multi-arch builds.** Each `(variant, arch)` matrix entry runs
+on its own runner — `ubuntu-24.04` (amd64) or `ubuntu-24.04-arm`
+(arm64) — never under QEMU.
 
-Event → tag mapping:
+**Separate per-registry buildx invocations.** On push events, each
+matrix entry runs **two** `docker/build-push-action` steps: one pushes
+by digest to GHCR, one pushes by digest to Docker Hub. Why two:
 
-| Event                | Variants                                                | Push? | Tags applied                                                       |
-| -------------------- | ------------------------------------------------------- | ----- | ------------------------------------------------------------------ |
-| PR (no labels)       | `cpu`                                                   | no    | —                                                                  |
-| PR + label `build all`  | all 6                                                   | no    | —                                                                  |
-| PR + label `build <v>`  | that variant                                            | no    | —                                                                  |
-| Push to `main`       | all 6                                                   | yes   | `main-<shortsha>-<variant>`                                        |
-| Push to tag `v*`     | all 6                                                   | yes   | `<tag>-<variant>` + `latest-<variant>`; plus `latest` → cpu image  |
-| `workflow_dispatch`  | input `variants` (default `all`, or comma-separated)    | no    | —                                                                  |
+```diagram
+                ╭──── build job (variant, arch) ────╮
+                │                                   │
+                │  ╭──── push by digest → GHCR ──╮  │
+                │  │   provenance attestation    │  │
+                │  │   names ghcr.io/...         │  │
+                │  │   surfaces outputs.digest A │  │
+                │  ╰─────────────────────────────╯  │
+                │                                   │
+                │  ╭──── push by digest → DH ────╮  │
+                │  │   provenance attestation    │  │
+                │  │   names docker.io/...       │  │
+                │  │   surfaces outputs.digest B │  │
+                │  ╰─────────────────────────────╯  │
+                │                                   │
+                │   uploads two artifacts:          │
+                │     digests-ghcr-<v>-<a>          │
+                │     digests-dh-<v>-<a>            │
+                ╰───────────────────────────────────╯
+```
 
-Per-`(variant, arch)` GHA cache scopes (`type=gha,scope=<variant>-<arch>`)
-keep the BuildKit cache hot across runs; the runner-level free-disk step
-reclaims ~25 GB up front so the all-backends + rocm builds don't run out of
-space.
+A single buildx invocation with two `outputs:` lines pushes
+**different index-manifest digests to each registry** (provenance
+embeds the destination registry name), but `steps.build.outputs.digest`
+exposes only one. The downstream `merge` job then can't reconstruct
+working references for the other registry — it sees `manifest unknown`
+and fails (the bug that broke an earlier version of this workflow).
+Splitting the pushes gives each step its own `outputs.digest`,
+preserves provenance on both registries, and only re-uploads layers to
+the second registry (the BuildKit cache picks up everything else).
 
-#### 19.14.3 Version Constant & Release Guard
+**Per-registry digest artifacts.** Each push uploads a tiny
+`digests-<registry>-<variant>-<arch>` artifact whose filename is the
+bare hex of the digest. The `merge` job downloads the matching
+artifacts for its variant with
+`actions/download-artifact@v8`'s `merge-multiple: true` — that flag is
+**required**: without it, `download-artifact@v8` has a documented
+asymmetry where 2+ matching artifacts get per-artifact subdirectories
+but exactly 1 match (the single-arch `rocm` case) extracts straight
+into `path/` with no subdir. Flattening unconditionally makes the
+layout uniform and is collision-free because filenames are unique
+digests.
+
+**Merge + sign.** The `merge` job per variant:
+
+1. Downloads the per-registry digest artifacts for its variant.
+2. Stitches the multi-arch manifest with `docker buildx imagetools
+   create -t <image>:<tag> <image>@sha256:<arch1>...` against both
+   registries independently.
+3. Signs every published `<registry>:<tag>` with **cosign keyless**
+   (OIDC). `id-token: write` is granted on this job only; cosign
+   exchanges the workflow's OIDC token for a short-lived Fulcio cert
+   tied to the workflow identity, signs the manifest, and records the
+   signature + Rekor log entry in the same registry as the image.
+
+   Consumers verify with:
+
+   ```shell
+   cosign verify ghcr.io/ardanlabs/kronk:v1.26.4-cpu \
+     --certificate-identity-regexp \
+       'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+   ```
+
+**Event → variants → tags:**
+
+| Event                  | Variants                                                  | Push? | Tags applied                                                              |
+| ---------------------- | --------------------------------------------------------- | ----- | ------------------------------------------------------------------------- |
+| PR (no labels)         | `cpu`                                                     | no    | — (plus a `kronk --version` / `kronk --help` smoke test on cpu/amd64)     |
+| PR + label `build all` | all 5                                                     | no    | —                                                                         |
+| PR + label `build <v>` | `cpu` + each labeled variant                              | no    | —                                                                         |
+| Push to `main`         | all 5                                                     | yes   | `main-<shortsha>-<variant>` (cosign-signed)                               |
+| Push to tag `v*`       | all 5                                                     | yes   | `<tag>-<variant>` + `latest-<variant>`; plus `latest` → cpu (all signed)  |
+| `workflow_dispatch`    | input `variants` (default `all`, or comma-separated)      | no    | —                                                                         |
+
+**PR relevance gate.** The trigger has no `paths:` filter — `paths:` is
+incompatible with `labeled` / `unlabeled` events (those carry no
+changeset, so GitHub silently drops every label event). The `plan` job
+replicates the relevance check inside its script: it calls
+`gh api .../pulls/N/files` and skips the build unless the diff touches
+`.go`, `go.{mod,sum}`, `.go-version`, `.dockerignore`,
+`cmd/server/api/frontends/bui/`, `zarf/docker/kronk/`, `zarf/kms/`, or
+`.github/workflows/docker.yml`.
+
+**PR smoke test.** The cpu/amd64 PR build additionally loads the
+resulting image into the local Docker daemon (`load: true`) and runs
+`docker run --rm kronk-smoke:latest kronk --version` /
+`kronk --help`. Catches breakage like a missing shared library or a
+bad ENTRYPOINT path that a non-load build wouldn't notice.
+
+**Registry-backed BuildKit cache.** `cache-to`/`cache-from` write to
+`ghcr.io/ardanlabs/kronk-buildcache:<variant>-<arch>`. On PR builds the
+cache is read-only — PR validation builds don't seed the trunk cache.
+On push builds the GHCR step writes the cache (`image-manifest=true`
+so it renders as a proper GHCR package) and the Docker Hub step reuses
+it (`cache-from` only). The `cache-cleanup.yml` workflow prunes stale
+entries — see [§19.14.8](#19148-support-workflows-cache-cleanupyml-label-guardyml).
+
+#### 19.14.8 Support Workflows (`cache-cleanup.yml`, `label-guard.yml`)
+
+**`cache-cleanup.yml`** — daily cron at 04:17 UTC + manual dispatch.
+Two cleanup passes:
+
+1. **GHA cache entries** older than `cutoff_days` (default 15) are
+   deleted via `gh cache delete`. GitHub's built-in 7-day-unused
+   eviction resets the timer on every read, so busy hot scopes never
+   expire on their own — this job enforces an absolute age cap.
+2. **GHCR `kronk-buildcache` package versions** older than the cutoff
+   are deleted via the GHCR packages API. The script handles the
+   first-run case where the package doesn't exist yet (404 → "nothing
+   to prune") so the workflow doesn't fail before any cache has been
+   pushed.
+
+Both passes support a `dry_run` input for safe inspection.
+
+**`label-guard.yml`** — `pull_request_target: labeled` + `issues: labeled`.
+`build *` labels expand the Docker workflow's matrix to expensive
+multi-arch builds, so they're maintainer-only. Two enforcement rules:
+
+- On PRs — only users with `write`, `maintain`, or `admin` permission
+  may apply a `build *` label. Unauthorized applications are removed
+  with an explanatory comment.
+- On issues — `build *` labels are PR-only; any application is removed.
+
+The workflow runs with minimum permissions (`issues: write` only —
+PR labels and comments both go through `/issues/` endpoints). It is a
+**cleanup pass**: it removes the label but cannot itself cancel an
+in-flight Docker build, because `GITHUB_TOKEN`-driven label removals
+don't trigger downstream workflow runs. The authoritative gate
+therefore lives in `docker.yml`'s `plan` job, which performs the same
+permission check and strips unauthorized `build *` labels from the
+matrix before expanding it. Belt + braces.
+
+`pull_request_target` (not `pull_request`) is required so the job runs
+in the base repo's context with write permissions, which is what lets
+it police labels on PRs from forks. The job never checks out or
+executes PR-author code — it only calls GitHub APIs with
+`github.event.label` / `github.event.sender` data — so the standard
+`pull_request_target` pwn-the-CI risk doesn't apply.
+
+#### 19.14.9 Version Constant & Release Guard
 
 The CLI's reported version is the value of the
 [`Version` constant in `sdk/kronk/kronk.go`](../sdk/kronk/kronk.go) — a
@@ -1950,5 +2314,10 @@ the value of `const Version`, not `KRONK_VERSION`.
 Release checklist when cutting `v<X.Y.Z>`:
 
 1. Bump `const Version` in [`sdk/kronk/kronk.go`](../sdk/kronk/kronk.go).
-2. Commit, then tag the same commit `v<X.Y.Z>` and push.
-3. CI's tag-guard step refuses the release if step 1 was forgotten.
+2. (Optional) bump `.go-version` to the latest patched Go in the
+   current minor line; `check-go-version.sh` will block the release
+   if `go.mod`'s minor doesn't match.
+3. Commit, then tag the same commit `v<X.Y.Z>` and push.
+4. CI's tag-guard step refuses the release if step 1 was forgotten.
+5. The maintainer approving the `release` environment unblocks the
+   `goreleaser` + SBOM + attestation pipeline.

--- a/cmd/server/api/frontends/bui/src/components/DocsManual.tsx
+++ b/cmd/server/api/frontends/bui/src/components/DocsManual.tsx
@@ -425,7 +425,7 @@ KRONK_OS        - OS override: \`linux\`, \`darwin\`, \`windows\``}</code></pre>
           <p><code>KRONK_LIB_PATH</code> is interpreted in one of three ways:</p>
           <ol>
             <li><em>Unset</em> — the runtime resolves <code>&lt;base&gt;/libraries/&lt;os&gt;/&lt;arch&gt;/&lt;processor&gt;/</code> based on the detected (or <code>KRONK_*</code>-overridden) triple.</li>
-            <li><em>Points at a directory containing a &lt;code&gt;version.json&lt;/code&gt;</em> — used as-is. This is the form to set when you want to switch the active install to a previously-downloaded triple folder. Example: ```shell export KRONK_LIB_PATH=~/.kronk/libraries/linux/amd64/cuda ```</li>
+            <li><em>Points at a directory containing a &lt;code&gt;version.json&lt;/code&gt;</em> — used as-is. This is the form to set when you want to switch the active install to a previously-downloaded triple folder. Example: ``<code>shell export KRONK_LIB_PATH=~/.kronk/libraries/linux/amd64/cuda </code>``</li>
             <li><em>Points at a non-empty directory without a &lt;code&gt;version.json&lt;/code&gt;</em> — treated as a user-managed read-only build. Kronk will load libraries from it but never write to it; mutating CLI/HTTP operations against it return an error.</li>
           </ol>
           <p>Switching the active install requires a server restart; libraries are not hot-reloaded.</p>
@@ -5484,8 +5484,8 @@ response = client.chat.completions.create(
           <p><strong>2. Point OpenCode at the new model.</strong></p>
           <p>Edit <code>~/.config/opencode/opencode.jsonc</code> and update two places:</p>
           <ul>
-            <li>The top-level <code>model</code> field — this is the active default. Format is <code>&lt;provider&gt;/&lt;model-name&gt;</code>, so for the Kronk provider: ```jsonc "model": "kronk/my-new-model-Q4_K_M/AGENT" ```</li>
-            <li>The <code>provider.kronk.models</code> map — add a new entry so OpenCode knows the model exists and what its limits are: ```jsonc "models": &#123; "my-new-model-Q4_K_M/AGENT": &#123; "name": "My New Model Q4_K_M", "limit": &#123; "context": 131072, "output": 65536 &#125; &#125; &#125; ```</li>
+            <li>The top-level <code>model</code> field — this is the active default. Format is <code>&lt;provider&gt;/&lt;model-name&gt;</code>, so for the Kronk provider: ``<code>jsonc "model": "kronk/my-new-model-Q4_K_M/AGENT" </code>``</li>
+            <li>The <code>provider.kronk.models</code> map — add a new entry so OpenCode knows the model exists and what its limits are: ``<code>jsonc "models": &#123; "my-new-model-Q4_K_M/AGENT": &#123; "name": "My New Model Q4_K_M", "limit": &#123; "context": 131072, "output": 65536 &#125; &#125; &#125; </code>``</li>
           </ul>
           <p>You can pre-register multiple models in the <code>models</code> map and switch between them inside OpenCode with the <code>/models</code> command — the top-level <code>model</code> field just sets the startup default.</p>
           <p><strong>3. Re-shipping the bundle.</strong></p>
@@ -7129,6 +7129,14 @@ export GITHUB_WORKSPACE=$(pwd)
 # Run from project root directory
 make test`}</code></pre>
           <p><code>make test</code> expands to <code>test-only + lint + vuln-check + diff</code>. The <code>test-only</code> target depends on <code>install-libraries</code> and <code>install-test-models</code>, so the llama.cpp libraries and test GGUF models are downloaded automatically the first time you run it.</p>
+          <blockquote><strong>CI parity note:</strong> CI doesn't use these make targets directly. It</blockquote>
+          <blockquote>reads its model list from</blockquote>
+          <blockquote><a href="../.github/test-models.txt"><code>.github/test-models.txt</code></a> (one</blockquote>
+          <blockquote><code>&lt;backend&gt; &lt;model-id&gt;</code> per line) so the cache key for the models</blockquote>
+          <blockquote>cache can be tied to that file's hash. If you add a test that</blockquote>
+          <blockquote>requires a new model, you MUST add it to <code>test-models.txt</code> AND to</blockquote>
+          <blockquote>the local install path (<code>install-test-models</code>) or CI will silently</blockquote>
+          <blockquote>skip the dependency. See <a href="#19145-test-modelstxt--test-model-manifest">§19.14.5</a>.</blockquote>
           <p>For fast iteration (skip <code>lint</code>, <code>vuln-check</code>, and <code>diff</code>):</p>
           <pre className="code-block"><code className="language-shell">{`make test-only`}</code></pre>
           <p><strong>Run a single test:</strong></p>
@@ -7149,6 +7157,30 @@ make test`}</code></pre>
           <pre className="code-block"><code className="language-shell">{`make install-gotooling   # staticcheck, govulncheck, protoc-gen-go(-grpc), gomod2nix
 make install-tooling     # brew: protobuf, grpcurl, node (only needed for codegen / BUI work)`}</code></pre>
           <p>A fresh checkout that skips <code>install-gotooling</code> will fail the <code>lint</code> and <code>vuln-check</code> steps of <code>make test</code> and the post-edit checks listed in §19.1.</p>
+          <p><strong>Go toolchain version:</strong></p>
+          <p>The repo carries two Go-version files with different roles:</p>
+          <table className="flags-table">
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Role</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="../go.mod"><code>go.mod</code></a></td>
+                <td>Minimum language version. Floor for downstream consumers.</td>
+                <td><code>go 1.26.0</code></td>
+              </tr>
+              <tr>
+                <td><a href="../.go-version"><code>.go-version</code></a></td>
+                <td>Exact toolchain CI / dev managers install (asdf, mise, goenv, gvm, direnv).</td>
+                <td><code>1.26.3</code></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>They are allowed to differ on the <em>patch</em> component but must agree on <code>&lt;major&gt;.&lt;minor&gt;</code>. The Linux + Release workflows run <a href="../.github/scripts/check-go-version.sh"><code>.github/scripts/check-go-version.sh</code></a> to enforce this — bump both files together or CI fails. See <a href="#19142-go-toolchain-pin-gomod-vs-go-version">§19.14.2</a>.</p>
           <h3 id="194-project-architecture">19.4 Project Architecture</h3>
           <p><strong>Directory Structure:</strong></p>
           <table className="flags-table">
@@ -8800,7 +8832,7 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
           <p>The transcribe tests skip themselves when no whisper model is on disk, so contributors without a pulled model still get a green run.</p>
           <h3 id="1914-continuous-integration">19.14 Continuous Integration</h3>
           <h4 id="19141-workflows">19.14.1 Workflows</h4>
-          <p>Three GitHub Actions workflows live under <a href="../.github/workflows/"><code>.github/workflows/</code></a>:</p>
+          <p>Five GitHub Actions workflows live under <a href="../.github/workflows/"><code>.github/workflows/</code></a>:</p>
           <table className="flags-table">
             <thead>
               <tr>
@@ -8812,23 +8844,169 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
             <tbody>
               <tr>
                 <td><a href="../.github/workflows/linux.yml"><code>linux.yml</code></a></td>
-                <td>PRs + push to <code>main</code> (Go/mod paths)</td>
-                <td><code>go vet</code>, <code>staticcheck</code>, <code>govulncheck</code>, <code>go fix -diff</code>, plus the SDK and HTTP tests against pulled models (cached across runs).</td>
+                <td>PRs + push to <code>main</code> (Go/mod/CI paths)</td>
+                <td>Three parallel jobs: <code>static</code> (vet/staticcheck/govulncheck/gofmt/gofix/tidy/goreleaser-check/-race unit tests), <code>api-tests</code> (<code>cmd/server/...</code>), <code>sdk-tests</code> (<code>sdk/...</code>).</td>
               </tr>
               <tr>
                 <td><a href="../.github/workflows/release.yaml"><code>release.yaml</code></a></td>
                 <td>Push of tag <code>v*</code></td>
-                <td>Runs <code>goreleaser</code> to produce per-OS/arch archives, checksums, and refresh the Homebrew cask in <code>ardanlabs/homebrew-kronk</code>.</td>
+                <td>Pinned-toolchain <code>goreleaser release --clean</code>, SBOM generation via syft, SLSA build-provenance attestation, Homebrew cask refresh.</td>
               </tr>
               <tr>
                 <td><a href="../.github/workflows/docker.yml"><code>docker.yml</code></a></td>
                 <td>PRs, push to <code>main</code>, push of tag <code>v*</code>, <code>workflow_dispatch</code></td>
-                <td>Builds (and on push events: publishes) the six container variants defined in <a href="../zarf/docker/kronk/Dockerfile"><code>zarf/docker/kronk/Dockerfile</code></a>. Every variant bakes in both llama.cpp and matching whisper.cpp (bucky) shared libraries plus <code>ffmpeg</code> for transcription.</td>
+                <td>Builds (and on push: publishes + cosign-signs) the <strong>five</strong> container variants defined in <a href="../zarf/docker/kronk/Dockerfile"><code>zarf/docker/kronk/Dockerfile</code></a>.</td>
+              </tr>
+              <tr>
+                <td><a href="../.github/workflows/cache-cleanup.yml"><code>cache-cleanup.yml</code></a></td>
+                <td>Daily cron + manual</td>
+                <td>Prunes stale GHA cache entries and stale <code>kronk-buildcache</code> GHCR tags older than the cutoff.</td>
+              </tr>
+              <tr>
+                <td><a href="../.github/workflows/label-guard.yml"><code>label-guard.yml</code></a></td>
+                <td>Label events on PRs/issues</td>
+                <td>Removes unauthorized <code>build *</code> labels (PRs from non-maintainers; any application on an issue).</td>
               </tr>
             </tbody>
           </table>
-          <h4 id="19142-container-image-build-publish">19.14.2 Container Image Build &amp; Publish</h4>
-          <p>The Docker workflow is matrix-driven; the <code>plan</code> job synthesises the build matrix at runtime from the event type (and from any <code>build &lt;variant&gt;</code> PR labels). Six variants are produced:</p>
+          <p>The three Linux jobs run in parallel and all use <a href="https://github.com/actions/setup-go"><code>actions/setup-go</code></a> keyed on <a href="../.go-version"><code>.go-version</code></a>, so they share one Go module + build cache (<code>setup-go</code>'s key encodes OS + Go version + <code>go.sum</code> hash). That's also why bumping <code>.go-version</code> invalidates the <code>go install ./cmd/kronk</code> step's cache exactly once per Go-version bump.</p>
+          <h4 id="19142-go-toolchain-pin-`gomod`-vs-`go-version`">19.14.2 Go Toolchain Pin (`go.mod` vs `.go-version`)</h4>
+          <p>Two files, two roles:</p>
+          <pre className="code-block"><code className="language-diagram">{`╭──────────────╮      minimum language version (floor)
+│   go.mod     │ ───► \`go 1.26.0\`
+╰──────────────╯      used by downstream consumers of the modules
+                      and by \`GOTOOLCHAIN=auto\` resolution
+
+╭──────────────╮      exact toolchain CI + dev managers install
+│ .go-version  │ ───► \`1.26.3\`
+╰──────────────╯      picked up by asdf, mise, goenv, gvm, direnv,
+                      and actions/setup-go's \`go-version-file:\` input`}</code></pre>
+          <p><a href="../.github/scripts/check-go-version.sh"><code>.github/scripts/check-go-version.sh</code></a> parses the <code>go</code> directive from <code>go.mod</code> and the bare version from <code>.go-version</code>, then fails the workflow when their <code>&lt;major&gt;.&lt;minor&gt;</code> components disagree. Patch-level drift is allowed (and expected: CI typically pins a patched toolchain ahead of the language minimum) — minor-level drift means someone bumped one file and forgot the other.</p>
+          <p>Where the guard runs:</p>
+          <ul>
+            <li><code>linux.yml</code> → the <code>static</code> job, as the first step after checkout.</li>
+            <li><code>release.yaml</code> → before <code>goreleaser</code>, so a release can never be cut with a mismatched toolchain.</li>
+          </ul>
+          <p>All CI jobs export <code>GOTOOLCHAIN=local</code>. A transitive dependency that bumps its <code>go</code> directive above <code>.go-version</code> therefore fails loudly instead of silently triggering a toolchain auto-download — the correct fix is to bump <code>.go-version</code> (and re-run <code>check-go-version.sh</code>).</p>
+          <p>The Docker build performs the same pin: the <a href="../zarf/docker/kronk/Dockerfile">Dockerfile</a> reads <code>.go-version</code> at build time and downloads exactly that toolchain, so binaries published to registries are built with the same compiler CI tested against.</p>
+          <h4 id="19143-linux-pipeline-layout-`linuxyml`">19.14.3 Linux Pipeline Layout (`linux.yml`)</h4>
+          <p><code>linux.yml</code> runs three jobs in parallel after the <code>paths:</code> filter matches. There is no <code>lint</code> / <code>test</code> serialisation — the heavyweight <code>api-tests</code> / <code>sdk-tests</code> jobs start at the same time as the lightweight <code>static</code> job.</p>
+          <pre className="code-block"><code className="language-diagram">{`                       push / pull_request
+                              │
+                              ▼
+              ╭───────── paths filter ─────────╮
+              │ **.go, go.mod, go.sum,         │
+              │ .go-version, .goreleaser.yaml, │
+              │ .github/workflows/linux.yml,   │
+              │ .github/actions/setup-kronk/**,│
+              │ .github/scripts/check-go-...,  │
+              │ .github/test-models.txt        │
+              ╰────────────────┬───────────────╯
+                               │
+        ┌──────────────────────┼──────────────────────┐
+        ▼                      ▼                      ▼
+ ╭────────────╮         ╭─────────────╮        ╭─────────────╮
+ │   static   │         │ api-tests   │        │ sdk-tests   │
+ │            │         │             │        │             │
+ │ check-go-  │         │ setup-kronk │        │ setup-kronk │
+ │ version    │         │ (composite) │        │ (composite) │
+ │ gofmt -l   │         │             │        │             │
+ │ go mod tidy│         │ cmd/server/ │        │ sdk/...     │
+ │ go vet     │         │ (RUN_IN_    │        │ (excluding  │
+ │ staticcheck│         │  PARALLEL=  │        │  /sdk/kronk/│
+ │ govulncheck│         │  no)        │        │  tests)     │
+ │ go fix     │         │             │        │             │
+ │ goreleaser │         │ saves       │        │             │
+ │ check      │         │ models      │        │             │
+ │ -race      │         │ cache on    │        │             │
+ │ unit tests │         │ main + miss │        │             │
+ ╰────────────╯         ╰─────────────╯        ╰─────────────╯`}</code></pre>
+          <p>Key design decisions:</p>
+          <ul>
+            <li><strong>Concurrency group</strong> keyed on <code>$&#123;&#123; github.head_ref || github.ref &#125;&#125;</code> cancels in-progress runs when a PR is force-pushed, collapsing duplicate <code>push</code> + <code>pull_request</code> runs on the same branch.</li>
+            <li><strong>Minimum permissions</strong> (<code>contents: read</code> workflow-wide); <code>api-tests</code> alone gets <code>actions: write</code> so it can save the models cache.</li>
+            <li><strong>Only &lt;code&gt;api-tests&lt;/code&gt; saves the models cache</strong> (<code>actions/cache/save</code>) and only on a cache miss on <code>main</code>. Two save jobs would race on the same key; PR runs and cache hits don't need to save at all.</li>
+            <li>The <code>static</code> job also runs <code>-race -short</code> over the SDK packages that don't spin up the full inference stack — catches concurrency bugs in parsers, kvstorage, pool primitives without doubling test wall-clock.</li>
+            <li>The <code>paths:</code> filter explicitly includes CI infra files (<code>.go-version</code>, <code>setup-kronk/**</code>, <code>check-go-version.sh</code>, <code>test-models.txt</code>, <code>.goreleaser.yaml</code>) so changes to CI itself trigger CI.</li>
+          </ul>
+          <h4 id="19144-shared-setup-action-caches">19.14.4 Shared Setup Action &amp; Caches</h4>
+          <p>Both test jobs delegate to <a href="../.github/actions/setup-kronk/action.yml"><code>.github/actions/setup-kronk</code></a>, a composite action that:</p>
+          <ol>
+            <li>Frees ~25 GB on the runner (drops dotnet, android, ghc, CodeQL).</li>
+            <li>Installs Go via <code>actions/setup-go</code> with <code>go-version-file: .go-version</code>.</li>
+            <li>Restores two <strong>independent</strong> caches: | Cache         | Path                                 | Key                                                                         | Why separate                                                    | | ------------- | ------------------------------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------- | | Libraries     | <code>~/.kronk/libraries</code>, <code>~/.kronk/bucky-libraries</code> | <code>$&#123;&#123; runner.os &#125;&#125;-kronk-libs-$&#123;&#123; hashFiles('sdk/tools/libs/libs.go', 'sdk/tools/bucky/libs/**/*.go') &#125;&#125;</code> | Libs change far less often than models; keep them hot.          | | Models        | <code>~/.kronk/models</code>, <code>~/.kronk/bucky-models</code>       | <code>$&#123;&#123; runner.os &#125;&#125;-models-$&#123;&#123; hashFiles('.github/test-models.txt') &#125;&#125;</code>        | Tied to the test-model manifest — see <a href="#19145-test-modelstxt--test-model-manifest">§19.14.5</a>. |</li>
+            <li><code>go install ./cmd/kronk</code> — fast because the Go module + build cache restored by <code>setup-go</code> is shared with the <code>static</code> job (same Go version, same <code>go.sum</code>).</li>
+            <li><code>kronk libs --local</code> + <code>kronk bucky libs --local</code> to install the llama.cpp + whisper.cpp native libraries (idempotent on a cache hit).</li>
+            <li>On models-cache miss only, walks <code>.github/test-models.txt</code> and pulls every listed model via <code>kronk model pull --local</code> or <code>kronk bucky model pull --local</code>.</li>
+          </ol>
+          <p>The composite emits <code>models-cache-hit</code> and <code>models-cache-key</code> as outputs so the caller can decide whether to re-save the cache.</p>
+          <h4 id="19145-`test-modelstxt`-—-test-model-manifest">19.14.5 `test-models.txt` — Test Model Manifest</h4>
+          <blockquote>⚠️ <strong>MAINTAIN THIS FILE.</strong> <a href="../.github/test-models.txt"><code>.github/test-models.txt</code></a> is the</blockquote>
+          <blockquote><strong>single source of truth</strong> for the models CI pulls into its test</blockquote>
+          <blockquote>environment. The file's hash is mixed into the models-cache key, so</blockquote>
+          <blockquote>adding / removing / renaming a model automatically invalidates the</blockquote>
+          <blockquote>cache on the next run and forces a fresh download. Forgetting to</blockquote>
+          <blockquote>update this file when a test gains a new model dependency means CI</blockquote>
+          <blockquote>will silently restore a stale cache and the new test will fail with</blockquote>
+          <blockquote>a "model not found" error.</blockquote>
+          <p>Format — one entry per line:</p>
+          <pre className="code-block"><code>{`<backend> <model-id>`}</code></pre>
+          <ul>
+            <li><code>backend</code> is <code>kronk</code> (LLM/embed/rerank, pulled with <code>kronk model pull</code>) or <code>bucky</code> (audio transcription, pulled with <code>kronk bucky model pull</code>).</li>
+            <li>Blank lines and lines starting with <code>#</code> are ignored.</li>
+            <li><strong>Do not add inline comments at the end of model lines</strong> — the parser word-splits each entry and treats the third field as garbage.</li>
+          </ul>
+          <p>Current manifest:</p>
+          <table className="flags-table">
+            <thead>
+              <tr>
+                <th>Backend</th>
+                <th>Model</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>kronk</code></td>
+                <td><code>unsloth/Qwen3.5-0.8B-Q8_0</code></td>
+              </tr>
+              <tr>
+                <td><code>kronk</code></td>
+                <td><code>Qwen/Qwen3-8B-Q8_0</code></td>
+              </tr>
+              <tr>
+                <td><code>kronk</code></td>
+                <td><code>ggml-org/embeddinggemma-300m-qat-Q8_0</code></td>
+              </tr>
+              <tr>
+                <td><code>kronk</code></td>
+                <td><code>gpustack/bge-reranker-v2-m3-Q8_0</code></td>
+              </tr>
+              <tr>
+                <td><code>bucky</code></td>
+                <td><code>tiny.en</code></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>Checklist when adding a test that needs a new model:</p>
+          <ol>
+            <li>Add the <code>&lt;backend&gt; &lt;model-id&gt;</code> line to <code>.github/test-models.txt</code>.</li>
+            <li>Also wire it into the local <code>install-test-models</code> make target so <code>make test</code> keeps working for contributors who don't go through CI.</li>
+            <li>Push — the cache key changes automatically, CI pulls the new model once, then everyone else picks it up from cache.</li>
+          </ol>
+          <h4 id="19146-release-workflow-`releaseyaml`">19.14.6 Release Workflow (`release.yaml`)</h4>
+          <p>Triggered only by <code>v*</code> tag pushes. Runs inside a maintainer-gated <code>release</code> GitHub environment (configure required reviewers + tag patterns in <strong>Settings → Environments</strong>), so the <code>HOMEBREW_TAP_GITHUB_TOKEN</code> PAT and signing capabilities can never fire from an unattended branch push.</p>
+          <p>Sequence:</p>
+          <ol>
+            <li><strong>&lt;code&gt;check-go-version.sh&lt;/code&gt;</strong> — same drift guard as <code>linux.yml</code>.</li>
+            <li><strong>&lt;code&gt;actions/setup-go&lt;/code&gt; with &lt;code&gt;.go-version&lt;/code&gt;</strong> — same pinned toolchain as the test jobs, so the release binary is built with the compiler CI tested against.</li>
+            <li><strong>&lt;code&gt;check-version.sh&lt;/code&gt;</strong> — pushed tag must match <code>const Version</code> in <code>sdk/kronk/kronk.go</code> (see <a href="#19149-version-constant--release-guard">§19.14.9</a>).</li>
+            <li><strong>Install syft</strong> (<code>anchore/sbom-action/download-syft</code>) — GoReleaser's <code>sboms:</code> section in <a href="../.goreleaser.yaml"><code>.goreleaser.yaml</code></a> shells out to it to produce a CycloneDX-flavoured SPDX SBOM per archive (e.g. <code>kronk_Linux_x86_64.tar.gz.sbom.json</code>).</li>
+            <li><strong>&lt;code&gt;goreleaser release --clean&lt;/code&gt;</strong> — produces per-OS/arch archives, <code>checksums.txt</code>, the SBOMs, and refreshes the Homebrew cask in <code>ardanlabs/homebrew-kronk</code>.</li>
+            <li><strong>&lt;code&gt;actions/attest-build-provenance&lt;/code&gt;</strong> — attaches SLSA build provenance to every archive, the checksums file, and every SBOM. Consumers can verify with: ``<code>shell gh attestation verify dist/kronk_&lt;...&gt;.tar.gz --repo ardanlabs/kronk gh attestation verify dist/kronk_&lt;...&gt;.tar.gz.sbom.json --repo ardanlabs/kronk </code>``</li>
+          </ol>
+          <p>Permissions are limited to exactly what's needed: <code>contents: write</code> (release assets), <code>id-token: write</code> + <code>attestations: write</code> (SLSA OIDC).</p>
+          <h4 id="19147-container-image-build-publish-`dockeryml`">19.14.7 Container Image Build &amp; Publish (`docker.yml`)</h4>
+          <p>The Docker workflow is matrix-driven. The <code>plan</code> job synthesises the build matrix at runtime from the event type (and from any <code>build &lt;variant&gt;</code> PR labels — see <a href="#19148-support-workflows-cache-cleanupyml-label-guardyml">§19.14.8</a>). <strong>Five</strong> variants are produced (the previous <code>jetson</code> variant was removed; reintroduce it only on user demand):</p>
           <table className="flags-table">
             <thead>
               <tr>
@@ -8869,13 +9047,6 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
                 <td><code>runtime</code></td>
               </tr>
               <tr>
-                <td><code>jetson</code></td>
-                <td><code>cuda</code></td>
-                <td><code>cuda</code></td>
-                <td><code>linux/arm64</code> only</td>
-                <td><code>runtime-jetson</code></td>
-              </tr>
-              <tr>
                 <td><code>all</code></td>
                 <td><code>cpu cuda vulkan rocm</code></td>
                 <td><code>cpu cuda vulkan</code></td>
@@ -8885,8 +9056,35 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
             </tbody>
           </table>
           <p>¹ Upstream whisper.cpp has no rocm build target (<a href="../sdk/tools/bucky/libs/combinations.go">combinations.go</a>), so the rocm variant ships the vulkan bucky bundle and the container entrypoint (<a href="../zarf/docker/kronk/entrypoint.sh">entrypoint.sh</a>) sets <code>KRONK_BUCKY_LIB_PATH</code> to point at it on ROCm hosts so transcription stays GPU-accelerated via the RADV Vulkan driver.</p>
-          <p>Multi-arch images are built <strong>natively</strong> on <code>ubuntu-24.04</code> (amd64) and <code>ubuntu-24.04-arm</code> (arm64) runners — never under QEMU. Each per-arch job pushes its image to GHCR + Docker Hub by <strong>digest only</strong> (no human-readable tag yet) and uploads a tiny artifact containing that digest. A downstream <code>merge</code> job per variant collects the arch-specific digests and stitches them into the final multi-arch manifest with <code>docker buildx imagetools create</code>, applying the human-readable tags at that step.</p>
-          <p>Event → tag mapping:</p>
+          <p><strong>Native multi-arch builds.</strong> Each <code>(variant, arch)</code> matrix entry runs on its own runner — <code>ubuntu-24.04</code> (amd64) or <code>ubuntu-24.04-arm</code> (arm64) — never under QEMU.</p>
+          <p><strong>Separate per-registry buildx invocations.</strong> On push events, each matrix entry runs <strong>two</strong> <code>docker/build-push-action</code> steps: one pushes by digest to GHCR, one pushes by digest to Docker Hub. Why two:</p>
+          <pre className="code-block"><code className="language-diagram">{`                ╭──── build job (variant, arch) ────╮
+                │                                   │
+                │  ╭──── push by digest → GHCR ──╮  │
+                │  │   provenance attestation    │  │
+                │  │   names ghcr.io/...         │  │
+                │  │   surfaces outputs.digest A │  │
+                │  ╰─────────────────────────────╯  │
+                │                                   │
+                │  ╭──── push by digest → DH ────╮  │
+                │  │   provenance attestation    │  │
+                │  │   names docker.io/...       │  │
+                │  │   surfaces outputs.digest B │  │
+                │  ╰─────────────────────────────╯  │
+                │                                   │
+                │   uploads two artifacts:          │
+                │     digests-ghcr-<v>-<a>          │
+                │     digests-dh-<v>-<a>            │
+                ╰───────────────────────────────────╯`}</code></pre>
+          <p>A single buildx invocation with two <code>outputs:</code> lines pushes <strong>different index-manifest digests to each registry</strong> (provenance embeds the destination registry name), but <code>steps.build.outputs.digest</code> exposes only one. The downstream <code>merge</code> job then can't reconstruct working references for the other registry — it sees <code>manifest unknown</code> and fails (the bug that broke an earlier version of this workflow). Splitting the pushes gives each step its own <code>outputs.digest</code>, preserves provenance on both registries, and only re-uploads layers to the second registry (the BuildKit cache picks up everything else).</p>
+          <p><strong>Per-registry digest artifacts.</strong> Each push uploads a tiny <code>digests-&lt;registry&gt;-&lt;variant&gt;-&lt;arch&gt;</code> artifact whose filename is the bare hex of the digest. The <code>merge</code> job downloads the matching artifacts for its variant with <code>actions/download-artifact@v8</code>'s <code>merge-multiple: true</code> — that flag is <strong>required</strong>: without it, <code>download-artifact@v8</code> has a documented asymmetry where 2+ matching artifacts get per-artifact subdirectories but exactly 1 match (the single-arch <code>rocm</code> case) extracts straight into <code>path/</code> with no subdir. Flattening unconditionally makes the layout uniform and is collision-free because filenames are unique digests.</p>
+          <p><strong>Merge + sign.</strong> The <code>merge</code> job per variant:</p>
+          <ol>
+            <li>Downloads the per-registry digest artifacts for its variant.</li>
+            <li>Stitches the multi-arch manifest with <code>docker buildx imagetools create -t &lt;image&gt;:&lt;tag&gt; &lt;image&gt;@sha256:&lt;arch1&gt;...</code> against both registries independently.</li>
+            <li>Signs every published <code>&lt;registry&gt;:&lt;tag&gt;</code> with <strong>cosign keyless</strong> (OIDC). <code>id-token: write</code> is granted on this job only; cosign exchanges the workflow's OIDC token for a short-lived Fulcio cert tied to the workflow identity, signs the manifest, and records the signature + Rekor log entry in the same registry as the image. Consumers verify with: ``<code>shell cosign verify ghcr.io/ardanlabs/kronk:v1.26.4-cpu \ --certificate-identity-regexp \ 'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \ --certificate-oidc-issuer https://token.actions.githubusercontent.com </code>``</li>
+          </ol>
+          <p><strong>Event → variants → tags:</strong></p>
           <table className="flags-table">
             <thead>
               <tr>
@@ -8901,31 +9099,31 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
                 <td>PR (no labels)</td>
                 <td><code>cpu</code></td>
                 <td>no</td>
-                <td>—</td>
+                <td>— (plus a <code>kronk --version</code> / <code>kronk --help</code> smoke test on cpu/amd64)</td>
               </tr>
               <tr>
                 <td>PR + label <code>build all</code></td>
-                <td>all 6</td>
+                <td>all 5</td>
                 <td>no</td>
                 <td>—</td>
               </tr>
               <tr>
                 <td>PR + label <code>build &lt;v&gt;</code></td>
-                <td>that variant</td>
+                <td><code>cpu</code> + each labeled variant</td>
                 <td>no</td>
                 <td>—</td>
               </tr>
               <tr>
                 <td>Push to <code>main</code></td>
-                <td>all 6</td>
+                <td>all 5</td>
                 <td>yes</td>
-                <td><code>main-&lt;shortsha&gt;-&lt;variant&gt;</code></td>
+                <td><code>main-&lt;shortsha&gt;-&lt;variant&gt;</code> (cosign-signed)</td>
               </tr>
               <tr>
                 <td>Push to tag <code>v*</code></td>
-                <td>all 6</td>
+                <td>all 5</td>
                 <td>yes</td>
-                <td><code>&lt;tag&gt;-&lt;variant&gt;</code> + <code>latest-&lt;variant&gt;</code>; plus <code>latest</code> → cpu image</td>
+                <td><code>&lt;tag&gt;-&lt;variant&gt;</code> + <code>latest-&lt;variant&gt;</code>; plus <code>latest</code> → cpu (all signed)</td>
               </tr>
               <tr>
                 <td><code>workflow_dispatch</code></td>
@@ -8935,8 +9133,24 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
               </tr>
             </tbody>
           </table>
-          <p>Per-<code>(variant, arch)</code> GHA cache scopes (<code>type=gha,scope=&lt;variant&gt;-&lt;arch&gt;</code>) keep the BuildKit cache hot across runs; the runner-level free-disk step reclaims ~25 GB up front so the all-backends + rocm builds don't run out of space.</p>
-          <h4 id="19143-version-constant-release-guard">19.14.3 Version Constant &amp; Release Guard</h4>
+          <p><strong>PR relevance gate.</strong> The trigger has no <code>paths:</code> filter — <code>paths:</code> is incompatible with <code>labeled</code> / <code>unlabeled</code> events (those carry no changeset, so GitHub silently drops every label event). The <code>plan</code> job replicates the relevance check inside its script: it calls <code>gh api .../pulls/N/files</code> and skips the build unless the diff touches <code>.go</code>, <code>go.&#123;mod,sum&#125;</code>, <code>.go-version</code>, <code>.dockerignore</code>, <code>cmd/server/api/frontends/bui/</code>, <code>zarf/docker/kronk/</code>, <code>zarf/kms/</code>, or <code>.github/workflows/docker.yml</code>.</p>
+          <p><strong>PR smoke test.</strong> The cpu/amd64 PR build additionally loads the resulting image into the local Docker daemon (<code>load: true</code>) and runs <code>docker run --rm kronk-smoke:latest kronk --version</code> / <code>kronk --help</code>. Catches breakage like a missing shared library or a bad ENTRYPOINT path that a non-load build wouldn't notice.</p>
+          <p><strong>Registry-backed BuildKit cache.</strong> <code>cache-to</code>/<code>cache-from</code> write to <code>ghcr.io/ardanlabs/kronk-buildcache:&lt;variant&gt;-&lt;arch&gt;</code>. On PR builds the cache is read-only — PR validation builds don't seed the trunk cache. On push builds the GHCR step writes the cache (<code>image-manifest=true</code> so it renders as a proper GHCR package) and the Docker Hub step reuses it (<code>cache-from</code> only). The <code>cache-cleanup.yml</code> workflow prunes stale entries — see <a href="#19148-support-workflows-cache-cleanupyml-label-guardyml">§19.14.8</a>.</p>
+          <h4 id="19148-support-workflows-`cache-cleanupyml`-`label-guardyml`">19.14.8 Support Workflows (`cache-cleanup.yml`, `label-guard.yml`)</h4>
+          <p><strong>&lt;code&gt;cache-cleanup.yml&lt;/code&gt;</strong> — daily cron at 04:17 UTC + manual dispatch. Two cleanup passes:</p>
+          <ol>
+            <li><strong>GHA cache entries</strong> older than <code>cutoff_days</code> (default 15) are deleted via <code>gh cache delete</code>. GitHub's built-in 7-day-unused eviction resets the timer on every read, so busy hot scopes never expire on their own — this job enforces an absolute age cap.</li>
+            <li><strong>GHCR &lt;code&gt;kronk-buildcache&lt;/code&gt; package versions</strong> older than the cutoff are deleted via the GHCR packages API. The script handles the first-run case where the package doesn't exist yet (404 → "nothing to prune") so the workflow doesn't fail before any cache has been pushed.</li>
+          </ol>
+          <p>Both passes support a <code>dry_run</code> input for safe inspection.</p>
+          <p><strong>&lt;code&gt;label-guard.yml&lt;/code&gt;</strong> — <code>pull_request_target: labeled</code> + <code>issues: labeled</code>. <code>build *</code> labels expand the Docker workflow's matrix to expensive multi-arch builds, so they're maintainer-only. Two enforcement rules:</p>
+          <ul>
+            <li>On PRs — only users with <code>write</code>, <code>maintain</code>, or <code>admin</code> permission may apply a <code>build *</code> label. Unauthorized applications are removed with an explanatory comment.</li>
+            <li>On issues — <code>build *</code> labels are PR-only; any application is removed.</li>
+          </ul>
+          <p>The workflow runs with minimum permissions (<code>issues: write</code> only — PR labels and comments both go through <code>/issues/</code> endpoints). It is a <strong>cleanup pass</strong>: it removes the label but cannot itself cancel an in-flight Docker build, because <code>GITHUB_TOKEN</code>-driven label removals don't trigger downstream workflow runs. The authoritative gate therefore lives in <code>docker.yml</code>'s <code>plan</code> job, which performs the same permission check and strips unauthorized <code>build *</code> labels from the matrix before expanding it. Belt + braces.</p>
+          <p><code>pull_request_target</code> (not <code>pull_request</code>) is required so the job runs in the base repo's context with write permissions, which is what lets it police labels on PRs from forks. The job never checks out or executes PR-author code — it only calls GitHub APIs with <code>github.event.label</code> / <code>github.event.sender</code> data — so the standard <code>pull_request_target</code> pwn-the-CI risk doesn't apply.</p>
+          <h4 id="19149-version-constant-release-guard">19.14.9 Version Constant &amp; Release Guard</h4>
           <p>The CLI's reported version is the value of the <a href="../sdk/kronk/kronk.go"><code>Version</code> constant in <code>sdk/kronk/kronk.go</code></a> — a plain <code>const string</code> with no link-time override. <a href="../sdk/bucky/bucky.go"><code>sdk/bucky.Version</code></a> is <code>const Version = kronk.Version</code> so the two SDKs always report the same string. Bumping the version is therefore part of the same commit that prepares a <code>v&lt;X.Y.Z&gt;</code> release tag.</p>
           <p>Both the release and Docker workflows enforce this with a shared guard: <a href="../.github/scripts/check-version.sh"><code>.github/scripts/check-version.sh</code></a> parses <code>const Version</code> out of <code>sdk/kronk/kronk.go</code>, strips the leading <code>v</code> from the pushed tag (<code>$GITHUB_REF</code>), and fails the workflow when the two don't match — before any binary, archive, or container image is produced.</p>
           <ul>
@@ -8947,8 +9161,10 @@ go test -v -count=1 ./sdk/bucky/tests/transcribe/...`}</code></pre>
           <p>Release checklist when cutting <code>v&lt;X.Y.Z&gt;</code>:</p>
           <ol>
             <li>Bump <code>const Version</code> in <a href="../sdk/kronk/kronk.go"><code>sdk/kronk/kronk.go</code></a>.</li>
+            <li>(Optional) bump <code>.go-version</code> to the latest patched Go in the current minor line; <code>check-go-version.sh</code> will block the release if <code>go.mod</code>'s minor doesn't match.</li>
             <li>Commit, then tag the same commit <code>v&lt;X.Y.Z&gt;</code> and push.</li>
             <li>CI's tag-guard step refuses the release if step 1 was forgotten.</li>
+            <li>The maintainer approving the <code>release</code> environment unblocks the <code>goreleaser</code> + SBOM + attestation pipeline.</li>
           </ol>
         </div>
 

--- a/cmd/server/api/tooling/docs/manual/manual.go
+++ b/cmd/server/api/tooling/docs/manual/manual.go
@@ -269,12 +269,21 @@ func markdownToJSX(markdown string) string {
 		}
 	}
 
+	// List items are accumulated as RAW markdown text (not yet
+	// inline-converted) because a single `<li>` body can span multiple
+	// source lines via list-continuation (an indented line under an OL
+	// entry, or a wrapped UL entry). Inline parsers like the inline-code
+	// regex `([^`]+)` only match within one line, so converting per-line
+	// would leave a backtick-span that crosses lines unrecognised — and
+	// any `<word>` inside it would then leak through as a (broken) JSX
+	// tag. Converting once at flush time, after the continuation lines
+	// have been joined, gives the inline parsers the complete span.
 	flushUL := func() {
 		flushParagraph()
 		if len(ulItems) > 0 {
 			result = append(result, "          <ul>")
 			for _, item := range ulItems {
-				result = append(result, fmt.Sprintf("            <li>%s</li>", item))
+				result = append(result, fmt.Sprintf("            <li>%s</li>", convertInlineMarkdown(item)))
 			}
 			result = append(result, "          </ul>")
 			ulItems = nil
@@ -289,15 +298,15 @@ func markdownToJSX(markdown string) string {
 			for j, item := range olItems {
 				switch {
 				case j < len(olSubItems) && len(olSubItems[j]) > 0:
-					result = append(result, fmt.Sprintf("            <li>%s", item))
+					result = append(result, fmt.Sprintf("            <li>%s", convertInlineMarkdown(item)))
 					result = append(result, "              <ul>")
 					for _, sub := range olSubItems[j] {
-						result = append(result, fmt.Sprintf("                <li>%s</li>", sub))
+						result = append(result, fmt.Sprintf("                <li>%s</li>", convertInlineMarkdown(sub)))
 					}
 					result = append(result, "              </ul>")
 					result = append(result, "            </li>")
 				default:
-					result = append(result, fmt.Sprintf("            <li>%s</li>", item))
+					result = append(result, fmt.Sprintf("            <li>%s</li>", convertInlineMarkdown(item)))
 				}
 			}
 			result = append(result, "          </ol>")
@@ -367,12 +376,12 @@ func markdownToJSX(markdown string) string {
 				for len(olSubItems) < len(olItems) {
 					olSubItems = append(olSubItems, nil)
 				}
-				olSubItems[len(olItems)-1] = append(olSubItems[len(olItems)-1], convertInlineMarkdown(item))
+				olSubItems[len(olItems)-1] = append(olSubItems[len(olItems)-1], item)
 				continue
 			}
 			// Continuation line: indented, non-empty, not a sub-item.
 			if line != trimmed && trimmed != "" && len(olItems) > 0 {
-				olItems[len(olItems)-1] += " " + convertInlineMarkdown(trimmed)
+				olItems[len(olItems)-1] += " " + trimmed
 				continue
 			}
 			// Blank line between items — skip without flushing.
@@ -385,7 +394,7 @@ func markdownToJSX(markdown string) string {
 			trimmed := strings.TrimLeft(line, " \t")
 			// Continuation line: indented, non-empty, not a nested bullet.
 			if line != trimmed && trimmed != "" && !strings.HasPrefix(trimmed, "- ") && !strings.HasPrefix(trimmed, "* ") && len(ulItems) > 0 {
-				ulItems[len(ulItems)-1] += " " + convertInlineMarkdown(trimmed)
+				ulItems[len(ulItems)-1] += " " + trimmed
 				continue
 			}
 			// Blank line between items — skip without flushing.
@@ -398,12 +407,12 @@ func markdownToJSX(markdown string) string {
 		case strings.HasPrefix(line, "- "):
 			flushOL()
 			inUL = true
-			ulItems = append(ulItems, convertInlineMarkdown(strings.TrimPrefix(line, "- ")))
+			ulItems = append(ulItems, strings.TrimPrefix(line, "- "))
 			continue
 		case strings.HasPrefix(line, "* "):
 			flushOL()
 			inUL = true
-			ulItems = append(ulItems, convertInlineMarkdown(strings.TrimPrefix(line, "* ")))
+			ulItems = append(ulItems, strings.TrimPrefix(line, "* "))
 			continue
 		default:
 			if inUL {
@@ -415,7 +424,7 @@ func markdownToJSX(markdown string) string {
 		case len(matches) > 1:
 			flushUL()
 			inOL = true
-			olItems = append(olItems, convertInlineMarkdown(matches[1]))
+			olItems = append(olItems, matches[1])
 			continue
 		default:
 			if inOL {

--- a/zarf/docker/kronk/Dockerfile
+++ b/zarf/docker/kronk/Dockerfile
@@ -504,16 +504,20 @@ WORKDIR /src
 
 # -----------------------------------------------------------------------------
 # Pre-cache Go modules (separate layer so source edits don't bust the cache).
+# .go-version is copied alongside go.mod/go.sum because the next RUN reads it.
 # -----------------------------------------------------------------------------
-COPY go.mod go.sum ./
+COPY .go-version go.mod go.sum ./
 
-# Install the Go toolchain version pinned in go.mod so the builder always
-# matches what developers use locally.
+# Install the Go toolchain version pinned in /.go-version so the builder
+# matches CI exactly (the linux.yml + release.yaml jobs read the same
+# file). go.mod's `go` directive stays at the minimum LANGUAGE version
+# required for the code, while /.go-version is the exact toolchain
+# everyone — CI, release, and this image — actually builds with.
 #
-# The Go version is dynamic (parsed from go.mod), so we can't ARG-pin a
-# single sha256. Instead we fetch go.dev's release metadata JSON (which
-# lists sha256 per filename) and verify the tarball before unpacking.
-# Two defensive checks:
+# The Go version is dynamic (read from /.go-version), so we can't
+# ARG-pin a single sha256. Instead we fetch go.dev's release metadata
+# JSON (which lists sha256 per filename) and verify the tarball before
+# unpacking. Two defensive checks:
 #   1. The extracted sha256 must be 64 hex chars — otherwise jq found
 #      nothing (e.g. version doesn't exist) and returned `null` / empty,
 #      and sha256sum -c silently exits 0 on a malformed line.
@@ -521,7 +525,11 @@ COPY go.mod go.sum ./
 # Still trusts the TLS chain to go.dev — full PGP verification would
 # require fetching Google's signing key out-of-band.
 RUN set -eux; \
-    GO_VERSION="$(awk '/^go [0-9]/ {print $2; exit}' go.mod)"; \
+    GO_VERSION="$(tr -d '[:space:]' <.go-version)"; \
+    if ! printf '%s' "${GO_VERSION}" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'; then \
+        echo ".go-version contains an unexpected value: '${GO_VERSION}'" >&2; \
+        exit 1; \
+    fi; \
     case "$(uname -m)" in \
         x86_64)  GO_ARCH=amd64 ;; \
         aarch64) GO_ARCH=arm64 ;; \


### PR DESCRIPTION
Overhauled CI for speed and safety: parallel Linux jobs sharing a Go cache via .go-version, a shared setup-kronk composite action with a model manifest (.github/test-models.txt) driving the cache key, plus Docker workflow fixes (5 variants, per-registry buildx pushes, cosign signing) and release-side SBOM/provenance — all documented in the manual.