### PR TITLE
sdk/bucky/model: add prompt-carryover, no-speech, and log-prob threshold controls

### DIFF
--- a/.manual/chapter-18-bucky.md
+++ b/.manual/chapter-18-bucky.md
@@ -416,6 +416,14 @@ Key SDK entry points:
 | `Bucky.Unload(ctx)`                 | Wait for active streams to drain and unload the model.                        |
 | `bucky.LangID/LangStr/LangMaxID`    | Language code ↔ id helpers.                                                   |
 
+`Transcribe` accepts `model.TranscribeOption` values for per-call tuning:
+`WithLanguage`, `WithTranslate`, `WithBeamSize`, `WithTranscribeNThreads`,
+and the hallucination quality gates `WithNoSpeechThreshold` (no-speech
+probability) / `WithLogProbThreshold` (average log-probability acceptance).
+Both gates leave the whisper.cpp defaults (`0.6` and `-1.0`) in place
+unless set; the streaming equivalents are in
+[18.9.3](#1893-stream-options).
+
 #### Channel-Separated Diarization
 
 For recordings where each speaker is on a dedicated channel (call-center
@@ -569,7 +577,35 @@ all defaults match whisper.cpp `stream` conventions where applicable.
 | `WithKeepMs(ms)`             | 300     | Trailing audio kept across a commit so a boundary word is not clipped.                    |
 | `WithVAD(bool)`              | **on**  | Energy-ratio silence detection that gates Finals. Pass `false` for fixed-cadence commits. |
 | `WithVADThreshold(f)`        | 0.6     | Trailing window is "silence" when its mean energy < `f` × the whole window's mean energy. |
+| `WithPromptCarryover(bool)`  | **on**  | Seed each window's decode with the previous window's tail tokens (manual `condition_on_previous_text`). Pass `false` to decode every window independently. |
+| `WithStreamNoSpeechThreshold(f)` | library (0.6) | Override whisper.cpp's no-speech probability gate for every decode in the session. `0` leaves the library default. |
+| `WithStreamLogProbThreshold(f)`  | library (-1.0) | Override whisper.cpp's average log-probability acceptance gate for every decode in the session. Passing any value (including `0`) sets the override. |
 | `WithEmitResetEvent(bool)`   | false   | Emit an `EventReset` after `Reset` completes.                                             |
+
+**Prompt carryover** is **on by default**: at each commit the decoded
+tail tokens are harvested and seeded into the next window's decode, so
+the decoder keeps linguistic context across commits (the manual
+equivalent of whisper.cpp's `condition_on_previous_text`). The trade-off
+is that a strong prior — e.g. a committed question — can condition a
+near-silent trailing window into a plausible but hallucinated
+continuation. Pass `WithPromptCarryover(false)` to decode every window
+independently and stop that. Like VAD, it is expressed by the negative
+`StreamConfig.DisablePromptCarryover` field so the default-on behavior
+needs no sentinel. `WithStreamInitialPrompt` is unaffected — it still
+biases the first window regardless of carryover. When carryover is
+disabled, `WithKeepPromptTokens` on a `Reset` becomes a no-op: the global
+setting always wins.
+
+**Quality gates** (`WithStreamNoSpeechThreshold` /
+`WithStreamLogProbThreshold`) are a second lever against hallucinated
+output on quiet audio. A lower no-speech threshold treats more borderline
+segments as silence (raise it to be more permissive); a stricter (higher)
+log-probability threshold rejects low-confidence decodes and retries them at
+a higher temperature. The same
+gates are available per call on the batch path via
+`WithNoSpeechThreshold` / `WithLogProbThreshold`
+([18.8](#188-sdk-quick-start)). Both leave the whisper.cpp defaults in
+place unless set.
 
 VAD is **on by default**: the detector is a pure-Go energy-ratio check
 (the same approach as whisper.cpp's `vad_simple` — no model file, no extra

--- a/cmd/server/api/frontends/bui/src/components/DocsManual.tsx
+++ b/cmd/server/api/frontends/bui/src/components/DocsManual.tsx
@@ -7107,6 +7107,7 @@ func main() {
               </tr>
             </tbody>
           </table>
+          <p><code>Transcribe</code> accepts <code>model.TranscribeOption</code> values for per-call tuning: <code>WithLanguage</code>, <code>WithTranslate</code>, <code>WithBeamSize</code>, <code>WithTranscribeNThreads</code>, and the hallucination quality gates <code>WithNoSpeechThreshold</code> (no-speech probability) / <code>WithLogProbThreshold</code> (average log-probability acceptance). Both gates leave the whisper.cpp defaults (<code>0.6</code> and <code>-1.0</code>) in place unless set; the streaming equivalents are in <a href="#1893-stream-options">18.9.3</a>.</p>
           <h4 id="channel-separated-diarization">Channel-Separated Diarization</h4>
           <p>For recordings where each speaker is on a dedicated channel (call-center and meeting captures often record one participant per channel), <code>TranscribeChannels</code> / <code>TranscribeChannelsFile</code> transcribe every channel separately and merge the results into a single diarized transcript. This builds on the upstream <code>audio.SplitChannels</code> helper: native multi-channel formats (WAV, FLAC) are de-interleaved and each channel resampled to 16 kHz, then transcribed on its own. Formats that require ffmpeg (WebM/Opus, MP4/AAC, ...) are downmixed to a single channel, so they yield one speaker.</p>
           <pre className="code-block"><code className="language-go">{`f, _ := os.Open("call.wav") // stereo: caller on L, agent on R
@@ -7289,12 +7290,29 @@ err := stream.FeedPCM(ctx, rawMicBytes, format)`}</code></pre>
                 <td>Trailing window is "silence" when its mean energy &lt; <code>f</code> × the whole window's mean energy.</td>
               </tr>
               <tr>
+                <td><code>WithPromptCarryover(bool)</code></td>
+                <td><strong>on</strong></td>
+                <td>Seed each window's decode with the previous window's tail tokens (manual <code>condition_on_previous_text</code>). Pass <code>false</code> to decode every window independently.</td>
+              </tr>
+              <tr>
+                <td><code>WithStreamNoSpeechThreshold(f)</code></td>
+                <td>library (0.6)</td>
+                <td>Override whisper.cpp's no-speech probability gate for every decode in the session. <code>0</code> leaves the library default.</td>
+              </tr>
+              <tr>
+                <td><code>WithStreamLogProbThreshold(f)</code></td>
+                <td>library (-1.0)</td>
+                <td>Override whisper.cpp's average log-probability acceptance gate for every decode in the session. Passing any value (including <code>0</code>) sets the override.</td>
+              </tr>
+              <tr>
                 <td><code>WithEmitResetEvent(bool)</code></td>
                 <td>false</td>
                 <td>Emit an <code>EventReset</code> after <code>Reset</code> completes.</td>
               </tr>
             </tbody>
           </table>
+          <p><strong>Prompt carryover</strong> is <strong>on by default</strong>: at each commit the decoded tail tokens are harvested and seeded into the next window's decode, so the decoder keeps linguistic context across commits (the manual equivalent of whisper.cpp's <code>condition_on_previous_text</code>). The trade-off is that a strong prior — e.g. a committed question — can condition a near-silent trailing window into a plausible but hallucinated continuation. Pass <code>WithPromptCarryover(false)</code> to decode every window independently and stop that. Like VAD, it is expressed by the negative <code>StreamConfig.DisablePromptCarryover</code> field so the default-on behavior needs no sentinel. <code>WithStreamInitialPrompt</code> is unaffected — it still biases the first window regardless of carryover. When carryover is disabled, <code>WithKeepPromptTokens</code> on a <code>Reset</code> becomes a no-op: the global setting always wins.</p>
+          <p><strong>Quality gates</strong> (<code>WithStreamNoSpeechThreshold</code> / <code>WithStreamLogProbThreshold</code>) are a second lever against hallucinated output on quiet audio. A lower no-speech threshold treats more borderline segments as silence (raise it to be more permissive); a stricter (higher) log-probability threshold rejects low-confidence decodes and retries them at a higher temperature. The same gates are available per call on the batch path via <code>WithNoSpeechThreshold</code> / <code>WithLogProbThreshold</code> (<a href="#188-sdk-quick-start">18.8</a>). Both leave the whisper.cpp defaults in place unless set.</p>
           <p>VAD is <strong>on by default</strong>: the detector is a pure-Go energy-ratio check (the same approach as whisper.cpp's <code>vad_simple</code> — no model file, no extra inference). It is expressed by the negative <code>StreamConfig.DisableVAD</code> field (the <code>http.Transport.DisableKeepAlives</code> idiom) so the default-on behavior needs no sentinel.</p>
           <h4 id="1894-indefinite-sessions-reset">18.9.4 Indefinite Sessions &amp; Reset</h4>
           <p>A single <code>*Stream</code> is designed to run <strong>indefinitely</strong> — for hours, across topic changes, mic mute/unmute, or "scratch that, start over". <code>Reset</code> clears the audio buffer and rolling context <strong>without</strong> releasing the pool slot, tearing down the worker, or closing <code>Events</code>, so you never re-pay acquisition latency or lose GPU cache warmth for what is logically one session. Resource use stays flat no matter how long a stream runs or how often it is reset.</p>

--- a/cmd/server/api/frontends/bui/src/components/DocsSDKBuckyModel.tsx
+++ b/cmd/server/api/frontends/bui/src/components/DocsSDKBuckyModel.tsx
@@ -268,7 +268,10 @@ export default function DocsSDKBuckyModel() {
 	// history across the reset so the next window keeps linguistic
 	// continuity ("rewind the audio buffer but keep context"). Default
 	// false, which treats Reset as a hard session boundary (e.g. a topic
-	// change) and clears the context.
+	// change) and clears the context. This is a no-op when the session
+	// was created with prompt carryover disabled
+	// (StreamConfig.DisablePromptCarryover): that global setting always
+	// wins, so every window decodes independently regardless of this flag.
 	KeepPromptTokens bool
 }`}</code>
               </pre>
@@ -367,6 +370,33 @@ export default function DocsSDKBuckyModel() {
 	// eager to cut. 0 = 0.6.
 	VADThreshold float32
 
+	// DisablePromptCarryover turns OFF the cross-window prompt-token
+	// continuity. By default (zero value) each committed window's tail
+	// tokens are harvested and seeded into the next window's decode, the
+	// manual equivalent of whisper.cpp's condition_on_previous_text, so the
+	// decoder keeps linguistic context across commits. The cost is that a
+	// strong prior (e.g. a committed question) can condition a near-silent
+	// trailing window into a plausible but hallucinated continuation. Set
+	// it true (via WithPromptCarryover(false)) to decode every window
+	// independently. The field is named for the non-default state, matching
+	// the DisableVAD idiom, so the default-on behavior needs no sentinel.
+	// InitialPrompt is unaffected; it still biases the first window.
+	DisablePromptCarryover bool
+
+	// NoSpeechThreshold overrides whisper.cpp's no-speech probability
+	// threshold for every decode in the session when > 0 (library default
+	// 0.6). A zero (or negative) value is the "unset" sentinel and leaves
+	// the default in place; see TranscribeConfig.NoSpeechThreshold for why
+	// >0 is a sufficient sentinel.
+	NoSpeechThreshold float32
+
+	// LogProbThreshold overrides whisper.cpp's average log-probability
+	// acceptance threshold for every decode in the session when non-nil
+	// (library default -1.0). nil leaves the default in place; it is a
+	// pointer rather than a sentinel because 0 is a legitimate threshold
+	// the caller must be able to set.
+	LogProbThreshold *float32
+
 	// EmitResetEvent, when true, emits an EventReset after Reset.
 	// Default false. Useful when a different goroutine consumes Events
 	// and keeps partial-text accumulators it must clear at a boundary.
@@ -406,6 +436,26 @@ export default function DocsSDKBuckyModel() {
 
 	// NThreads overrides Config.NThreads for this call when > 0.
 	NThreads int32
+
+	// NoSpeechThreshold overrides whisper.cpp's no-speech probability
+	// threshold when > 0 (the library default is 0.6). A segment whose
+	// no-speech probability exceeds this is treated as silence during
+	// the decode's temperature-fallback decision, reducing the chance a
+	// near-silent window is decoded into hallucinated text. The value is
+	// a probability in (0, 1]; a zero (or negative) value is the "unset"
+	// sentinel and leaves the library default in place. A >0 sentinel is
+	// sufficient here because 0 is not a useful threshold (it would flag
+	// nearly every segment as silence), so it need not be expressible.
+	NoSpeechThreshold float32
+
+	// LogProbThreshold overrides whisper.cpp's average log-probability
+	// acceptance threshold when non-nil (the library default is -1.0).
+	// Decodes whose average token log-probability falls below this are
+	// rejected and retried at a higher temperature. nil leaves the
+	// library default in place. Unlike NoSpeechThreshold this is a
+	// pointer rather than a >0/!=0 sentinel because 0 is a legitimate
+	// (maximally strict) threshold the caller must be able to set.
+	LogProbThreshold *float32
 
 	// BeamSize, when > 0, switches the sampler to beam search with
 	// the specified beam size. Defaults to greedy.

--- a/sdk/bucky/model/stream.go
+++ b/sdk/bucky/model/stream.go
@@ -168,6 +168,33 @@ type StreamConfig struct {
 	// eager to cut. 0 = 0.6.
 	VADThreshold float32
 
+	// DisablePromptCarryover turns OFF the cross-window prompt-token
+	// continuity. By default (zero value) each committed window's tail
+	// tokens are harvested and seeded into the next window's decode, the
+	// manual equivalent of whisper.cpp's condition_on_previous_text, so the
+	// decoder keeps linguistic context across commits. The cost is that a
+	// strong prior (e.g. a committed question) can condition a near-silent
+	// trailing window into a plausible but hallucinated continuation. Set
+	// it true (via WithPromptCarryover(false)) to decode every window
+	// independently. The field is named for the non-default state, matching
+	// the DisableVAD idiom, so the default-on behavior needs no sentinel.
+	// InitialPrompt is unaffected; it still biases the first window.
+	DisablePromptCarryover bool
+
+	// NoSpeechThreshold overrides whisper.cpp's no-speech probability
+	// threshold for every decode in the session when > 0 (library default
+	// 0.6). A zero (or negative) value is the "unset" sentinel and leaves
+	// the default in place; see TranscribeConfig.NoSpeechThreshold for why
+	// >0 is a sufficient sentinel.
+	NoSpeechThreshold float32
+
+	// LogProbThreshold overrides whisper.cpp's average log-probability
+	// acceptance threshold for every decode in the session when non-nil
+	// (library default -1.0). nil leaves the default in place; it is a
+	// pointer rather than a sentinel because 0 is a legitimate threshold
+	// the caller must be able to set.
+	LogProbThreshold *float32
+
 	// EmitResetEvent, when true, emits an EventReset after Reset.
 	// Default false. Useful when a different goroutine consumes Events
 	// and keeps partial-text accumulators it must clear at a boundary.
@@ -252,6 +279,30 @@ func WithVADThreshold(v float32) StreamOption {
 	return func(c *StreamConfig) { c.VADThreshold = v }
 }
 
+// WithPromptCarryover toggles cross-window prompt-token continuity
+// (the manual condition_on_previous_text). Carryover is ON by default;
+// pass false to decode each window independently and stop a committed
+// prior from conditioning a near-silent trailing window into a
+// hallucinated continuation.
+func WithPromptCarryover(v bool) StreamOption {
+	return func(c *StreamConfig) { c.DisablePromptCarryover = !v }
+}
+
+// WithStreamNoSpeechThreshold overrides whisper.cpp's no-speech
+// probability threshold for every decode in the session. 0 leaves the
+// library default (0.6) in place.
+func WithStreamNoSpeechThreshold(v float32) StreamOption {
+	return func(c *StreamConfig) { c.NoSpeechThreshold = v }
+}
+
+// WithStreamLogProbThreshold overrides whisper.cpp's average
+// log-probability acceptance threshold for every decode in the session.
+// Passing a value (including 0) sets the override; not calling the option
+// leaves the library default (-1.0) in place.
+func WithStreamLogProbThreshold(v float32) StreamOption {
+	return func(c *StreamConfig) { c.LogProbThreshold = &v }
+}
+
 // WithEmitResetEvent makes Reset emit an EventReset on the channel.
 func WithEmitResetEvent(v bool) StreamOption {
 	return func(c *StreamConfig) { c.EmitResetEvent = v }
@@ -276,7 +327,10 @@ type ResetConfig struct {
 	// history across the reset so the next window keeps linguistic
 	// continuity ("rewind the audio buffer but keep context"). Default
 	// false, which treats Reset as a hard session boundary (e.g. a topic
-	// change) and clears the context.
+	// change) and clears the context. This is a no-op when the session
+	// was created with prompt carryover disabled
+	// (StreamConfig.DisablePromptCarryover): that global setting always
+	// wins, so every window decodes independently regardless of this flag.
 	KeepPromptTokens bool
 }
 
@@ -377,10 +431,12 @@ func (m *Model) NewStream(ctx context.Context, onClose func(), opts ...StreamOpt
 
 	decode := func(samples []float32, firstWindow bool, prompt []whisper.Token) (Transcription, []whisper.Token, error) {
 		tcfg := TranscribeConfig{
-			Language:     cfg.Language,
-			Translate:    cfg.Translate,
-			NThreads:     cfg.NThreads,
-			PromptTokens: prompt,
+			Language:          cfg.Language,
+			Translate:         cfg.Translate,
+			NThreads:          cfg.NThreads,
+			PromptTokens:      prompt,
+			NoSpeechThreshold: cfg.NoSpeechThreshold,
+			LogProbThreshold:  cfg.LogProbThreshold,
 		}
 		if firstWindow {
 			tcfg.InitialPrompt = cfg.InitialPrompt
@@ -707,7 +763,9 @@ func (s *Stream) commit() error {
 
 	s.emitFinal(tr)
 	s.firstWindow = false
-	s.promptTokens = toks
+	if !s.cfg.DisablePromptCarryover {
+		s.promptTokens = toks
+	}
 
 	keep := min(samplesForMs(s.cfg.KeepMs), len(s.buf))
 	committed := len(s.buf) - keep
@@ -747,8 +805,10 @@ func (s *Stream) doReset(rc ResetConfig) error {
 		s.emitFinal(tr)
 
 		// When continuity is requested, the flush is the freshest
-		// context, so carry its tail tokens forward.
-		if rc.KeepPromptTokens {
+		// context, so carry its tail tokens forward — unless the session
+		// has prompt carryover disabled, in which case windows are always
+		// decoded independently.
+		if rc.KeepPromptTokens && !s.cfg.DisablePromptCarryover {
 			s.promptTokens = toks
 		}
 	}

--- a/sdk/bucky/model/stream_test.go
+++ b/sdk/bucky/model/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -540,6 +541,108 @@ func TestStream_ResetKeepsPromptTokens(t *testing.T) {
 	}
 	if got := calls[before]; !tokensEqual(got, []whisper.Token{4, 5, 6}) {
 		t.Errorf("prompt on first decode after keep-reset: got %v, want [4 5 6]", got)
+	}
+}
+
+func TestStream_PromptCarryoverDisabled(t *testing.T) {
+	// WithPromptCarryover(false) flips DisablePromptCarryover on; assert the
+	// option wiring before exercising the worker.
+	var cfg StreamConfig
+	WithPromptCarryover(false)(&cfg)
+	if !cfg.DisablePromptCarryover {
+		t.Fatal("WithPromptCarryover(false) did not set DisablePromptCarryover")
+	}
+	WithPromptCarryover(true)(&cfg)
+	if cfg.DisablePromptCarryover {
+		t.Fatal("WithPromptCarryover(true) did not clear DisablePromptCarryover")
+	}
+
+	fd := &fakeDecoder{text: "x", harvest: []whisper.Token{7, 8, 9}}
+	cfg = StreamConfig{
+		PartialEveryMs:         -1,
+		CommitEveryMs:          200,
+		MaxUtteranceMs:         100000,
+		DisableVAD:             true,
+		DisablePromptCarryover: true,
+	}.withDefaults()
+
+	s := newStream(cfg, fd.decode, func() {})
+	c := newCollector(s)
+
+	// Two windows worth of audio so at least two commits occur; a harvested
+	// prompt would normally roll into the decode after the first commit.
+	if err := s.Feed(context.Background(), tone(400, 0.5)); err != nil {
+		t.Fatalf("Feed 1: %v", err)
+	}
+	c.waitFor(t, func(evs []Event) bool { return countKind(evs, EventFinal) >= 1 })
+
+	if err := s.Feed(context.Background(), tone(400, 0.5)); err != nil {
+		t.Fatalf("Feed 2: %v", err)
+	}
+	c.waitFor(t, func(evs []Event) bool { return countKind(evs, EventFinal) >= 2 })
+
+	s.Close()
+	<-c.doneC
+
+	// With carryover disabled every window must decode independently: no
+	// decode may ever see the harvested {7,8,9} as its prompt.
+	calls := fd.promptCalls()
+	if len(calls) == 0 {
+		t.Fatal("decoder never called")
+	}
+	for i, p := range calls {
+		if len(p) != 0 {
+			t.Errorf("decode %d carried a prompt with carryover disabled: got %v, want empty", i, p)
+		}
+	}
+}
+
+func TestStream_PromptCarryoverEnabled(t *testing.T) {
+	// Carryover is the default (DisablePromptCarryover false). The first
+	// window decodes independently, but the tokens harvested at its commit
+	// must seed the next window's decode. This is the positive counterpart
+	// to TestStream_PromptCarryoverDisabled: without it, a commit() that
+	// always cleared promptTokens would still pass the disabled test.
+	fd := &fakeDecoder{text: "x", harvest: []whisper.Token{7, 8, 9}}
+	cfg := StreamConfig{
+		PartialEveryMs: -1,
+		CommitEveryMs:  200,
+		MaxUtteranceMs: 100000,
+		DisableVAD:     true,
+	}.withDefaults()
+
+	s := newStream(cfg, fd.decode, func() {})
+	c := newCollector(s)
+
+	if err := s.Feed(context.Background(), tone(400, 0.5)); err != nil {
+		t.Fatalf("Feed 1: %v", err)
+	}
+	c.waitFor(t, func(evs []Event) bool { return countKind(evs, EventFinal) >= 1 })
+
+	if err := s.Feed(context.Background(), tone(400, 0.5)); err != nil {
+		t.Fatalf("Feed 2: %v", err)
+	}
+	c.waitFor(t, func(evs []Event) bool { return countKind(evs, EventFinal) >= 2 })
+
+	s.Close()
+	<-c.doneC
+
+	calls := fd.promptCalls()
+	if len(calls) < 2 {
+		t.Fatalf("expected at least 2 decode calls, got %d", len(calls))
+	}
+
+	// First window decodes independently.
+	if len(calls[0]) != 0 {
+		t.Errorf("first decode carried a prompt: got %v, want empty", calls[0])
+	}
+
+	// At least one later decode must have been seeded with the harvested
+	// tail tokens.
+	if !slices.ContainsFunc(calls[1:], func(p []whisper.Token) bool {
+		return slices.Equal(p, []whisper.Token{7, 8, 9})
+	}) {
+		t.Errorf("no decode after the first commit carried the harvested prompt {7 8 9}; got %v", calls[1:])
 	}
 }
 

--- a/sdk/bucky/model/threshold_test.go
+++ b/sdk/bucky/model/threshold_test.go
@@ -1,0 +1,65 @@
+package model
+
+import "testing"
+
+// The threshold overrides feed whisper.cpp's no-speech and log-probability
+// acceptance gates. buildFullParams maps them into whisper_full_params, but
+// that call dlopens the native library (see fakeDecoder for why the model
+// package avoids it in unit tests), so these tests assert the option wiring
+// and the sentinel/pointer semantics that decide whether buildFullParams
+// applies an override at all.
+
+func TestTranscribeThresholdOptions(t *testing.T) {
+	// Zero value: no override requested on either path.
+	var cfg TranscribeConfig
+	if cfg.NoSpeechThreshold != 0 {
+		t.Fatalf("default NoSpeechThreshold: got %v, want 0", cfg.NoSpeechThreshold)
+	}
+	if cfg.LogProbThreshold != nil {
+		t.Fatalf("default LogProbThreshold: got %v, want nil", cfg.LogProbThreshold)
+	}
+
+	WithNoSpeechThreshold(0.7)(&cfg)
+	if cfg.NoSpeechThreshold != 0.7 {
+		t.Errorf("WithNoSpeechThreshold(0.7): got %v, want 0.7", cfg.NoSpeechThreshold)
+	}
+
+	// 0 must be expressible for LogProbThreshold (a maximally strict
+	// threshold); that is the whole reason the field is a pointer rather
+	// than a !=0 sentinel.
+	WithLogProbThreshold(0)(&cfg)
+	if cfg.LogProbThreshold == nil {
+		t.Fatal("WithLogProbThreshold(0): got nil, want a settable 0")
+	}
+	if *cfg.LogProbThreshold != 0 {
+		t.Errorf("WithLogProbThreshold(0): got %v, want 0", *cfg.LogProbThreshold)
+	}
+
+	WithLogProbThreshold(-2)(&cfg)
+	if cfg.LogProbThreshold == nil || *cfg.LogProbThreshold != -2 {
+		t.Errorf("WithLogProbThreshold(-2): got %v, want -2", cfg.LogProbThreshold)
+	}
+}
+
+func TestStreamThresholdOptions(t *testing.T) {
+	var cfg StreamConfig
+	if cfg.NoSpeechThreshold != 0 {
+		t.Fatalf("default NoSpeechThreshold: got %v, want 0", cfg.NoSpeechThreshold)
+	}
+	if cfg.LogProbThreshold != nil {
+		t.Fatalf("default LogProbThreshold: got %v, want nil", cfg.LogProbThreshold)
+	}
+
+	WithStreamNoSpeechThreshold(0.7)(&cfg)
+	if cfg.NoSpeechThreshold != 0.7 {
+		t.Errorf("WithStreamNoSpeechThreshold(0.7): got %v, want 0.7", cfg.NoSpeechThreshold)
+	}
+
+	WithStreamLogProbThreshold(0)(&cfg)
+	if cfg.LogProbThreshold == nil {
+		t.Fatal("WithStreamLogProbThreshold(0): got nil, want a settable 0")
+	}
+	if *cfg.LogProbThreshold != 0 {
+		t.Errorf("WithStreamLogProbThreshold(0): got %v, want 0", *cfg.LogProbThreshold)
+	}
+}

--- a/sdk/bucky/model/transcribe.go
+++ b/sdk/bucky/model/transcribe.go
@@ -83,6 +83,26 @@ type TranscribeConfig struct {
 	// NThreads overrides Config.NThreads for this call when > 0.
 	NThreads int32
 
+	// NoSpeechThreshold overrides whisper.cpp's no-speech probability
+	// threshold when > 0 (the library default is 0.6). A segment whose
+	// no-speech probability exceeds this is treated as silence during
+	// the decode's temperature-fallback decision, reducing the chance a
+	// near-silent window is decoded into hallucinated text. The value is
+	// a probability in (0, 1]; a zero (or negative) value is the "unset"
+	// sentinel and leaves the library default in place. A >0 sentinel is
+	// sufficient here because 0 is not a useful threshold (it would flag
+	// nearly every segment as silence), so it need not be expressible.
+	NoSpeechThreshold float32
+
+	// LogProbThreshold overrides whisper.cpp's average log-probability
+	// acceptance threshold when non-nil (the library default is -1.0).
+	// Decodes whose average token log-probability falls below this are
+	// rejected and retried at a higher temperature. nil leaves the
+	// library default in place. Unlike NoSpeechThreshold this is a
+	// pointer rather than a >0/!=0 sentinel because 0 is a legitimate
+	// (maximally strict) threshold the caller must be able to set.
+	LogProbThreshold *float32
+
 	// BeamSize, when > 0, switches the sampler to beam search with
 	// the specified beam size. Defaults to greedy.
 	BeamSize int32
@@ -119,6 +139,20 @@ func WithTranslate(v bool) TranscribeOption {
 // WithTranscribeNThreads overrides Config.NThreads for this call.
 func WithTranscribeNThreads(v int32) TranscribeOption {
 	return func(c *TranscribeConfig) { c.NThreads = v }
+}
+
+// WithNoSpeechThreshold overrides whisper.cpp's no-speech probability
+// threshold for this call. 0 leaves the library default (0.6) in place.
+func WithNoSpeechThreshold(v float32) TranscribeOption {
+	return func(c *TranscribeConfig) { c.NoSpeechThreshold = v }
+}
+
+// WithLogProbThreshold overrides whisper.cpp's average log-probability
+// acceptance threshold for this call. Passing a value (including 0) sets
+// the override; not calling the option leaves the library default (-1.0)
+// in place.
+func WithLogProbThreshold(v float32) TranscribeOption {
+	return func(c *TranscribeConfig) { c.LogProbThreshold = &v }
 }
 
 // WithBeamSize switches the sampler to beam search of the specified
@@ -279,6 +313,12 @@ func (m *Model) buildFullParams(tcfg TranscribeConfig) (whisper.WhisperFullParam
 	}
 	if tcfg.NoTimestamps {
 		params.NoTimestamps = 1
+	}
+	if tcfg.NoSpeechThreshold > 0 {
+		params.NoSpeechThold = tcfg.NoSpeechThreshold
+	}
+	if tcfg.LogProbThreshold != nil {
+		params.LogprobThold = *tcfg.LogProbThreshold
 	}
 
 	params.PrintProgress = 0


### PR DESCRIPTION
Adds three decode-tuning knobs to sdk/bucky/model, each exposed on both the streaming (StreamConfig/StreamOption) and one-shot (TranscribeConfig/ TranscribeOption) paths:

1. Prompt-carryover toggle — WithPromptCarryover(bool) / StreamConfig.DisablePromptCarryover. Carryover (the manual equivalent of whisper.cpp's condition_on_previous_text) stays ON by default. Pass false to decode every window independently, which stops a strong committed prior (e.g. a question) from conditioning a near-silent trailing window into a plausible-but-hallucinated continuation. Streaming-only.

2. No-speech threshold override — WithNoSpeechThreshold / WithStreamNoSpeechThreshold, mapped to whisper_full_params.no_speech_thold (library default 0.6).

3. Log-prob threshold override — WithLogProbThreshold / WithStreamLogProbThreshold, mapped to whisper_full_params.logprob_thold (library default -1.0).

Design notes:

- NoSpeechThreshold uses a >0 sentinel; LogProbThreshold uses a *float32. This asymmetry is deliberate: a no-speech probability of 0 is not a useful threshold (it would flag nearly every segment as silence), so the zero-value sentinel is sufficient. A log-prob threshold of 0 is a legitimate maximally-strict value, so the field is a pointer and nil is the "unset" sentinel — 0 stays settable.
- KeepPromptTokens x DisablePromptCarryover: when a session is created with carryover disabled, a per-reset KeepPromptTokens request is a no-op — the global setting always wins so every window decodes independently. Documented on the public field.

Tests:

- TestTranscribeThresholdOptions / TestStreamThresholdOptions — option wiring and the pointer/sentinel semantics (notably that WithLogProbThreshold(0) yields a settable 0, and unset stays nil/default).
- TestStream_PromptCarryoverEnabled — positive counterpart to the existing disabled test: first window decodes independently, harvested tail tokens seed the next window. (Without it, a commit() that always cleared promptTokens would still pass the disabled test.)
- The buildFullParams -> whisper_full_params mapping is left to the integration suite that loads a real model; the unit tests above avoid it because that path dlopens the native library (the same reason the package's fakeDecoder exists).

Docs: chapter-18-bucky.md and the BUI manual/SDK doc components document all three knobs, the design asymmetry, and the carryover/InitialPrompt/ KeepPromptTokens interactions.

Known limitation: NoSpeechThreshold is a probability and is not range-validated against [0, 1] — callers must pass a valid probability. This matches the rest of the package, where functional options are not validated, and whisper.cpp owns any clamping.

gofmt -s, go vet, and staticcheck are clean on the package.