### PR TITLE
fix: recognize "ROCm"-prefixed HIP devices (AMD GPU not detected)

### DIFF
--- a/sdk/kronk/model/model.go
+++ b/sdk/kronk/model/model.go
@@ -1242,6 +1242,24 @@ func resolveBackendDevice(name string) llama.GGMLBackendDevice {
 		}
 	}
 
+	// Newer llama.cpp builds expose the HIP backend devices under "ROCm"
+	// names (e.g. "ROCm0") rather than "HIP", so an exact by-name lookup
+	// for the "hip"/"rocm" aliases misses them. Fall back to a prefix scan
+	// over the registered devices.
+	if strings.EqualFold(name, "rocm") {
+		for i := range llama.GGMLBackendDeviceCount() {
+			dev := llama.GGMLBackendDeviceGet(i)
+			if dev == 0 {
+				continue
+			}
+
+			n := llama.GGMLBackendDeviceName(dev)
+			if strings.HasPrefix(n, "ROCm") || strings.HasPrefix(n, "HIP") {
+				return dev
+			}
+		}
+	}
+
 	return 0
 }
 

--- a/sdk/tools/devices/devices.go
+++ b/sdk/tools/devices/devices.go
@@ -130,7 +130,7 @@ func ClassifyDeviceType(name string) string {
 		return "gpu_cuda"
 	case name == "Metal":
 		return "gpu_metal"
-	case strings.HasPrefix(name, "HIP"):
+	case strings.HasPrefix(name, "HIP"), strings.HasPrefix(name, "ROCm"):
 		return "gpu_rocm"
 	case strings.HasPrefix(name, "Vulkan"):
 		return "gpu_vulkan"


### PR DESCRIPTION
## Problem

On an AMD ROCm host, the GPU is loaded and fully usable by ggml/llama.cpp, but Kronk reports **`gpu_count: 0`** and the Browser UI shows no GPU. Models then load CPU-only.

Root cause: recent llama.cpp builds (e.g. **b9748**, the version currently bundled) name the HIP backend devices **`ROCm0`, `ROCm1`, …** instead of the older **`HIP0`** naming. Kronk only matches the `HIP` prefix, so the device falls through to `"unknown"`.

This was reproduced and isolated end-to-end on a Ryzen AI MAX+ 395 (Radeon 8060S, **gfx1151**):

- `rocminfo`, the HIP runtime, a direct `ggml_backend_load_all_from_path` call, and the **bundled `llama-cli --list-devices`** all see the GPU correctly (`ROCm0: Radeon 8060S Graphics`).
- But `GET /v1/devices` returns:
  ```json
  {"index":0,"name":"ROCm0","type":"unknown", ...}, "gpu_count":0
  ```

So the failure is purely Kronk-side string matching, not driver/runtime/library setup.

## Fix

Accept the `ROCm` prefix in both places that special-case HIP:

- **`ClassifyDeviceType`** (`sdk/tools/devices/devices.go`) — map `ROCm*` to `gpu_rocm` so the device is counted as a GPU.
- **`resolveBackendDevice`** (`sdk/kronk/model/model.go`) — the exact by-name lookup for the `hip`/`rocm` aliases never matches `ROCm0`; add a prefix scan over the registered devices so explicit ROCm offload resolves the handle.

The older `HIP` prefix is kept, so both old and new llama.cpp builds work.

## Verification

After the fix, on the same machine:

```
resman-init: gpu-count:1, gpu[0]: name=ROCm0 type=gpu_rocm total=32.8GB budget=26.0GB
```
```json
GET /v1/devices → {"name":"ROCm0","type":"gpu_rocm", ...}, "gpu_count":1, "supports_gpu_offload":true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)