### PR TITLE
Add better container labels, job timeouts, CVE scanning, and supply-chain attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,6 +104,7 @@ jobs:
   # ---------------------------------------------------------------------------
   plan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # `pull-requests: read` is needed by `gh api /repos/.../pulls/N/files`
     # in the relevance gate below. Everything else stays at the default.
     permissions:
@@ -406,6 +407,10 @@ jobs:
     needs: plan
     if: needs.plan.outputs.matrix != '{"include":[]}'
     runs-on: ${{ matrix.runner }}
+    # The `all` variant (cpu+cuda+vulkan+rocm) is the long pole; 90 min
+    # leaves headroom over a cold-cache build while still killing a hung
+    # runner well before the 6-hour GitHub default.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
@@ -496,6 +501,15 @@ jobs:
       # missing shared library or a bad ENTRYPOINT path that the build
       # alone would not detect. Runs only on the (cpu, amd64, no-push)
       # path — see `load:` above.
+      #
+      # Coverage gap (intentional): only cpu/amd64 is exercised at
+      # runtime. arm64 can't run natively on this amd64 runner without
+      # QEMU emulation (the whole point of the native-arch matrix is to
+      # avoid QEMU), and the cuda/vulkan/rocm variants need GPU hardware
+      # the hosted runners don't have. cpu is the most-shared Dockerfile
+      # path, so a single (cpu, amd64) smoke test catches the breakage
+      # most likely to be common across variants. arm64 image validity
+      # is still covered structurally by the build succeeding.
       - name: Smoke test cpu/amd64 image
         if: >-
           needs.plan.outputs.push != 'true'
@@ -504,6 +518,30 @@ jobs:
         run: |
           docker run --rm --entrypoint kronk kronk-smoke:latest --version
           docker run --rm --entrypoint kronk kronk-smoke:latest --help
+
+      # Vulnerability scan the runtime image before it can ship. Runs on
+      # the same (cpu, amd64, no-push) path as the smoke test — the only
+      # path where the image is `load`ed into the local daemon. This
+      # gates PR and push→main builds; since a tag push builds the same
+      # layers from the same cache, a CVE introduced by a base-image or
+      # dependency bump is caught on main before a release tag is cut.
+      #
+      # Fails only on fixable CRITICAL findings to keep the gate
+      # actionable — unfixed CVEs (no upstream patch yet) would block
+      # every build with no remediation available, so they're ignored.
+      - name: Scan cpu/amd64 image for vulnerabilities (Trivy)
+        if: >-
+          needs.plan.outputs.push != 'true'
+          && matrix.variant == 'cpu'
+          && matrix.arch == 'amd64'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: kronk-smoke:latest
+          format: table
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
+          vuln-type: os,library
 
       # Tag-push path (refs/tags/v*): build & push by digest only.
       # Final tags get applied by the `merge` job once both arches
@@ -546,6 +584,22 @@ jobs:
             BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
             KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Supply-chain attestations: max-mode SLSA provenance plus an
+          # SPDX SBOM, attached to each per-arch image so consumers can
+          # `cosign verify-attestation` / pull the SBOM alongside the
+          # cosign signatures produced in the merge job.
+          #
+          # CAVEAT — validate on a throwaway tag before trusting: with
+          # push-by-digest, buildx attaches the attestations as extra
+          # manifests referenced from a per-arch image index. The merge
+          # job assembles the final manifest list from the image digests
+          # collected in Export digests; confirm those attestation
+          # manifests survive `imagetools create` (inspect the published
+          # tag for provenance/SBOM). If they're dropped by the merge,
+          # switch to attaching the SBOM via cosign attest in the merge
+          # job instead.
+          provenance: mode=max
+          sbom: true
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
           cache-to: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }},mode=max,image-manifest=true,compression=zstd
 
