### PR TITLE
Update gomod2nix.toml to latest additions.

### DIFF
--- a/zarf/nix/gomod2nix.toml
+++ b/zarf/nix/gomod2nix.toml
@@ -38,8 +38,8 @@ schema = 3
     version = "v1.2.1"
     hash = "sha256-3XnCzf7tFgEE0MmjxvjfWaw6qK6mKLabFZ3c23JIH9Y="
   [mod."github.com/ardanlabs/bucky"]
-    version = "v1.0.4"
-    hash = "sha256-m2jq6Yo/+XLs3duDqxFsSdppBMumZhz+mD6/Jz3YB3E="
+    version = "v1.0.5"
+    hash = "sha256-Lqtdao4/9iybPbm4lG84z8ymBrlWFfjZ9YSpH+XqxkY="
   [mod."github.com/ardanlabs/conf/v3"]
     version = "v3.12.0"
     hash = "sha256-lywKaxHXxsGBNlIOu0c4kLPB4U3oaX0INu56qv6/V3A="
@@ -206,8 +206,8 @@ schema = 3
     version = "v1.9.0"
     hash = "sha256-sRr/50k8Wra0PJLCJgSkIxvR+ce3PItx4HpFvVijGYk="
   [mod."github.com/hybridgroup/yzma"]
-    version = "v1.16.1"
-    hash = "sha256-mba0KrwhlBMtQvBpspyTICTHmYJLRqMs5K4LvsR5GfE="
+    version = "v1.17.1"
+    hash = "sha256-giiAIXEEP1JvOsi4CcudMugcnpZe/cx0Uy2zSDUWVHQ="
   [mod."github.com/icza/bitio"]
     version = "v1.1.0"
     hash = "sha256-CtV/dr1L46cZ65EnK9DrBduZCaMnTGf4N2MnElCymtM="


### PR DESCRIPTION
# Was

When `nix build ./zarf/nix` or `nix shell ./zarf/nix` it failed.

```
main ❯ nix shell ./zarf/nix
error: Cannot build '/nix/store/d5plrns944fng6icr3v9nz1x89s33gn4-kronk-1.27.9.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/y55gjkv4kf8fa6m85bwi4glcml0snkdv-kronk-1.27.9
       Last 25 log lines:
       > github.com/segmentio/encoding/json
       > github.com/modelcontextprotocol/go-sdk/internal/json
       > github.com/modelcontextprotocol/go-sdk/oauthex
       > github.com/modelcontextprotocol/go-sdk/auth
       > github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2
       > github.com/modelcontextprotocol/go-sdk/internal/mcpgodebug
       > github.com/modelcontextprotocol/go-sdk/internal/xcontext
       > github.com/modelcontextprotocol/go-sdk/jsonrpc
       > github.com/yosida95/uritemplate/v3
       > github.com/modelcontextprotocol/go-sdk/mcp
       > github.com/ardanlabs/kronk/cmd/server/app/domain/mcpapp
       > github.com/arl/statsviz/internal/plot
       > github.com/arl/statsviz/internal/static
       > github.com/gorilla/websocket
       > github.com/arl/statsviz
       > github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header
       > github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil
       > github.com/prometheus/client_golang/prometheus/promhttp/internal
       > github.com/prometheus/client_golang/prometheus/promhttp
       > internal/profile
       > net/http/pprof
       > github.com/ardanlabs/kronk/cmd/server/app/sdk/debug
       > google.golang.org/grpc/test/bufconn
       > os/signal
       > github.com/ardanlabs/kronk/cmd/kronk/server/stop
       For full logs, run:
         nix log /nix/store/d5plrns944fng6icr3v9nz1x89s33gn4-kronk-1.27.9.drv
error: Cannot build '/nix/store/bal958a0dvzsp718v63za98280w9m40h-kronk.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/j0qh9sq8sksbskdy8dald14ng5689yh4-kronk
error: Build failed due to failed dependency
```

# Is

After updating the configuration, things work smoothly.

```
nix shell ./zarf/nix

feature/nix ♥ kronk --version
kronk version 1.27.9
```