### PR TITLE
fix: use os exit 1 to return and log error

### DIFF
--- a/examples/agent/main.go
+++ b/examples/agent/main.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -36,7 +35,8 @@ var modelSource = "unsloth/gemma-4-E4B-it-qat-UD-Q4_K_XL"
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 

--- a/examples/concurrency/main.go
+++ b/examples/concurrency/main.go
@@ -13,7 +13,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -41,7 +40,8 @@ const (
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Standardized error handling in examples by replacing `log.Fatal` with `os.Exit(1)`. 

In most cases, examples use this error handling except those fixed in this PR.

```
func main() {
	if err := run(); err != nil {
		fmt.Printf("\nERROR: %s\n", err)
		os.Exit(1)
	}
}
```