### PR TITLE
Fix flaky tests

### DIFF
--- a/sdk/kronk/concurrency.go
+++ b/sdk/kronk/concurrency.go
@@ -43,8 +43,17 @@ func streaming[T any](ctx context.Context, krn *Kronk, f streamingFunc[T], ef er
 				sendError(ch, ef, rec)
 			}
 
-			close(ch)
+			// Release the model BEFORE closing the channel. The HTTP
+			// handler (and any caller ranging over ch) unblocks on
+			// close, so the request is considered done by the caller
+			// the instant close fires. The pool's evictOneIdle reads
+			// krn.ActiveStreams() once and returns ErrServerBusy when
+			// it's still nonzero (no retry, no poll) — closing before
+			// releasing leaves a race window where the next sequential
+			// request against a one-slot pool can flake with
+			// "all model slots have active requests".
 			krn.releaseModel()
+			close(ch)
 		}()
 
 		lch := f(mdl)
@@ -110,8 +119,13 @@ func streamingWith[T, U any](ctx context.Context, krn *Kronk, f streamingFunc[T]
 				sendError(ch, ef, ctx.Err())
 			}
 
-			close(ch)
+			// Release the model BEFORE closing the channel — same
+			// rationale as in streaming() above: the pool reads
+			// krn.ActiveStreams() once with no retry, so back-to-back
+			// requests against a one-slot pool flake if release runs
+			// after close.
 			krn.releaseModel()
+			close(ch)
 		}()
 
 		for _, msg := range p.Start() {

--- a/sdk/kronk/model/batch_finish.go
+++ b/sdk/kronk/model/batch_finish.go
@@ -22,6 +22,7 @@ func (e *batchEngine) finishSlot(s *slot, err error) {
 
 	ctx := s.job.ctx
 	jobID := s.job.id
+	jobCh := s.job.ch
 	slotID := s.id
 	seqID := s.seqID
 	nPrompt := s.nPrompt
@@ -29,8 +30,6 @@ func (e *batchEngine) finishSlot(s *slot, err error) {
 	var elapsed time.Duration
 
 	defer func() {
-		close(s.job.ch)
-
 		if s.prefillSpan != nil {
 			s.prefillSpan.End()
 			s.prefillSpan = nil
@@ -57,7 +56,17 @@ func (e *batchEngine) finishSlot(s *slot, err error) {
 		e.freeSlotResources(s)
 		s.reset()
 
+		// Decrement activeStreams BEFORE close(jobCh). The model-level
+		// activeStreams counter coordinates Model.Unload — closing the
+		// channel before decrementing leaves a window where Unload could
+		// race past the count. The pool-visible flake on a one-slot
+		// pool (cap-evict-failed) is fixed at the outer kronk.Kronk
+		// layer in concurrency.go (release before close); this inner
+		// ordering keeps the per-model accounting consistent for the
+		// same reason. Note: s.reset() above sets s.job = nil, so we
+		// must close via the locally captured jobCh, not s.job.ch.
 		remaining := e.model.activeStreams.Add(-1)
+		close(jobCh)
 
 		args := []any{
 			"status", "slot-finished",
@@ -312,9 +321,12 @@ func (e *batchEngine) failJob(job *chatJob, err error) {
 		e.model.imcClearPending(job.imcSlotID)
 	}
 
-	close(job.ch)
-
+	// Decrement activeStreams BEFORE close(job.ch). See finishSlot's
+	// defer for the full rationale: closing first leaves a race window
+	// where the next sequential request can hit ErrServerBusy while
+	// this stream's count is still in flight.
 	remaining := e.model.activeStreams.Add(-1)
+	close(job.ch)
 
 	e.model.log(job.ctx, "batch-engine", "status", "job-failed", "id", job.id,
 		"imc_slot", job.imcSlotID, "imc_cache_hit", job.imcCacheHit,

--- a/sdk/kronk/model/chat.go
+++ b/sdk/kronk/model/chat.go
@@ -79,9 +79,18 @@ func (m *Model) ChatStreaming(ctx context.Context, d D) <-chan ChatResponse {
 			}
 
 			if !batching {
-				close(ch)
+				// Decrement activeStreams BEFORE close(ch). The HTTP handler
+				// (and Chat()'s range loop) blocks on the response channel; the
+				// instant close fires, the request is considered done by the
+				// caller and the next sequential request can start. The pool's
+				// evictOneIdle reads ActiveStreams() once and returns
+				// ErrServerBusy when it's still nonzero (no retry), so closing
+				// before decrementing leaves a race window where back-to-back
+				// requests against a one-slot pool flake with "all model slots
+				// have active requests".
 				remaining := m.activeStreams.Add(-1)
 				metrics.SetPoolActiveStreams(m.modelInfo.ID, int(remaining))
+				close(ch)
 				m.log(ctx, "chat-streaming", "status", "finished", "id", id, "active_streams", remaining)
 			}
 		}()


### PR DESCRIPTION
Fixes a flaky `cap-evict-failed: server busy: all model slots have active requests` failure in the `api/service` tests, caused by a race where `close(ch)` ran before `krn.releaseModel()` in `streaming`/`streamingWith`
The HTTP handler returned (and the next sequential test started) while the pool's `ActiveStreams()` count was still nonzero, so `evictOneIdle` rejected the next model load. Swapping the order to `releaseModel(); close(ch)` (plus the equivalent `activeStreams.Add(-1)` before `close` in the inner `Model` finish paths for `Unload` consistency) closes
the window.

Specifically, it fixes this issue: https://github.com/ardanlabs/kronk/actions/runs/26876968463/job/79266726854