@@ -563,6 +617,12 @@ jobs:
             BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
             KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
           outputs: type=image,name=${{ env.DH_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Same provenance + SBOM attestations as the GHCR push above so
+          # both registries carry equivalent supply-chain metadata. See
+          # the CAVEAT there re: validating attestation survival through
+          # the imagetools merge.
+          provenance: mode=max
+          sbom: true
           # cache-from only: the GHCR step above already populated the
           # cache for this (variant, arch); a second cache-to would
           # just rewrite the same content.
@@ -613,6 +673,7 @@ jobs:
     needs: [plan, build]
     if: needs.plan.outputs.push == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -666,14 +666,103 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Per-variant title + description for the OCI annotations the
+      # next step generates. The description ends up on the GHCR /
+      # Docker Hub package pages (each registry reads
+      # `org.opencontainers.image.description` from the INDEX manifest
+      # — see DOCKER_METADATA_ANNOTATIONS_LEVELS below). Keep these
+      # blurbs in sync with DockerHub.md and the "Available Images"
+      # table there; if you add or rename a variant, update both.
+      - name: Compute per-variant annotation overrides
+        id: variant_meta
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          case "$VARIANT" in
+            cpu)
+              DESC="Kronk — Local LLM inference and audio transcription server (OpenAI-compatible API). CPU-only build, runs anywhere (no GPU required)."
+              ;;
+            cuda)
+              DESC="Kronk — Local LLM inference and audio transcription server (OpenAI-compatible API). NVIDIA CUDA build (requires --gpus all and nvidia-container-toolkit)."
+              ;;
+            vulkan)
+              DESC="Kronk — Local LLM inference and audio transcription server (OpenAI-compatible API). Vulkan build for AMD / Intel / NVIDIA GPUs (vendor-neutral)."
+              ;;
+            rocm)
+              DESC="Kronk — Local LLM inference and audio transcription server (OpenAI-compatible API). AMD ROCm build (linux/amd64 only)."
+              ;;
+            all)
+              DESC="Kronk — Local LLM inference and audio transcription server (OpenAI-compatible API). All backends bundled (cpu, cuda, vulkan, rocm); selects the right one at runtime based on host hardware."
+              ;;
+            *)
+              echo "::error::No description configured for variant '$VARIANT' — add a case branch in .github/workflows/docker.yml" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "title=kronk ($VARIANT)"
+            echo "description=$DESC"
+          } >>"$GITHUB_OUTPUT"
+
+      # Generate the canonical OCI annotation set (title, description,
+      # source, url, revision, created, version, licenses, vendor) from
+      # the workflow context, with per-variant title/description
+      # overrides applied above.
+      #
+      # DOCKER_METADATA_ANNOTATIONS_LEVELS=index is the critical bit:
+      # GHCR (and Docker Hub) read the description from annotations on
+      # the INDEX manifest, not on the per-platform manifests beneath
+      # it. The default is `manifest`, which silently does nothing for
+      # multi-arch images — that's why the GHCR UI was warning that no
+      # description was set despite per-arch labels being present.
+      #
+      # We don't use the `tags` output here (tag set is computed
+      # downstream in the merge step), but `images:` is required by the
+      # action so we pass both registries.
+      - name: Generate OCI annotations
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DH_IMAGE }}
+          annotations: |
+            org.opencontainers.image.title=${{ steps.variant_meta.outputs.title }}
+            org.opencontainers.image.description=${{ steps.variant_meta.outputs.description }}
+            org.opencontainers.image.vendor=Ardan Labs
+
       - name: Create and push manifests
         id: merge_manifests
         env:
           VERSION: ${{ needs.plan.outputs.version }}
           VARIANT: ${{ matrix.variant }}
           IS_TAG: ${{ needs.plan.outputs.is_tag }}
+          # Multi-line string of `index:<key>=<value>` entries produced
+          # by docker/metadata-action above. Parsed into --annotation
+          # flags for each `imagetools create` call below.
+          ANNOTATIONS_INPUT: ${{ steps.meta.outputs.annotations }}
         run: |
           set -euo pipefail
+
+          # -------------------------------------------------------------------
+          # Translate metadata-action's `annotations` output into the
+          # repeated --annotation flags that `buildx imagetools create`
+          # expects. Each input line is already in the form
+          # `index:org.opencontainers.image.<key>=<value>` (because of
+          # DOCKER_METADATA_ANNOTATIONS_LEVELS=index on the meta step).
+          # -------------------------------------------------------------------
+          ANNOTATION_FLAGS=()
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            ANNOTATION_FLAGS+=(--annotation "$line")
+          done <<<"$ANNOTATIONS_INPUT"
+
+          echo "::group::Annotations"
+          printf '  %s\n' "${ANNOTATION_FLAGS[@]}"
+          echo "::endgroup::"
 
           # Build per-registry lists of per-arch digest references.
           # Layout (flattened by `merge-multiple: true` on the download


### PR DESCRIPTION
## What:
- **Timeouts**: plan 10m, build 90m, merge 30m (was 6h default).
- **CVE scan**: Trivy on the cpu/amd64 image (no-push path), fails on fixable CRITICAL.
- **Attestations**: provenance mode=max + SBOM on GHCR/DH push steps.

## Caveats:
- Attestation survival through the `imagetools` merge is **unverified** — validate on a test tag first.
- CVE scan covers **cpu only**, not GPU variants.
- CRITICAL hard-fail can red-X unrelated PRs.
- Smoke test is cpu/amd64-only by design.