### PR TITLE
fix[windows]: add pre-load libraries

### DIFF
--- a/sdk/kronk/init.go
+++ b/sdk/kronk/init.go
@@ -101,6 +101,15 @@ func Init(opts ...InitOption) error {
 			os.Setenv("PATH", fmt.Sprintf("%s;%s", libPath, v))
 		}
 
+		// PATH alone is not enough on Windows: the system directory (System32)
+		// is searched before PATH, so a stale same-named copy of a bundled
+		// dependency (e.g. libomp140.x86_64.dll) shadows ours and fails the
+		// load with "the specified procedure could not be found". Preload our
+		// libraries from libPath so they (and their dependency tree) win.
+		// Best-effort: on failure the PATH entry above remains the fallback, so
+		// the error is intentionally non-fatal.
+		_ = preloadLibraries(libPath)
+
 	default:
 		if v := os.Getenv("LD_LIBRARY_PATH"); !strings.Contains(v, libPath) {
 			os.Setenv("LD_LIBRARY_PATH", fmt.Sprintf("%s:%s", libPath, v))

--- a/sdk/kronk/library_search_other.go
+++ b/sdk/kronk/library_search_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package kronk
+
+// preloadLibraries is a no-op on non-Windows platforms. Linux uses
+// LD_LIBRARY_PATH and macOS uses dylib install names / @rpath, both of which
+// already let the bundled library directory take precedence over system
+// locations, so no DLL-search-order fixup is required. See the Windows build
+// of this function for the full rationale.
+func preloadLibraries(libPath string) error {
+	return nil
+}

--- a/sdk/kronk/library_search_windows.go
+++ b/sdk/kronk/library_search_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package kronk
+
+import (
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// preloadLibraries loads kronk's bundled top-level DLLs (and their transitive
+// static dependencies) from libPath BEFORE yzma loads them, so they resolve to
+// our copies instead of an older, same-named DLL that happens to live in the
+// Windows system directory (System32).
+//
+// Why this is needed only on Windows: yzma loads the top-level libraries
+// (llama.dll, mtmd.dll) by absolute path, but the OS resolves their transitive
+// dependencies by bare file name using the standard search order, in which
+// System32 is searched BEFORE the directories on PATH. A stale system-wide copy
+// of a bundled dependency therefore shadows ours and the load fails with "The
+// specified procedure could not be found" (a newer llama.cpp build imports a
+// symbol the old system DLL does not export). Appending libPath to PATH cannot
+// win that race. Linux (LD_LIBRARY_PATH) and macOS (install names / @rpath)
+// already let the bundled directory take precedence, so they need no equivalent.
+//
+// Mechanism: each top-level DLL is loaded with LoadLibraryEx and
+// LOAD_WITH_ALTERED_SEARCH_PATH, which makes the directory containing that DLL
+// (libPath) the first directory searched for it AND its dependency tree —
+// ggml.dll, ggml-base.dll, libomp140.x86_64.dll, and so on. This fixes the
+// whole class of System32-shadowing for everything kronk ships, not just
+// libomp. yzma's later plain LoadLibrary of the same absolute path simply
+// reuses the already-resident module. The ggml-cpu-*.dll backends loaded later
+// by GGMLBackendLoadAllFromPath are covered indirectly: their shared
+// dependencies (ggml-base, libomp) are already resident, and loaded modules are
+// the first thing the loader checks.
+//
+// This is deliberately scoped to kronk's own load. It does NOT alter the
+// process-global DLL search order, so it cannot break or cross-contaminate a
+// sibling backend (e.g. bucky/whisper) that loads its own libraries from a
+// different directory in the same process.
+//
+// libomp140.x86_64.dll is preloaded explicitly first as a deterministic leaf
+// guard, in case LOAD_WITH_ALTERED_SEARCH_PATH does not propagate to that deep
+// a transitive dependency on some Windows versions; an absolute path ignores
+// the search order entirely. Every load here is best-effort: handles are
+// intentionally leaked for the process lifetime (these libraries are never
+// unloaded), and the first error is returned for the caller to treat as
+// non-fatal, leaving the PATH entry as the fallback.
+func preloadLibraries(libPath string) error {
+	names := []string{
+		"libomp140.x86_64.dll", // leaf dependency: load first by absolute path
+		"llama.dll",
+		"mtmd.dll",
+	}
+
+	var firstErr error
+	for _, name := range names {
+		full := filepath.Join(libPath, name)
+
+		if _, err := windows.LoadLibraryEx(full, 0, windows.LOAD_WITH_ALTERED_SEARCH_PATH); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+
+	return firstErr
+}


### PR DESCRIPTION
# Fix: Windows DLL search-order shadowing breaks library load (degraded mode)

## Problem

On Windows, Kronk fails to initialize and falls back to degraded mode with:

```
init: unable to load library: ...\.kronk\libraries\windows\amd64\cpu\ggml.dll:
error loading library: The specified procedure could not be found.
```

## Root cause

`ggml-base.dll` (in current llama.cpp builds) imports `__kmpc_dispatch_deinit`
from `libomp140.x86_64.dll`. yzma loads `llama.dll`/`mtmd.dll` by absolute path,
but Windows resolves their transitive dependencies **by bare name using the
standard search order, where `System32` is searched before `PATH`**. Microsoft
ships an older LLVM OpenMP runtime as part of the Visual C++ Redistributable
(`C:\Windows\System32\libomp140.x86_64.dll`) that predates that symbol. That
stale copy shadows Kronk's bundled libomp, so the import can't resolve and the
load fails. Appending `libPath` to `PATH` can't win that race.

This is a **latent Windows-only flaw**: Linux (`LD_LIBRARY_PATH`) and macOS
(install names / `@rpath`) already let the bundled lib dir take precedence. It
became observable once the pinned llama.cpp build started requiring a newer
libomp export than the common System32 copy provides — last known-good `v1.24.8`
(llama.cpp `b9048`); regression surfaced in `v1.28.0` (first release pinning
`b9664`).

## Fix

Preload Kronk's bundled top-level DLLs from `libPath` with
`LoadLibraryEx(..., LOAD_WITH_ALTERED_SEARCH_PATH)` before yzma loads them, so
the bundled directory is searched first for each DLL **and its entire dependency
tree** (`ggml.dll`, `ggml-base.dll`, `libomp140.x86_64.dll`, …). yzma's later
plain `LoadLibrary` reuses the already-resident modules; the dynamically-loaded
`ggml-cpu-*.dll` backends are covered indirectly since their shared deps are
already in memory. `libomp140.x86_64.dll` is preloaded first by absolute path as
a deterministic leaf guard.

The fix is **deliberately scoped to Kronk's own load** — it does not alter the
process-global DLL search order, so it cannot break or cross-contaminate a
sibling backend (bucky/whisper) that loads its own libraries from a different
directory in the same process.

This addresses the whole **class** of System32 shadowing for everything Kronk
ships, not just libomp.

## Changes

- `sdk/kronk/library_search_windows.go` (new, `//go:build windows`) —
  `preloadLibraries`.
- `sdk/kronk/library_search_other.go` (new, `//go:build !windows`) — no-op.
- `sdk/kronk/init.go` — call `preloadLibraries(libPath)` from the existing
  `case "windows":` arm; `PATH` entry retained as fallback.

## Testing

- `gofmt`, `go fix`, `go vet`, and `staticcheck` clean;
- Native Windows build of `./cmd/kronk` links successfully;
- Verified on **release v1.28.3 with llama.cpp build b9750**: `make kronk-server` starts
  cleanly
