### PR TITLE
cleanup: remove Go Reportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Read the [Manual](./manual) to learn more about running the Kronk Model Server.
 ## Project Status
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ardanlabs/kronk.svg)](https://pkg.go.dev/github.com/ardanlabs/kronk)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ardanlabs/kronk)](https://goreportcard.com/report/github.com/ardanlabs/kronk)
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/ardanlabs/kronk)](https://github.com/ardanlabs/kronk)
 [![llama.cpp Release](https://img.shields.io/github/v/release/ggml-org/llama.cpp?label=llama.cpp)](https://github.com/ggml-org/llama.cpp/releases)
 


### PR DESCRIPTION
This removes the badge for Go Reportcard now that the service has been shut down. :city_sunset: 