### PR TITLE
Publish signed trunk snapshots on push to main

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -4,7 +4,7 @@ name: Cache cleanup
 # so the repo never bumps into GitHub Actions' 10 GB GHA-cache quota
 # or accumulates dead OCI manifests on GHCR / Docker Hub.
 #
-# Five scopes get cleaned (one job each, all run in parallel):
+# Eight scopes get cleaned (one job each, all run in parallel):
 #
 #   1. prune-gha-cache — GHA cache (actions/cache + buildx `type=gha`
 #      exports). Anything older than CUTOFF_DAYS is deleted via
@@ -35,6 +35,24 @@ name: Cache cleanup
 #      set before deleting. Docker Hub auto-collects untagged
 #      manifests after 30 days so we don't replicate this for DH.
 #
+#   6. prune-snapshot-tags-ghcr-main — immutable per-commit snapshot
+#      tags (`main-<sha>-<variant>`) on `ghcr.io/ardanlabs/kronk-main`
+#      older than CUTOFF_DAYS. The floating `main-latest-<variant>`
+#      pointers are NEVER pruned. Deleting a snapshot's index manifest
+#      here leaves its per-arch children + cosign signatures behind;
+#      jobs 7 and 8 reap those on subsequent runs.
+#
+#   7. prune-untagged-ghcr-main — same untagged-manifest sweep as job 5
+#      but for `ghcr.io/ardanlabs/kronk-main`. Reclaims the per-arch
+#      children orphaned by job 6, plus any by-digest pushes from a
+#      main build whose `merge_main` never ran (e.g. a failed gate, so
+#      no tags were ever applied).
+#
+#   8. prune-orphan-signatures-ghcr-main — same orphan-cosign sweep as
+#      job 3 but for `ghcr.io/ardanlabs/kronk-main`. Reaps the
+#      `sha256-<hex>.{sig,att,sbom}` versions left behind when job 6
+#      removes a snapshot the signature targeted.
+#
 # NEVER prunes:
 #   - Release tags (`v*-*`, `latest*`) on either registry — those are
 #     product artifacts. Removing them would break users pinning to a
@@ -42,6 +60,10 @@ name: Cache cleanup
 #     release tags; if you ever want one, do it in a separate workflow
 #     and require explicit dry-run for at least two cycles before
 #     turning it live.
+#   - The floating `main-latest-<variant>` snapshot pointers on
+#     `ghcr.io/ardanlabs/kronk-main` — always the newest trunk build,
+#     so consumers pinning to `main-latest-*` never break. Only the
+#     immutable `main-<sha>-<variant>` snapshots age out (job 6).
 #   - GitHub Actions workflow artifacts uploaded by docker.yml — those
 #     already have `retention-days: 1`, so GitHub auto-deletes them
 #     within 24 hours. No code here for them.
@@ -78,6 +100,11 @@ env:
   # and on Docker Hub ($ORG/$RELEASE_PACKAGE). Kept in sync with
   # docker.yml's GHCR_IMAGE / DH_IMAGE.
   RELEASE_PACKAGE: kronk
+  # Trunk-snapshot image package on GHCR (ghcr.io/$ORG/$MAIN_PACKAGE),
+  # written only by docker.yml's `merge_main` job on push→main. GHCR
+  # only — this repo has no Docker Hub counterpart. Kept in sync with
+  # docker.yml's GHCR_MAIN_IMAGE.
+  MAIN_PACKAGE: kronk-main
   # Sibling repo on Docker Hub that holds cosign signatures (see
   # docker.yml's COSIGN_REPOSITORY redirect). Not a thing on GHCR
   # (signatures co-located there).
@@ -558,3 +585,249 @@ jobs:
           done < <(echo "${stale}" | jq -r '.[] | [.id, .name, .updated_at] | @tsv')
 
           echo "Done. deleted=${deleted} kept(protected-children)=${kept}"
+
+  # ---------------------------------------------------------------------------
+  # prune-snapshot-tags-ghcr-main
+  #
+  # Age out immutable trunk snapshots on ghcr.io/$ORG/kronk-main. Every
+  # push→main publishes, per variant, two tags on that repo:
+  #   - main-<sha>-<variant>   immutable per-commit (accumulates forever)
+  #   - main-latest-<variant>  floating pointer to the newest build
+  #
+  # We delete `main-<sha>-<variant>` index manifests older than the
+  # cutoff and NEVER touch `main-latest-<variant>` (a version can carry
+  # both a snapshot tag and main-latest right after a build — if ANY tag
+  # is main-latest we keep the whole version). Removing the snapshot's
+  # index leaves its per-arch children + cosign sigs orphaned;
+  # prune-untagged-ghcr-main and prune-orphan-signatures-ghcr-main
+  # collect those on later runs.
+  # ---------------------------------------------------------------------------
+  prune-snapshot-tags-ghcr-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete main-<sha> snapshot tags older than the cutoff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          CUTOFF_DAYS: ${{ github.event.inputs.cutoff_days || '15' }}
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch=$(date -u -d "${CUTOFF_DAYS} days ago" +%s)
+          echo "Pruning ${MAIN_PACKAGE} snapshot tags updated before $(date -u -d "@${cutoff_epoch}" --iso-8601=seconds) (>${CUTOFF_DAYS}d old)"
+          echo "Dry run: ${DRY_RUN}"
+
+          # Same paginate-first, delete-after pattern as the other GHCR
+          # jobs (see prune-registry-cache for the rationale). 404 on the
+          # first-ever run (package not created yet) → nothing to prune.
+          if ! all="$(gh api --paginate \
+            "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions?per_page=100" \
+            2>/dev/null | jq -s 'add // []')"; then
+            echo "Package versions API returned an error — assuming nothing to prune."
+            exit 0
+          fi
+
+          # Snapshot version = has >=1 tag, EVERY tag is a snapshot tag
+          # (main-<7+ hex>-<variant>), NONE is a main-latest pointer, and
+          # it's older than the cutoff. The all/none tag checks make a
+          # version that still carries main-latest untouchable.
+          stale="$(echo "${all}" | jq -c --argjson cutoff "${cutoff_epoch}" '
+            [ .[] | select(
+                ((.metadata.container.tags // []) | length) > 0
+                and ((.metadata.container.tags // [])
+                     | map(test("^main-latest-")) | any | not)
+                and ((.metadata.container.tags // [])
+                     | map(test("^main-[0-9a-f]{7,}-.+$")) | all)
+                and (.updated_at | fromdateiso8601) < $cutoff
+              ) ]
+          ')"
+
+          deleted=0
+          kept="$(echo "${all}" | jq --argjson stale "${stale}" 'length - ($stale | length)')"
+          while IFS=$'\t' read -r vid updated tags; do
+            [[ -z "${vid}" ]] && continue
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[dry-run] would delete version=${vid} updated=${updated} tags=[${tags}]"
+            else
+              echo "Deleting version=${vid} updated=${updated} tags=[${tags}]"
+              gh api \
+                --method DELETE \
+                "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions/${vid}" \
+                || echo "  (skipped — already gone or last version of package)"
+            fi
+            deleted=$((deleted + 1))
+          done < <(echo "${stale}" | jq -r '.[] | [
+            .id,
+            .updated_at,
+            ((.metadata.container.tags // []) | join(","))
+          ] | @tsv')
+
+          echo "Done. deleted=${deleted} kept(latest-or-within-window)=${kept}"
+
+  # ---------------------------------------------------------------------------
+  # prune-untagged-ghcr-main
+  #
+  # The kronk-main counterpart to prune-untagged-ghcr (see that job for
+  # the full algorithm + rationale). Deletes untagged manifest versions
+  # on ghcr.io/$ORG/kronk-main that are neither tagged nor referenced as
+  # a child by any tagged index. Covers two sources of orphans:
+  #   - per-arch children of snapshots removed by prune-snapshot-tags;
+  #   - by-digest pushes from a main build whose merge_main never ran
+  #     (failed gate → no tags applied → the digest is never referenced).
+  # ---------------------------------------------------------------------------
+  prune-untagged-ghcr-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete unreferenced untagged manifests from GHCR kronk-main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          CUTOFF_DAYS: ${{ github.event.inputs.cutoff_days || '15' }}
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch=$(date -u -d "${CUTOFF_DAYS} days ago" +%s)
+          echo "Scanning ghcr.io/${ORG}/${MAIN_PACKAGE} for unreferenced untagged versions"
+          echo "Cutoff: $(date -u -d "@${cutoff_epoch}" --iso-8601=seconds) (>${CUTOFF_DAYS}d old)"
+          echo "Dry run: ${DRY_RUN}"
+
+          if ! all="$(gh api --paginate \
+            "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions?per_page=100" \
+            2>/dev/null | jq -s 'add // []')"; then
+            echo "Package versions API returned an error — assuming nothing to prune."
+            exit 0
+          fi
+
+          ghcr_token="$(curl -sS -u "${GITHUB_ACTOR}:${GH_TOKEN}" \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:${ORG}/${MAIN_PACKAGE}:pull" \
+            | jq -r .token)"
+          if [[ -z "${ghcr_token}" || "${ghcr_token}" == "null" ]]; then
+            echo "::error::Failed to obtain a GHCR pull token"
+            exit 1
+          fi
+
+          tagged_digests="$(echo "${all}" | jq -r '
+            [ .[] | select(((.metadata.container.tags // []) | length) > 0) | .name ]
+            | unique[]
+          ')"
+
+          protected_file="$(mktemp)"
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+          while IFS= read -r digest; do
+            [[ -z "${digest}" ]] && continue
+            manifest="$(curl -sSL \
+              -H "Authorization: Bearer ${ghcr_token}" \
+              -H "Accept: ${accept}" \
+              "https://ghcr.io/v2/${ORG}/${MAIN_PACKAGE}/manifests/${digest}" \
+              2>/dev/null || echo '{}')"
+            echo "${manifest}" | jq -r '.manifests[]?.digest // empty' >>"${protected_file}"
+          done <<<"${tagged_digests}"
+
+          sort -u "${protected_file}" -o "${protected_file}"
+          protected_count="$(wc -l <"${protected_file}" | tr -d ' ')"
+          echo "Protected child manifests (referenced by tagged indexes): ${protected_count}"
+
+          stale="$(echo "${all}" | jq -c --argjson cutoff "${cutoff_epoch}" '
+            [ .[] | select(
+                ((.metadata.container.tags // []) | length) == 0
+                and (.updated_at | fromdateiso8601) < $cutoff
+              ) ]
+          ')"
+
+          deleted=0
+          kept=0
+          while IFS=$'\t' read -r vid name updated; do
+            [[ -z "${vid}" ]] && continue
+            if grep -qxF "${name}" "${protected_file}"; then
+              kept=$((kept + 1))
+              continue
+            fi
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[dry-run] would delete version=${vid} digest=${name} updated=${updated}"
+            else
+              echo "Deleting version=${vid} digest=${name} updated=${updated}"
+              gh api \
+                --method DELETE \
+                "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions/${vid}" \
+                || echo "  (skipped — already gone or last version of package)"
+            fi
+            deleted=$((deleted + 1))
+          done < <(echo "${stale}" | jq -r '.[] | [.id, .name, .updated_at] | @tsv')
+
+          echo "Done. deleted=${deleted} kept(protected-children)=${kept}"
+
+  # ---------------------------------------------------------------------------
+  # prune-orphan-signatures-ghcr-main
+  #
+  # The kronk-main counterpart to prune-orphan-signatures-ghcr (see that
+  # job for the full algorithm). Deletes `sha256-<hex>.{sig,att,sbom}`
+  # cosign versions on ghcr.io/$ORG/kronk-main whose target digest is no
+  # longer published — e.g. the signature of a snapshot that
+  # prune-snapshot-tags-ghcr-main aged out.
+  # ---------------------------------------------------------------------------
+  prune-orphan-signatures-ghcr-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete orphan cosign signatures from GHCR kronk-main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          echo "Scanning ghcr.io/${ORG}/${MAIN_PACKAGE} for orphan cosign signatures"
+          echo "Dry run: ${DRY_RUN}"
+
+          if ! all="$(gh api --paginate \
+            "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions?per_page=100" \
+            2>/dev/null | jq -s 'add // []')"; then
+            echo "Package versions API returned an error — assuming nothing to prune."
+            exit 0
+          fi
+
+          live_digests="$(echo "${all}" | jq -r '
+            [ .[] | select(
+                (.metadata.container.tags // [])
+                | map(test("^sha256-[a-f0-9]{64}\\.(sig|att|sbom)$"))
+                | any(. == false)
+              ) | .name ]
+            | unique[]
+          ')"
+
+          candidates="$(echo "${all}" | jq -r '
+            .[]
+            | select(
+                ((.metadata.container.tags // []) | length) > 0
+                and ((.metadata.container.tags // [])
+                     | map(test("^sha256-[a-f0-9]{64}\\.(sig|att|sbom)$"))
+                     | all)
+              )
+            | [
+                .id,
+                ((.metadata.container.tags[0] | capture("^sha256-(?<h>[a-f0-9]{64})\\.")).h),
+                ((.metadata.container.tags // []) | join(","))
+              ] | @tsv
+          ')"
+
+          deleted=0
+          kept=0
+          while IFS=$'\t' read -r vid target_hex tags; do
+            [[ -z "${vid}" ]] && continue
+            if grep -qxF "sha256:${target_hex}" <<<"${live_digests}"; then
+              kept=$((kept + 1))
+              continue
+            fi
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[dry-run] would delete version=${vid} target=sha256:${target_hex} tags=[${tags}]"
+            else
+              echo "Deleting version=${vid} target=sha256:${target_hex} tags=[${tags}]"
+              gh api \
+                --method DELETE \
+                "/orgs/${ORG}/packages/container/${MAIN_PACKAGE}/versions/${vid}" \
+                || echo "  (skipped — already gone)"
+            fi
+            deleted=$((deleted + 1))
+          done <<<"${candidates}"
+
+          echo "Done. deleted=${deleted} kept(target-still-live)=${kept}"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -4,7 +4,7 @@ name: Cache cleanup
 # so the repo never bumps into GitHub Actions' 10 GB GHA-cache quota
 # or accumulates dead OCI manifests on GHCR / Docker Hub.
 #
-# Eight scopes get cleaned (one job each, all run in parallel):
+# Ten scopes get cleaned (one job each, all run in parallel):
 #
 #   1. prune-gha-cache — GHA cache (actions/cache + buildx `type=gha`
 #      exports). Anything older than CUTOFF_DAYS is deleted via
@@ -53,6 +53,17 @@ name: Cache cleanup
 #      `sha256-<hex>.{sig,att,sbom}` versions left behind when job 6
 #      removes a snapshot the signature targeted.
 #
+#   9. prune-snapshot-tags-dh-main — Docker Hub counterpart to job 6.
+#      Deletes `main-<sha>-<variant>` tags on `ardanlabs/kronk-main`
+#      older than CUTOFF_DAYS, always keeping `main-latest-<variant>`.
+#      DH auto-collects the now-untagged manifests after 30 days, so
+#      there's no DH equivalent of job 7.
+#
+#  10. prune-orphan-signatures-dh-main — Docker Hub counterpart to job
+#      8 (and to job 4): reaps orphan cosign tags in the sibling
+#      `ardanlabs/kronk-main-signatures` repo whose target digest is no
+#      longer live in `ardanlabs/kronk-main`.
+#
 # NEVER prunes:
 #   - Release tags (`v*-*`, `latest*`) on either registry — those are
 #     product artifacts. Removing them would break users pinning to a
@@ -61,9 +72,10 @@ name: Cache cleanup
 #     and require explicit dry-run for at least two cycles before
 #     turning it live.
 #   - The floating `main-latest-<variant>` snapshot pointers on
-#     `ghcr.io/ardanlabs/kronk-main` — always the newest trunk build,
-#     so consumers pinning to `main-latest-*` never break. Only the
-#     immutable `main-<sha>-<variant>` snapshots age out (job 6).
+#     `ghcr.io/ardanlabs/kronk-main` and `ardanlabs/kronk-main` —
+#     always the newest trunk build, so consumers pinning to
+#     `main-latest-*` never break. Only the immutable
+#     `main-<sha>-<variant>` snapshots age out (jobs 6 and 9).
 #   - GitHub Actions workflow artifacts uploaded by docker.yml — those
 #     already have `retention-days: 1`, so GitHub auto-deletes them
 #     within 24 hours. No code here for them.
@@ -109,6 +121,10 @@ env:
   # docker.yml's COSIGN_REPOSITORY redirect). Not a thing on GHCR
   # (signatures co-located there).
   DH_SIG_REPO: kronk-signatures
+  # Docker Hub sibling repo holding cosign signatures for the
+  # trunk-snapshot images (ardanlabs/kronk-main). Kept in sync with
+  # docker.yml's merge_main DH_MAIN_SIG_REPO.
+  DH_MAIN_SIG_REPO: kronk-main-signatures
   # Kept in sync with docker.yml's BUILDCACHE_IMAGE / GHCR_IMAGE /
   # DH_IMAGE namespace.
   ORG: ardanlabs
@@ -831,3 +847,186 @@ jobs:
           done <<<"${candidates}"
 
           echo "Done. deleted=${deleted} kept(target-still-live)=${kept}"
+
+  # ---------------------------------------------------------------------------
+  # prune-snapshot-tags-dh-main
+  #
+  # Docker Hub counterpart to prune-snapshot-tags-ghcr-main. Age out the
+  # immutable `main-<sha>-<variant>` snapshot tags on ardanlabs/kronk-main
+  # older than the cutoff, always keeping the floating
+  # `main-latest-<variant>` pointers. On DH each tag is its own entity
+  # (deleting the snapshot tag never touches the main-latest tag, even
+  # when both point at the same digest), so — unlike the GHCR version —
+  # there's no all/none tag-set guard to worry about. DH auto-collects
+  # the now-untagged manifests after 30 days, so no untagged sweep here.
+  # ---------------------------------------------------------------------------
+  prune-snapshot-tags-dh-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete main-<sha> snapshot tags from Docker Hub kronk-main
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          CUTOFF_DAYS: ${{ github.event.inputs.cutoff_days || '15' }}
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch=$(date -u -d "${CUTOFF_DAYS} days ago" +%s)
+          echo "Pruning ${ORG}/${MAIN_PACKAGE} snapshot tags pushed before $(date -u -d "@${cutoff_epoch}" --iso-8601=seconds) (>${CUTOFF_DAYS}d old)"
+          echo "Dry run: ${DRY_RUN}"
+
+          jwt="$(curl -sS \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
+            'https://hub.docker.com/v2/users/login/' | jq -r .token)"
+          if [[ -z "${jwt}" || "${jwt}" == "null" ]]; then
+            echo "::error::Docker Hub login failed (empty JWT)"
+            exit 1
+          fi
+
+          fetch_all_tags() {
+            local repo="$1"
+            local url="https://hub.docker.com/v2/repositories/${ORG}/${repo}/tags/?page_size=100"
+            local page acc='[]'
+            while [[ -n "${url}" && "${url}" != "null" ]]; do
+              page="$(curl -sS -H "Authorization: JWT ${jwt}" "${url}")"
+              acc="$(jq -c --argjson p "$(echo "${page}" | jq '.results // []')" \
+                '. + $p' <<<"${acc}")"
+              url="$(echo "${page}" | jq -r '.next // empty')"
+            done
+            echo "${acc}"
+          }
+
+          # Snapshot tags: name matches main-<7+ hex>-<variant>, never a
+          # main-latest pointer, last pushed before the cutoff. Emit
+          # `name\tpushed` per row.
+          all_tags="$(fetch_all_tags "${MAIN_PACKAGE}")"
+          stale="$(echo "${all_tags}" | jq -r --argjson cutoff "${cutoff_epoch}" '
+            .[]
+            | select(
+                (.name | test("^main-latest-") | not)
+                and (.name | test("^main-[0-9a-f]{7,}-.+$"))
+                and (((.tag_last_pushed // .last_updated) // "1970-01-01T00:00:00Z")
+                     | fromdateiso8601) < $cutoff
+              )
+            | [ .name, ((.tag_last_pushed // .last_updated) // "") ] | @tsv
+          ')"
+
+          deleted=0
+          while IFS=$'\t' read -r tag pushed; do
+            [[ -z "${tag}" ]] && continue
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[dry-run] would delete tag=${tag} pushed=${pushed}"
+            else
+              echo "Deleting tag=${tag} pushed=${pushed}"
+              http=$(curl -sS -o /dev/null -w '%{http_code}' \
+                -X DELETE \
+                -H "Authorization: JWT ${jwt}" \
+                "https://hub.docker.com/v2/repositories/${ORG}/${MAIN_PACKAGE}/tags/${tag}/")
+              case "${http}" in
+                204|404) ;;
+                *) echo "  (HTTP ${http} — continuing)" ;;
+              esac
+            fi
+            deleted=$((deleted + 1))
+          done <<<"${stale}"
+
+          echo "Done. deleted=${deleted}"
+
+  # ---------------------------------------------------------------------------
+  # prune-orphan-signatures-dh-main
+  #
+  # Docker Hub counterpart to prune-orphan-signatures-ghcr-main (and a
+  # clone of prune-orphan-signatures-dh pointed at the snapshot repos).
+  # Reaps `sha256-<hex>.{sig,att,sbom}` tags in ardanlabs/kronk-main-
+  # signatures whose target digest is no longer live in
+  # ardanlabs/kronk-main — e.g. the signature of a snapshot that
+  # prune-snapshot-tags-dh-main just aged out.
+  # ---------------------------------------------------------------------------
+  prune-orphan-signatures-dh-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete orphan cosign signatures from Docker Hub kronk-main-signatures
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          echo "Scanning ${ORG}/${DH_MAIN_SIG_REPO} on Docker Hub for orphan cosign signatures"
+          echo "Dry run: ${DRY_RUN}"
+
+          jwt="$(curl -sS \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
+            'https://hub.docker.com/v2/users/login/' | jq -r .token)"
+          if [[ -z "${jwt}" || "${jwt}" == "null" ]]; then
+            echo "::error::Docker Hub login failed (empty JWT)"
+            exit 1
+          fi
+
+          fetch_all_tags() {
+            local repo="$1"
+            local url="https://hub.docker.com/v2/repositories/${ORG}/${repo}/tags/?page_size=100"
+            local page acc='[]'
+            while [[ -n "${url}" && "${url}" != "null" ]]; do
+              page="$(curl -sS -H "Authorization: JWT ${jwt}" "${url}")"
+              acc="$(jq -c --argjson p "$(echo "${page}" | jq '.results // []')" \
+                '. + $p' <<<"${acc}")"
+              url="$(echo "${page}" | jq -r '.next // empty')"
+            done
+            echo "${acc}"
+          }
+
+          release_tags="$(fetch_all_tags "${MAIN_PACKAGE}")"
+          live_digests="$(echo "${release_tags}" | jq -r '
+            [ .[].digest // empty ] | unique[]
+          ')"
+          live_count="$(wc -l <<<"${live_digests}" | tr -d ' ')"
+          echo "Found ${live_count} live digests in ${ORG}/${MAIN_PACKAGE}"
+
+          sig_tags="$(fetch_all_tags "${DH_MAIN_SIG_REPO}")"
+          candidates="$(echo "${sig_tags}" | jq -r '
+            .[]
+            | select(.name | test("^sha256-[a-f0-9]{64}\\.(sig|att|sbom)$"))
+            | [
+                .name,
+                ((.name | capture("^sha256-(?<h>[a-f0-9]{64})\\.")).h),
+                (.tag_last_pushed // .last_updated // "")
+              ] | @tsv
+          ')"
+
+          skipped_non_sig="$(echo "${sig_tags}" | jq '
+            [ .[] | select(.name | test("^sha256-[a-f0-9]{64}\\.(sig|att|sbom)$") | not) ] | length
+          ')"
+          if (( skipped_non_sig > 0 )); then
+            echo "::warning::Found ${skipped_non_sig} non-signature tag(s) in ${ORG}/${DH_MAIN_SIG_REPO} — leaving them alone."
+          fi
+
+          deleted=0
+          kept=0
+          while IFS=$'\t' read -r tag target_hex pushed; do
+            [[ -z "${tag}" ]] && continue
+            if grep -qxF "sha256:${target_hex}" <<<"${live_digests}"; then
+              kept=$((kept + 1))
+              continue
+            fi
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[dry-run] would delete tag=${tag} target=sha256:${target_hex} pushed=${pushed}"
+            else
+              echo "Deleting tag=${tag} target=sha256:${target_hex} pushed=${pushed}"
+              http=$(curl -sS -o /dev/null -w '%{http_code}' \
+                -X DELETE \
+                -H "Authorization: JWT ${jwt}" \
+                "https://hub.docker.com/v2/repositories/${ORG}/${DH_MAIN_SIG_REPO}/tags/${tag}/")
+              case "${http}" in
+                204|404) ;;
+                *) echo "  (HTTP ${http} — continuing)" ;;
+              esac
+            fi
+            deleted=$((deleted + 1))
+          done <<<"${candidates}"
+
+          echo "Done. deleted=${deleted} kept(target-still-live)=${kept} skipped(non-sig)=${skipped_non_sig}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,9 +34,13 @@ name: Docker
 # │                    │ (each added variant builds on all its arches, and   │
 # │                    │ promotes cpu back to its full arch list too).       │
 # ├────────────────────┼─────────────────────────────────────────────────────┤
-# │ push → main        │ Build all variants (no push). Smoke-tests cpu/amd64 │
-# │                    │ and refreshes the registry-backed BuildKit cache so │
-# │                    │ PR builds stay warm. No images are published.       │
+# │ push → main        │ Build all variants, smoke-test cpu/amd64, then      │
+# │                    │ push & cosign-sign to the trunk-snapshot repo       │
+# │                    │   ghcr.io/ardanlabs/kronk-main:main-<sha>-<v>       │
+# │                    │   ghcr.io/ardanlabs/kronk-main:main-latest-<v>      │
+# │                    │ GHCR only (no Docker Hub). Also refreshes the       │
+# │                    │ registry-backed BuildKit cache so PR builds stay    │
+# │                    │ warm.                                               │
 # ├────────────────────┼─────────────────────────────────────────────────────┤
 # │ push → tag v*      │ Build & push all variants as                        │
 # │                    │   <registry>/ardanlabs/kronk:<tag>-<v>              │
@@ -86,6 +90,12 @@ concurrency:
 
 env:
   GHCR_IMAGE: ghcr.io/ardanlabs/kronk
+  # Separate GHCR repo for main-branch builds. Kept apart from the
+  # release repo (GHCR_IMAGE) so trunk snapshots never mix into the
+  # release tag list, and so a floating `main-latest` can move freely
+  # without touching `latest`. Only GHCR is targeted for main builds —
+  # Docker Hub carries release tags only.
+  GHCR_MAIN_IMAGE: ghcr.io/ardanlabs/kronk-main
   DH_IMAGE: ardanlabs/kronk
   # Registry-backed BuildKit cache. Stored as OCI artifacts alongside
   # the runtime images in GHCR — no 10 GB per-repo GHA quota to fight,
@@ -114,6 +124,7 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
       push: ${{ steps.plan.outputs.push }}
       is_tag: ${{ steps.plan.outputs.is_tag }}
+      is_main: ${{ steps.plan.outputs.is_main }}
       version: ${{ steps.plan.outputs.version }}
       variants: ${{ steps.plan.outputs.variants }}
     steps:
@@ -152,22 +163,29 @@ jobs:
           # -------------------------------------------------------------------
           # Version + push policy
           #
-          # Only tag pushes (v*) publish images. Main pushes build every
-          # variant for CI validation (and smoke-test cpu/amd64) but do
-          # NOT push to any registry — there's no main-* tag on GHCR or
-          # Docker Hub. Main builds DO refresh the registry-backed
-          # BuildKit cache; see the "Build (no push)" step's cache-to.
+          # Two events publish images, to two different GHCR repos:
+          #
+          #   * tag push (v*) → release repo (GHCR_IMAGE + Docker Hub),
+          #     cosign-signed. IS_TAG=true.
+          #   * push → main  → trunk-snapshot repo (GHCR_MAIN_IMAGE only),
+          #     cosign-signed, tagged main-<sha> + main-latest.
+          #     IS_MAIN=true.
+          #
+          # Both refresh the registry-backed BuildKit cache. PRs and
+          # workflow_dispatch build only (PUSH=false) and never publish.
           # -------------------------------------------------------------------
           IS_TAG=false
+          IS_MAIN=false
           if [[ "$EVENT" == "push" && "$REF" == refs/tags/v* ]]; then
             VERSION="${REF#refs/tags/}"     # e.g. v1.26.4
             PUSH=true
             IS_TAG=true
           elif [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then
             VERSION="main-${SHA:0:7}"       # e.g. main-abc1234 (stamped
-                                            # into the binary; not used
-                                            # as an image tag)
-            PUSH=false
+                                            # into the binary AND used as
+                                            # the image tag prefix)
+            PUSH=true
+            IS_MAIN=true
           else
             # pull_request or workflow_dispatch — build only, no push.
             VERSION="pr-${SHA:0:7}"
@@ -384,12 +402,13 @@ jobs:
             echo "matrix=$MATRIX"
             echo "push=$PUSH"
             echo "is_tag=$IS_TAG"
+            echo "is_main=$IS_MAIN"
             echo "version=$VERSION"
             echo "variants=$VARIANTS_JSON"
           } >> "$GITHUB_OUTPUT"
 
           echo "::group::Plan"
-          echo "event=$EVENT  ref=$REF  push=$PUSH  is_tag=$IS_TAG  version=$VERSION"
+          echo "event=$EVENT  ref=$REF  push=$PUSH  is_tag=$IS_TAG  is_main=$IS_MAIN  version=$VERSION"
           echo "chosen variants: ${CHOSEN[*]}"
           echo "$MATRIX" | jq .
           echo "::endgroup::"
@@ -447,17 +466,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub carries release tags only — main pushes go to GHCR
+      # (GHCR_MAIN_IMAGE) exclusively, so skip the DH login on main.
       - name: Log in to Docker Hub
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Non-push path: build, no registry push. Used by PRs,
-      # workflow_dispatch, AND main pushes (main no longer publishes
-      # images — see the plan job). Validates the Dockerfile compiles
-      # and produces a runnable image for this arch.
+      # Non-push validation build. Runs on every path that needs the
+      # smoke-test / Trivy gate BEFORE anything is published:
+      #   - PR / workflow_dispatch: every matrix entry (Dockerfile
+      #     compile check for this arch).
+      #   - push → main: ONLY the cpu/amd64 entry, purely to produce
+      #     the loaded `kronk-smoke:latest` image the gate needs. Every
+      #     other main entry is built directly by the push step below;
+      #     the cache makes cpu/amd64's second build there nearly free.
+      # Tag pushes skip this entirely — they build the same layers from
+      # cache in the push step, and the gate already ran on main.
       #
       # The cpu/amd64 build additionally loads the resulting image
       # into the local Docker daemon so the smoke-test step below can
@@ -466,16 +493,16 @@ jobs:
       # cpu is the most-shared Dockerfile path and amd64 is the only
       # arch whose local daemon matches the runner's host arch.
       #
-      # Registry-backed BuildKit cache:
-      #   - PR / workflow_dispatch: READ only, never WRITE — a PR
-      #     could otherwise overwrite the trunk-seeded layers.
-      #   - push → main: READ and WRITE. Refreshing the cache here
-      #     keeps PR builds fast even though main no longer pushes
-      #     runtime images.
-      #   - push → tag v*: cache WRITE happens in the build_ghcr
-      #     step below (which is the push-path step).
+      # This step never WRITES the registry-backed BuildKit cache: on
+      # publish paths (main / tag) the push steps below own the
+      # cache-to; on PR / workflow_dispatch we read only so a PR can't
+      # overwrite the trunk-seeded layers.
       - name: Build (no push)
-        if: needs.plan.outputs.push != 'true'
+        if: >-
+          needs.plan.outputs.push != 'true'
+          || (needs.plan.outputs.is_main == 'true'
+              && matrix.variant == 'cpu'
+              && matrix.arch == 'amd64')
         id: build_nopush
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
@@ -491,10 +518,6 @@ jobs:
             BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
             KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
-          # cache-to: only on main pushes (see the comment block
-          # above). PRs and workflow_dispatch evaluate to '', which
-          # build-push-action treats as "no cache export".
-          cache-to: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && format('type=registry,ref={0}:{1}-{2},mode=max,image-manifest=true,compression=zstd', env.BUILDCACHE_IMAGE, matrix.variant, matrix.arch) || '' }}
 
       # Smoke test: prove the cpu/amd64 image actually starts and the
       # entrypoint resolves the kronk binary. Catches breakage like a
@@ -512,7 +535,7 @@ jobs:
       # is still covered structurally by the build succeeding.
       - name: Smoke test cpu/amd64 image
         if: >-
-          needs.plan.outputs.push != 'true'
+          needs.plan.outputs.is_tag != 'true'
           && matrix.variant == 'cpu'
           && matrix.arch == 'amd64'
         run: |
@@ -531,7 +554,7 @@ jobs:
       # every build with no remediation available, so they're ignored.
       - name: Scan cpu/amd64 image for vulnerabilities (Trivy)
         if: >-
-          needs.plan.outputs.push != 'true'
+          needs.plan.outputs.is_tag != 'true'
           && matrix.variant == 'cpu'
           && matrix.arch == 'amd64'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
@@ -571,7 +594,7 @@ jobs:
       # instead of unknown artifacts. Only the GHCR step writes the
       # cache; the DH step reads from it.
       - name: Build & push by digest to GHCR
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         id: build_ghcr
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
@@ -604,7 +627,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }},mode=max,image-manifest=true,compression=zstd
 
       - name: Build & push by digest to Docker Hub
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         id: build_dh
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
@@ -628,8 +651,37 @@ jobs:
           # just rewrite the same content.
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
 
+      # Main-push path (refs/heads/main): build & push by digest to the
+      # trunk-snapshot repo GHCR_MAIN_IMAGE only (no Docker Hub). The
+      # merge_main job applies the main-<sha> / main-latest tags once
+      # both arches are available. Tag pushes never reach this step;
+      # main pushes never reach the release GHCR/DH steps above.
+      #
+      # This is also the cache WRITE for main builds (mode=max), keeping
+      # PR builds warm — the old main "Build (no push)" cache-to moved
+      # here. Same provenance + SBOM attestations as the release path.
+      - name: Build & push by digest to GHCR (main)
+        if: needs.plan.outputs.is_main == 'true'
+        id: build_ghcr_main
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
+        with:
+          context: .
+          file: zarf/docker/kronk/Dockerfile
+          platforms: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          build-args: |
+            LLAMA_PROCESSORS=${{ matrix.processors }}
+            BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
+            KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
+          outputs: type=image,name=${{ env.GHCR_MAIN_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
+          cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }},mode=max,image-manifest=true,compression=zstd
+
+      # Release-path digest export (tag push): GHCR + Docker Hub.
       - name: Export digests
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         run: |
           # One file per registry, named with the bare hex of the digest
           # so the merge job can reconstruct `<image>@sha256:<digest>`
@@ -640,8 +692,16 @@ jobs:
           touch "/tmp/digests/ghcr/${d_ghcr#sha256:}"
           touch "/tmp/digests/dh/${d_dh#sha256:}"
 
+      # Main-path digest export: GHCR_MAIN_IMAGE only.
+      - name: Export digest (main)
+        if: needs.plan.outputs.is_main == 'true'
+        run: |
+          mkdir -p /tmp/digests/ghcr-main
+          d_main='${{ steps.build_ghcr_main.outputs.digest }}'
+          touch "/tmp/digests/ghcr-main/${d_main#sha256:}"
+
       - name: Upload GHCR digest
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: digests-ghcr-${{ matrix.variant }}-${{ matrix.arch }}
@@ -650,11 +710,20 @@ jobs:
           retention-days: 1
 
       - name: Upload Docker Hub digest
-        if: needs.plan.outputs.push == 'true'
+        if: needs.plan.outputs.is_tag == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: digests-dh-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/dh/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload GHCR main digest
+        if: needs.plan.outputs.is_main == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: digests-ghcr-main-${{ matrix.variant }}-${{ matrix.arch }}
+          path: /tmp/digests/ghcr-main/*
           if-no-files-found: error
           retention-days: 1
 
@@ -671,7 +740,7 @@ jobs:
   # ---------------------------------------------------------------------------
   merge:
     needs: [plan, build]
-    if: needs.plan.outputs.push == 'true'
+    if: needs.plan.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -1023,3 +1092,218 @@ jobs:
         run: |
           docker buildx imagetools inspect "${GHCR_IMAGE}:${VERSION}-${VARIANT}" || true
           docker buildx imagetools inspect "${DH_IMAGE}:${VERSION}-${VARIANT}" || true
+
+  # ---------------------------------------------------------------------------
+  # merge_main
+  #
+  # The main-branch counterpart to `merge`. Runs only on push → main
+  # (`if: is_main == 'true'`). Assembles the multi-arch manifest for each
+  # variant from the per-arch digests uploaded by `build`, applies the
+  # trunk-snapshot tags to GHCR_MAIN_IMAGE only (no Docker Hub), and
+  # cosign-signs the manifest-list digest — full supply-chain parity with
+  # the release path, one registry.
+  #
+  #   push → main → <GHCR_MAIN_IMAGE>:main-<sha>-<variant>   (immutable)
+  #               + <GHCR_MAIN_IMAGE>:main-latest-<variant>  (floating)
+  #
+  # No floating `latest` / `main` alias — main-latest-<variant> is the
+  # only moving pointer, so a consumer must always name a variant.
+  #
+  # ONE-TIME SETUP: the first run creates the GHCR_MAIN_IMAGE package,
+  # which GHCR makes private and unlinked to the repo by default. A
+  # maintainer must set its visibility to public on the package settings
+  # page before external consumers can pull/verify main-latest-*.
+  # Retention of the immutable main-<sha> snapshots is handled by
+  # cache-cleanup.yml (see its prune-*-ghcr-main jobs).
+  # ---------------------------------------------------------------------------
+  merge_main:
+    needs: [plan, build]
+    if: needs.plan.outputs.is_main == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.plan.outputs.variants) }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # cosign keyless signing exchanges this OIDC token for a Fulcio cert
+    steps:
+      # `merge-multiple: true` flattens every matching artifact's file
+      # straight into `path/`. Required for the single-arch rocm variant
+      # (one matching artifact) — see the long note on the release
+      # `merge` job's download step for the download-artifact@v8
+      # single-vs-multi asymmetry this avoids.
+      - name: Download GHCR main digests for this variant
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          path: /tmp/digests/ghcr-main
+          pattern: digests-ghcr-main-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Per-variant title + description for the OCI index annotations
+      # GHCR renders on the package page. Kept in sync with the release
+      # `merge` job's variant_meta step; the main images carry the same
+      # blurbs with a trunk-snapshot note appended.
+      - name: Compute per-variant annotation overrides
+        id: variant_meta
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          case "$VARIANT" in
+            cpu)
+              DESC="Kronk (main-branch snapshot) — Local LLM inference and audio transcription server (OpenAI-compatible API). CPU-only build, runs anywhere (no GPU required)."
+              ;;
+            cuda)
+              DESC="Kronk (main-branch snapshot) — Local LLM inference and audio transcription server (OpenAI-compatible API). NVIDIA CUDA build (requires --gpus all and nvidia-container-toolkit)."
+              ;;
+            vulkan)
+              DESC="Kronk (main-branch snapshot) — Local LLM inference and audio transcription server (OpenAI-compatible API). Vulkan build for AMD / Intel / NVIDIA GPUs (vendor-neutral)."
+              ;;
+            rocm)
+              DESC="Kronk (main-branch snapshot) — Local LLM inference and audio transcription server (OpenAI-compatible API). AMD ROCm build (linux/amd64 only)."
+              ;;
+            all)
+              DESC="Kronk (main-branch snapshot) — Local LLM inference and audio transcription server (OpenAI-compatible API). All backends bundled (cpu, cuda, vulkan, rocm); selects the right one at runtime based on host hardware."
+              ;;
+            *)
+              echo "::error::No description configured for variant '$VARIANT' — add a case branch in .github/workflows/docker.yml" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "title=kronk-main ($VARIANT)"
+            echo "description=$DESC"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Generate OCI annotations
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: ${{ env.GHCR_MAIN_IMAGE }}
+          annotations: |
+            org.opencontainers.image.title=${{ steps.variant_meta.outputs.title }}
+            org.opencontainers.image.description=${{ steps.variant_meta.outputs.description }}
+            org.opencontainers.image.vendor=Ardan Labs
+
+      - name: Create and push manifests
+        id: merge_manifests
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+          VARIANT: ${{ matrix.variant }}
+          ANNOTATIONS_INPUT: ${{ steps.meta.outputs.annotations }}
+        run: |
+          set -euo pipefail
+
+          # metadata-action emits `index:<key>=<value>` lines (because of
+          # DOCKER_METADATA_ANNOTATIONS_LEVELS=index) — turn each into a
+          # repeated --annotation flag for `imagetools create`.
+          ANNOTATION_FLAGS=()
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            ANNOTATION_FLAGS+=(--annotation "$line")
+          done <<<"$ANNOTATIONS_INPUT"
+
+          echo "::group::Annotations"
+          printf '  %s\n' "${ANNOTATION_FLAGS[@]}"
+          echo "::endgroup::"
+
+          # Per-arch digest refs for this variant (flattened layout from
+          # merge-multiple: true above): /tmp/digests/ghcr-main/<hexdigest>
+          collect_refs() {
+            local dir="$1" image="$2"
+            local f d
+            for f in "$dir"/*; do
+              [[ -f "$f" ]] || continue
+              d=$(basename "$f")
+              printf '%s@sha256:%s\n' "$image" "$d"
+            done
+          }
+
+          mapfile -t REFS < <(collect_refs /tmp/digests/ghcr-main "$GHCR_MAIN_IMAGE")
+
+          if (( ${#REFS[@]} == 0 )); then
+            echo "::error::No digests found for variant=${VARIANT}"
+            ls -laR /tmp/digests || true
+            exit 1
+          fi
+
+          # Trunk-snapshot tag set: immutable per-commit + floating.
+          #   main-<sha>-<variant>  (VERSION is already "main-<sha>")
+          #   main-latest-<variant>
+          TAGS=("${VERSION}-${VARIANT}" "main-latest-${VARIANT}")
+
+          echo "::group::Manifest plan"
+          echo "variant=${VARIANT}"
+          echo "tags=${TAGS[*]}"
+          printf '  ref: %s\n' "${REFS[@]}"
+          echo "::endgroup::"
+
+          # Capture the manifest-list digest from the FIRST imagetools
+          # create via --metadata-file. Both tags point at the same
+          # manifest-list blob, so one capture is enough to sign once.
+          META=$(mktemp)
+          first=1
+          for TAG in "${TAGS[@]}"; do
+            EXTRA=()
+            if (( first )); then
+              EXTRA=(--metadata-file "$META")
+              first=0
+            fi
+            echo ">>> ${GHCR_MAIN_IMAGE}:${TAG}"
+            docker buildx imagetools create \
+              "${ANNOTATION_FLAGS[@]}" \
+              "${EXTRA[@]}" \
+              -t "${GHCR_MAIN_IMAGE}:${TAG}" "${REFS[@]}"
+          done
+
+          DIGEST=$(jq -r '."containerimage.descriptor".digest // empty' "$META")
+          [[ "$DIGEST" == sha256:* ]] || {
+            echo "::error::Failed to capture GHCR main digest from $META"
+            cat "$META" || true
+            exit 1
+          }
+
+          echo "sign_ref=${GHCR_MAIN_IMAGE}@${DIGEST}" >>"$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
+
+      # Keyless-sign the manifest-list digest (and each per-arch child
+      # via --recursive). GHCR signatures are co-located with the image,
+      # the default cosign layout. Consumers verify by tag:
+      #
+      #   cosign verify ghcr.io/ardanlabs/kronk-main:main-latest-cpu \
+      #     --certificate-identity-regexp \
+      #       'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Sign published manifest (cosign keyless)
+        env:
+          SIGN_REF: ${{ steps.merge_manifests.outputs.sign_ref }}
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          echo ">>> cosign sign $SIGN_REF"
+          cosign sign --recursive "$SIGN_REF"
+
+      - name: Inspect published images
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          docker buildx imagetools inspect "${GHCR_MAIN_IMAGE}:${VERSION}-${VARIANT}" || true
+          docker buildx imagetools inspect "${GHCR_MAIN_IMAGE}:main-latest-${VARIANT}" || true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,12 +35,12 @@ name: Docker
 # │                    │ promotes cpu back to its full arch list too).       │
 # ├────────────────────┼─────────────────────────────────────────────────────┤
 # │ push → main        │ Build all variants, smoke-test cpu/amd64, then      │
-# │                    │ push & cosign-sign to the trunk-snapshot repo       │
-# │                    │   ghcr.io/ardanlabs/kronk-main:main-<sha>-<v>       │
-# │                    │   ghcr.io/ardanlabs/kronk-main:main-latest-<v>      │
-# │                    │ GHCR only (no Docker Hub). Also refreshes the       │
-# │                    │ registry-backed BuildKit cache so PR builds stay    │
-# │                    │ warm.                                               │
+# │                    │ push & cosign-sign to the trunk-snapshot repos      │
+# │                    │ on BOTH registries:                                 │
+# │                    │   {ghcr.io/ardanlabs,ardanlabs}/kronk-main          │
+# │                    │     :main-<sha>-<v>  +  :main-latest-<v>            │
+# │                    │ Also refreshes the registry-backed BuildKit cache   │
+# │                    │ so PR builds stay warm.                             │
 # ├────────────────────┼─────────────────────────────────────────────────────┤
 # │ push → tag v*      │ Build & push all variants as                        │
 # │                    │   <registry>/ardanlabs/kronk:<tag>-<v>              │
@@ -90,12 +90,13 @@ concurrency:
 
 env:
   GHCR_IMAGE: ghcr.io/ardanlabs/kronk
-  # Separate GHCR repo for main-branch builds. Kept apart from the
-  # release repo (GHCR_IMAGE) so trunk snapshots never mix into the
-  # release tag list, and so a floating `main-latest` can move freely
-  # without touching `latest`. Only GHCR is targeted for main builds —
-  # Docker Hub carries release tags only.
+  # Separate repos for main-branch builds, one per registry. Kept apart
+  # from the release repos (GHCR_IMAGE / DH_IMAGE) so trunk snapshots
+  # never mix into the release tag list, and so a floating `main-latest`
+  # can move freely without touching `latest`. Main builds publish to
+  # BOTH registries, same as releases.
   GHCR_MAIN_IMAGE: ghcr.io/ardanlabs/kronk-main
+  DH_MAIN_IMAGE: ardanlabs/kronk-main
   DH_IMAGE: ardanlabs/kronk
   # Registry-backed BuildKit cache. Stored as OCI artifacts alongside
   # the runtime images in GHCR — no 10 GB per-repo GHA quota to fight,
@@ -163,13 +164,14 @@ jobs:
           # -------------------------------------------------------------------
           # Version + push policy
           #
-          # Two events publish images, to two different GHCR repos:
+          # Two events publish images, each to its own pair of repos
+          # (GHCR + Docker Hub):
           #
-          #   * tag push (v*) → release repo (GHCR_IMAGE + Docker Hub),
+          #   * tag push (v*) → release repos (GHCR_IMAGE + DH_IMAGE),
           #     cosign-signed. IS_TAG=true.
-          #   * push → main  → trunk-snapshot repo (GHCR_MAIN_IMAGE only),
-          #     cosign-signed, tagged main-<sha> + main-latest.
-          #     IS_MAIN=true.
+          #   * push → main  → trunk-snapshot repos (GHCR_MAIN_IMAGE +
+          #     DH_MAIN_IMAGE), cosign-signed, tagged main-<sha> +
+          #     main-latest. IS_MAIN=true.
           #
           # Both refresh the registry-backed BuildKit cache. PRs and
           # workflow_dispatch build only (PUSH=false) and never publish.
@@ -466,10 +468,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Docker Hub carries release tags only — main pushes go to GHCR
-      # (GHCR_MAIN_IMAGE) exclusively, so skip the DH login on main.
+      # Both publish paths (tag → release repos, main → snapshot repos)
+      # push to Docker Hub. PR / workflow_dispatch never publish, so
+      # skip the DH login there to avoid a needless credential use.
       - name: Log in to Docker Hub
-        if: needs.plan.outputs.is_tag == 'true'
+        if: needs.plan.outputs.is_tag == 'true' || needs.plan.outputs.is_main == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -652,14 +655,18 @@ jobs:
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
 
       # Main-push path (refs/heads/main): build & push by digest to the
-      # trunk-snapshot repo GHCR_MAIN_IMAGE only (no Docker Hub). The
-      # merge_main job applies the main-<sha> / main-latest tags once
-      # both arches are available. Tag pushes never reach this step;
+      # trunk-snapshot repos GHCR_MAIN_IMAGE + DH_MAIN_IMAGE, mirroring
+      # the release GHCR/DH split above (separate buildx invocations so
+      # each surfaces its own outputs.digest — see the long note there).
+      # The merge_main job applies the main-<sha> / main-latest tags once
+      # both arches are available. Tag pushes never reach these steps;
       # main pushes never reach the release GHCR/DH steps above.
       #
-      # This is also the cache WRITE for main builds (mode=max), keeping
-      # PR builds warm — the old main "Build (no push)" cache-to moved
-      # here. Same provenance + SBOM attestations as the release path.
+      # The GHCR step is also the cache WRITE for main builds (mode=max),
+      # keeping PR builds warm — the old main "Build (no push)" cache-to
+      # moved here. The DH step reads from that cache (cache-from only),
+      # exactly like the release DH step. Same provenance + SBOM
+      # attestations as the release path.
       - name: Build & push by digest to GHCR (main)
         if: needs.plan.outputs.is_main == 'true'
         id: build_ghcr_main
@@ -679,6 +686,26 @@ jobs:
           cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
           cache-to: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }},mode=max,image-manifest=true,compression=zstd
 
+      - name: Build & push by digest to Docker Hub (main)
+        if: needs.plan.outputs.is_main == 'true'
+        id: build_dh_main
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
+        with:
+          context: .
+          file: zarf/docker/kronk/Dockerfile
+          platforms: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          build-args: |
+            LLAMA_PROCESSORS=${{ matrix.processors }}
+            BUCKY_PROCESSORS=${{ matrix.bucky_processors }}
+            KRONK_VERSION=${{ needs.plan.outputs.version }}-${{ matrix.variant }}
+          outputs: type=image,name=${{ env.DH_MAIN_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
+          # cache-from only: the GHCR (main) step above already populated
+          # the cache for this (variant, arch).
+          cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}:${{ matrix.variant }}-${{ matrix.arch }}
+
       # Release-path digest export (tag push): GHCR + Docker Hub.
       - name: Export digests
         if: needs.plan.outputs.is_tag == 'true'
@@ -692,13 +719,15 @@ jobs:
           touch "/tmp/digests/ghcr/${d_ghcr#sha256:}"
           touch "/tmp/digests/dh/${d_dh#sha256:}"
 
-      # Main-path digest export: GHCR_MAIN_IMAGE only.
+      # Main-path digest export: GHCR_MAIN_IMAGE + DH_MAIN_IMAGE.
       - name: Export digest (main)
         if: needs.plan.outputs.is_main == 'true'
         run: |
-          mkdir -p /tmp/digests/ghcr-main
-          d_main='${{ steps.build_ghcr_main.outputs.digest }}'
-          touch "/tmp/digests/ghcr-main/${d_main#sha256:}"
+          mkdir -p /tmp/digests/ghcr-main /tmp/digests/dh-main
+          d_ghcr_main='${{ steps.build_ghcr_main.outputs.digest }}'
+          d_dh_main='${{ steps.build_dh_main.outputs.digest }}'
+          touch "/tmp/digests/ghcr-main/${d_ghcr_main#sha256:}"
+          touch "/tmp/digests/dh-main/${d_dh_main#sha256:}"
 
       - name: Upload GHCR digest
         if: needs.plan.outputs.is_tag == 'true'
@@ -724,6 +753,15 @@ jobs:
         with:
           name: digests-ghcr-main-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/ghcr-main/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Docker Hub main digest
+        if: needs.plan.outputs.is_main == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: digests-dh-main-${{ matrix.variant }}-${{ matrix.arch }}
+          path: /tmp/digests/dh-main/*
           if-no-files-found: error
           retention-days: 1
 
@@ -1099,22 +1137,26 @@ jobs:
   # The main-branch counterpart to `merge`. Runs only on push → main
   # (`if: is_main == 'true'`). Assembles the multi-arch manifest for each
   # variant from the per-arch digests uploaded by `build`, applies the
-  # trunk-snapshot tags to GHCR_MAIN_IMAGE only (no Docker Hub), and
-  # cosign-signs the manifest-list digest — full supply-chain parity with
-  # the release path, one registry.
+  # trunk-snapshot tags to BOTH snapshot repos (GHCR_MAIN_IMAGE +
+  # DH_MAIN_IMAGE), and cosign-signs each manifest-list digest — full
+  # supply-chain parity with the release path, on both registries.
   #
   #   push → main → <GHCR_MAIN_IMAGE>:main-<sha>-<variant>   (immutable)
   #               + <GHCR_MAIN_IMAGE>:main-latest-<variant>  (floating)
+  #               + <DH_MAIN_IMAGE>:main-<sha>-<variant>     (immutable)
+  #               + <DH_MAIN_IMAGE>:main-latest-<variant>    (floating)
   #
   # No floating `latest` / `main` alias — main-latest-<variant> is the
   # only moving pointer, so a consumer must always name a variant.
   #
-  # ONE-TIME SETUP: the first run creates the GHCR_MAIN_IMAGE package,
-  # which GHCR makes private and unlinked to the repo by default. A
-  # maintainer must set its visibility to public on the package settings
-  # page before external consumers can pull/verify main-latest-*.
+  # ONE-TIME SETUP: the first run creates the GHCR_MAIN_IMAGE package
+  # (GHCR makes it private and unlinked to the repo by default — a
+  # maintainer must set it public on the package settings page) and the
+  # DH_MAIN_IMAGE + kronk-main-signatures repos on Docker Hub (create
+  # them public before the first run, or verification fails). Only then
+  # can external consumers pull/verify main-latest-*.
   # Retention of the immutable main-<sha> snapshots is handled by
-  # cache-cleanup.yml (see its prune-*-ghcr-main jobs).
+  # cache-cleanup.yml (see its prune-*-main jobs).
   # ---------------------------------------------------------------------------
   merge_main:
     needs: [plan, build]
@@ -1142,6 +1184,13 @@ jobs:
           pattern: digests-ghcr-main-${{ matrix.variant }}-*
           merge-multiple: true
 
+      - name: Download Docker Hub main digests for this variant
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          path: /tmp/digests/dh-main
+          pattern: digests-dh-main-${{ matrix.variant }}-*
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 
@@ -1151,6 +1200,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Per-variant title + description for the OCI index annotations
       # GHCR renders on the package page. Kept in sync with the release
@@ -1194,7 +1249,9 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
-          images: ${{ env.GHCR_MAIN_IMAGE }}
+          images: |
+            ${{ env.GHCR_MAIN_IMAGE }}
+            ${{ env.DH_MAIN_IMAGE }}
           annotations: |
             org.opencontainers.image.title=${{ steps.variant_meta.outputs.title }}
             org.opencontainers.image.description=${{ steps.variant_meta.outputs.description }}
@@ -1222,8 +1279,10 @@ jobs:
           printf '  %s\n' "${ANNOTATION_FLAGS[@]}"
           echo "::endgroup::"
 
-          # Per-arch digest refs for this variant (flattened layout from
-          # merge-multiple: true above): /tmp/digests/ghcr-main/<hexdigest>
+          # Per-registry per-arch digest refs for this variant (flattened
+          # layout from merge-multiple: true above):
+          #   /tmp/digests/ghcr-main/<hexdigest>
+          #   /tmp/digests/dh-main/<hexdigest>
           collect_refs() {
             local dir="$1" image="$2"
             local f d
@@ -1234,10 +1293,11 @@ jobs:
             done
           }
 
-          mapfile -t REFS < <(collect_refs /tmp/digests/ghcr-main "$GHCR_MAIN_IMAGE")
+          mapfile -t GHCR_REFS < <(collect_refs /tmp/digests/ghcr-main "$GHCR_MAIN_IMAGE")
+          mapfile -t DH_REFS   < <(collect_refs /tmp/digests/dh-main   "$DH_MAIN_IMAGE")
 
-          if (( ${#REFS[@]} == 0 )); then
-            echo "::error::No digests found for variant=${VARIANT}"
+          if (( ${#GHCR_REFS[@]} == 0 || ${#DH_REFS[@]} == 0 )); then
+            echo "::error::No digests found for variant=${VARIANT} (ghcr=${#GHCR_REFS[@]}, dh=${#DH_REFS[@]})"
             ls -laR /tmp/digests || true
             exit 1
           fi
@@ -1250,55 +1310,104 @@ jobs:
           echo "::group::Manifest plan"
           echo "variant=${VARIANT}"
           echo "tags=${TAGS[*]}"
-          printf '  ref: %s\n' "${REFS[@]}"
+          printf '  GHCR ref: %s\n' "${GHCR_REFS[@]}"
+          printf '  DH   ref: %s\n' "${DH_REFS[@]}"
           echo "::endgroup::"
 
-          # Capture the manifest-list digest from the FIRST imagetools
-          # create via --metadata-file. Both tags point at the same
-          # manifest-list blob, so one capture is enough to sign once.
-          META=$(mktemp)
+          # Capture each registry's manifest-list digest from the FIRST
+          # imagetools create via --metadata-file. Both tags on a registry
+          # point at the same manifest-list blob, so one capture per
+          # registry is enough to sign once.
+          GHCR_META=$(mktemp)
+          DH_META=$(mktemp)
           first=1
           for TAG in "${TAGS[@]}"; do
-            EXTRA=()
+            GHCR_EXTRA=()
+            DH_EXTRA=()
             if (( first )); then
-              EXTRA=(--metadata-file "$META")
+              GHCR_EXTRA=(--metadata-file "$GHCR_META")
+              DH_EXTRA=(--metadata-file "$DH_META")
               first=0
             fi
+
             echo ">>> ${GHCR_MAIN_IMAGE}:${TAG}"
             docker buildx imagetools create \
               "${ANNOTATION_FLAGS[@]}" \
-              "${EXTRA[@]}" \
-              -t "${GHCR_MAIN_IMAGE}:${TAG}" "${REFS[@]}"
+              "${GHCR_EXTRA[@]}" \
+              -t "${GHCR_MAIN_IMAGE}:${TAG}" "${GHCR_REFS[@]}"
+
+            echo ">>> ${DH_MAIN_IMAGE}:${TAG}"
+            docker buildx imagetools create \
+              "${ANNOTATION_FLAGS[@]}" \
+              "${DH_EXTRA[@]}" \
+              -t "${DH_MAIN_IMAGE}:${TAG}" "${DH_REFS[@]}"
           done
 
-          DIGEST=$(jq -r '."containerimage.descriptor".digest // empty' "$META")
-          [[ "$DIGEST" == sha256:* ]] || {
-            echo "::error::Failed to capture GHCR main digest from $META"
-            cat "$META" || true
+          GHCR_DIGEST=$(jq -r '."containerimage.descriptor".digest // empty' "$GHCR_META")
+          DH_DIGEST=$(jq -r '."containerimage.descriptor".digest // empty' "$DH_META")
+          [[ "$GHCR_DIGEST" == sha256:* ]] || {
+            echo "::error::Failed to capture GHCR main digest from $GHCR_META"
+            cat "$GHCR_META" || true
+            exit 1
+          }
+          [[ "$DH_DIGEST" == sha256:* ]] || {
+            echo "::error::Failed to capture Docker Hub main digest from $DH_META"
+            cat "$DH_META" || true
             exit 1
           }
 
-          echo "sign_ref=${GHCR_MAIN_IMAGE}@${DIGEST}" >>"$GITHUB_OUTPUT"
+          SIGN_REFS=(
+            "${GHCR_MAIN_IMAGE}@${GHCR_DIGEST}"
+            "${DH_MAIN_IMAGE}@${DH_DIGEST}"
+          )
+          {
+            echo 'sign_refs<<EOF'
+            printf '%s\n' "${SIGN_REFS[@]}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
 
-      # Keyless-sign the manifest-list digest (and each per-arch child
-      # via --recursive). GHCR signatures are co-located with the image,
-      # the default cosign layout. Consumers verify by tag:
+      # Keyless-sign each registry's manifest-list digest (and each
+      # per-arch child via --recursive). GHCR signatures are co-located
+      # with the image (default cosign layout); Docker Hub signatures are
+      # redirected to a sibling repo (ardanlabs/kronk-main-signatures) via
+      # COSIGN_REPOSITORY so they don't clutter the kronk-main tag list —
+      # exactly as the release path does for kronk-signatures. That repo
+      # must exist and be public for keyless verification. Consumers
+      # verify by tag:
       #
+      #   # GHCR (signatures co-located):
       #   cosign verify ghcr.io/ardanlabs/kronk-main:main-latest-cpu \
       #     --certificate-identity-regexp \
       #       'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
-      - name: Sign published manifest (cosign keyless)
+      #
+      #   # Docker Hub (signatures in sibling repo):
+      #   COSIGN_REPOSITORY=ardanlabs/kronk-main-signatures \
+      #     cosign verify ardanlabs/kronk-main:main-latest-cpu \
+      #       --certificate-identity-regexp \
+      #         'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+      #       --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Sign published manifests (cosign keyless)
         env:
-          SIGN_REF: ${{ steps.merge_manifests.outputs.sign_ref }}
+          SIGN_REFS: ${{ steps.merge_manifests.outputs.sign_refs }}
+          DH_MAIN_IMAGE: ${{ env.DH_MAIN_IMAGE }}
+          DH_MAIN_SIG_REPO: ardanlabs/kronk-main-signatures
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
-          echo ">>> cosign sign $SIGN_REF"
-          cosign sign --recursive "$SIGN_REF"
+          while IFS= read -r ref; do
+            [[ -z "$ref" ]] && continue
+            if [[ "$ref" == "${DH_MAIN_IMAGE}@"* ]]; then
+              echo ">>> cosign sign $ref (COSIGN_REPOSITORY=${DH_MAIN_SIG_REPO})"
+              COSIGN_REPOSITORY="${DH_MAIN_SIG_REPO}" cosign sign --recursive "$ref"
+            else
+              echo ">>> cosign sign $ref"
+              cosign sign --recursive "$ref"
+            fi
+          done <<<"$SIGN_REFS"
 
       - name: Inspect published images
         env:
@@ -1307,3 +1416,5 @@ jobs:
         run: |
           docker buildx imagetools inspect "${GHCR_MAIN_IMAGE}:${VERSION}-${VARIANT}" || true
           docker buildx imagetools inspect "${GHCR_MAIN_IMAGE}:main-latest-${VARIANT}" || true
+          docker buildx imagetools inspect "${DH_MAIN_IMAGE}:${VERSION}-${VARIANT}" || true
+          docker buildx imagetools inspect "${DH_MAIN_IMAGE}:main-latest-${VARIANT}" || true

--- a/.manual/chapter-19-developer-guide.md
+++ b/.manual/chapter-19-developer-guide.md
@@ -1972,7 +1972,7 @@ Five GitHub Actions workflows live under [`.github/workflows/`](../.github/workf
 | ------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`linux.yml`](../.github/workflows/linux.yml)                 | PRs + push to `main` (Go/mod/CI paths)                     | Three parallel jobs: `static` (vet/staticcheck/govulncheck/gofmt/gofix/tidy/goreleaser-check/-race unit tests), `api-tests` (`cmd/server/...`), `sdk-tests` (`sdk/...`).                                                                                                        |
 | [`release.yaml`](../.github/workflows/release.yaml)           | Push of tag `v*`                                           | Pinned-toolchain `goreleaser release --clean`, SBOM generation via syft, SLSA build-provenance attestation, Homebrew cask refresh.                                                                                                                                              |
-| [`docker.yml`](../.github/workflows/docker.yml)               | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds the **five** container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). Only tag pushes (`v*`) publish + cosign-sign; main pushes build all variants for CI validation (and smoke-test cpu/amd64) but do not push to any registry. |
+| [`docker.yml`](../.github/workflows/docker.yml)               | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds the **five** container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). Tag pushes (`v*`) publish + cosign-sign to the release repos (`ghcr.io/ardanlabs/kronk` + Docker Hub); main pushes publish + cosign-sign trunk snapshots to a separate GHCR repo (`ghcr.io/ardanlabs/kronk-main`, `main-<sha>` / `main-latest` tags, GHCR only). Both smoke-test cpu/amd64 before publishing. |
 | [`cache-cleanup.yml`](../.github/workflows/cache-cleanup.yml) | Daily cron + manual                                        | Prunes stale GHA cache entries and stale `kronk-buildcache` GHCR tags older than the cutoff.                                                                                                                                                                                    |
 | [`label-guard.yml`](../.github/workflows/label-guard.yml)     | Label events on PRs/issues                                 | Removes unauthorized `build *` labels (PRs from non-maintainers; any application on an issue).                                                                                                                                                                                  |
 
@@ -2308,6 +2308,45 @@ pushes never reach this job):
        --certificate-oidc-issuer https://token.actions.githubusercontent.com
    ```
 
+**Merge + sign (main).** The `merge_main` job is the main-branch
+counterpart to `merge` (runs only when `is_main == 'true'`). It is the
+same shape — download digests → `imagetools create` → cosign keyless
+sign the manifest-list digest — but targets a **single** registry, the
+trunk-snapshot repo `ghcr.io/ardanlabs/kronk-main`, and never touches
+Docker Hub. Per variant it applies two tags to that repo:
+
+- `main-<sha>-<variant>` — immutable per-commit snapshot (the `<sha>`
+  is the same `main-<sha>` version string stamped into the binary).
+- `main-latest-<variant>` — a floating pointer to the newest main build.
+
+There is no floating `latest` / `main` alias on the snapshot repo, so a
+consumer always names a variant (`ghcr.io/ardanlabs/kronk-main:main-latest-cpu`).
+Signatures are GHCR-co-located (default cosign layout); verify exactly
+as for the release GHCR images but against the `kronk-main` repo:
+
+   ```shell
+   cosign verify ghcr.io/ardanlabs/kronk-main:main-latest-cpu \
+     --certificate-identity-regexp \
+       'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+   ```
+
+> **One-time setup.** The first `push → main` build creates the
+> `kronk-main` GHCR package, which GHCR makes **private** by default and
+> does not link to the repo. Until a maintainer sets its visibility to
+> public (and grants the repo write access) on the package settings
+> page, `docker pull` / `cosign verify` of `main-latest-*` will 401 for
+> anyone but the org. This is a one-time manual step per new package.
+
+> **Retention.** `cache-cleanup.yml` prunes the `kronk-main` repo on its
+> daily cron: immutable `main-<sha>-<variant>` tags age out after
+> `cutoff_days` (default 15), while the floating `main-latest-<variant>`
+> pointers are kept forever. Three cooperating jobs handle it —
+> `prune-snapshot-tags-ghcr-main` removes aged snapshot indexes, then
+> `prune-untagged-ghcr-main` and `prune-orphan-signatures-ghcr-main`
+> reap the per-arch children and cosign signatures those leave behind
+> (the same untagged/orphan sweeps that run for the release repo).
+
 **Event → variants → tags:**
 
 | Event                  | Variants                                             | Push? | Tags applied                                                             |
@@ -2315,7 +2354,7 @@ pushes never reach this job):
 | PR (no labels)         | `cpu` (linux/amd64 only)                             | no    | — (plus a `kronk --version` / `kronk --help` smoke test on cpu/amd64)    |
 | PR + label `build all` | all 5 (all supported arches)                         | no    | —                                                                        |
 | PR + label `build <v>` | `cpu` + each labeled variant (all supported arches)  | no    | —                                                                        |
-| Push to `main`         | all 5                                                | no    | — (smoke-tests cpu/amd64; refreshes the registry-backed BuildKit cache)  |
+| Push to `main`         | all 5                                                | yes   | `main-<sha>-<variant>` + `main-latest-<variant>` on `ghcr.io/ardanlabs/kronk-main` (GHCR only, cosign-signed); smoke-tests cpu/amd64; refreshes the BuildKit cache |
 | Push to tag `v*`       | all 5                                                | yes   | `<tag>-<variant>` + `latest-<variant>`; plus `latest` → cpu (all signed) |
 | `workflow_dispatch`    | input `variants` (default `all`, or comma-separated) | no    | —                                                                        |
 

--- a/.manual/chapter-19-developer-guide.md
+++ b/.manual/chapter-19-developer-guide.md
@@ -1972,7 +1972,7 @@ Five GitHub Actions workflows live under [`.github/workflows/`](../.github/workf
 | ------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`linux.yml`](../.github/workflows/linux.yml)                 | PRs + push to `main` (Go/mod/CI paths)                     | Three parallel jobs: `static` (vet/staticcheck/govulncheck/gofmt/gofix/tidy/goreleaser-check/-race unit tests), `api-tests` (`cmd/server/...`), `sdk-tests` (`sdk/...`).                                                                                                        |
 | [`release.yaml`](../.github/workflows/release.yaml)           | Push of tag `v*`                                           | Pinned-toolchain `goreleaser release --clean`, SBOM generation via syft, SLSA build-provenance attestation, Homebrew cask refresh.                                                                                                                                              |
-| [`docker.yml`](../.github/workflows/docker.yml)               | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds the **five** container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). Tag pushes (`v*`) publish + cosign-sign to the release repos (`ghcr.io/ardanlabs/kronk` + Docker Hub); main pushes publish + cosign-sign trunk snapshots to a separate GHCR repo (`ghcr.io/ardanlabs/kronk-main`, `main-<sha>` / `main-latest` tags, GHCR only). Both smoke-test cpu/amd64 before publishing. |
+| [`docker.yml`](../.github/workflows/docker.yml)               | PRs, push to `main`, push of tag `v*`, `workflow_dispatch` | Builds the **five** container variants defined in [`zarf/docker/kronk/Dockerfile`](../zarf/docker/kronk/Dockerfile). Tag pushes (`v*`) publish + cosign-sign to the release repos (`ghcr.io/ardanlabs/kronk` + Docker Hub); main pushes publish + cosign-sign trunk snapshots to separate repos on both registries (`ghcr.io/ardanlabs/kronk-main` + `ardanlabs/kronk-main`, `main-<sha>` / `main-latest` tags). Both smoke-test cpu/amd64 before publishing. |
 | [`cache-cleanup.yml`](../.github/workflows/cache-cleanup.yml) | Daily cron + manual                                        | Prunes stale GHA cache entries and stale `kronk-buildcache` GHCR tags older than the cutoff.                                                                                                                                                                                    |
 | [`label-guard.yml`](../.github/workflows/label-guard.yml)     | Label events on PRs/issues                                 | Removes unauthorized `build *` labels (PRs from non-maintainers; any application on an issue).                                                                                                                                                                                  |
 
@@ -2311,41 +2311,54 @@ pushes never reach this job):
 **Merge + sign (main).** The `merge_main` job is the main-branch
 counterpart to `merge` (runs only when `is_main == 'true'`). It is the
 same shape — download digests → `imagetools create` → cosign keyless
-sign the manifest-list digest — but targets a **single** registry, the
-trunk-snapshot repo `ghcr.io/ardanlabs/kronk-main`, and never touches
-Docker Hub. Per variant it applies two tags to that repo:
+sign each manifest-list digest — and publishes to **both** registries'
+trunk-snapshot repos, `ghcr.io/ardanlabs/kronk-main` and Docker Hub
+`ardanlabs/kronk-main`. Per variant it applies two tags to each repo:
 
 - `main-<sha>-<variant>` — immutable per-commit snapshot (the `<sha>`
   is the same `main-<sha>` version string stamped into the binary).
 - `main-latest-<variant>` — a floating pointer to the newest main build.
 
-There is no floating `latest` / `main` alias on the snapshot repo, so a
-consumer always names a variant (`ghcr.io/ardanlabs/kronk-main:main-latest-cpu`).
-Signatures are GHCR-co-located (default cosign layout); verify exactly
-as for the release GHCR images but against the `kronk-main` repo:
+There is no floating `latest` / `main` alias on the snapshot repos, so a
+consumer always names a variant (`.../kronk-main:main-latest-cpu`). GHCR
+signatures are co-located (default cosign layout); Docker Hub signatures
+are redirected to the sibling `ardanlabs/kronk-main-signatures` repo via
+`COSIGN_REPOSITORY` (mirroring how the release path uses
+`kronk-signatures`). Verify:
 
    ```shell
+   # GHCR (signatures co-located):
    cosign verify ghcr.io/ardanlabs/kronk-main:main-latest-cpu \
      --certificate-identity-regexp \
        'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+   # Docker Hub (signatures in sibling repo):
+   COSIGN_REPOSITORY=ardanlabs/kronk-main-signatures \
+     cosign verify ardanlabs/kronk-main:main-latest-cpu \
+       --certificate-identity-regexp \
+         'https://github.com/ardanlabs/kronk/.github/workflows/docker.yml@.*' \
+       --certificate-oidc-issuer https://token.actions.githubusercontent.com
    ```
 
 > **One-time setup.** The first `push → main` build creates the
 > `kronk-main` GHCR package, which GHCR makes **private** by default and
-> does not link to the repo. Until a maintainer sets its visibility to
-> public (and grants the repo write access) on the package settings
-> page, `docker pull` / `cosign verify` of `main-latest-*` will 401 for
-> anyone but the org. This is a one-time manual step per new package.
+> does not link to the repo — a maintainer must set its visibility to
+> public (and grant the repo write access) on the package settings page.
+> On Docker Hub, create the `ardanlabs/kronk-main` and
+> `ardanlabs/kronk-main-signatures` repos as **public** before the first
+> main build. Until both are done, `docker pull` / `cosign verify` of
+> `main-latest-*` will fail for anyone outside the org.
 
-> **Retention.** `cache-cleanup.yml` prunes the `kronk-main` repo on its
+> **Retention.** `cache-cleanup.yml` prunes both snapshot repos on its
 > daily cron: immutable `main-<sha>-<variant>` tags age out after
 > `cutoff_days` (default 15), while the floating `main-latest-<variant>`
-> pointers are kept forever. Three cooperating jobs handle it —
-> `prune-snapshot-tags-ghcr-main` removes aged snapshot indexes, then
-> `prune-untagged-ghcr-main` and `prune-orphan-signatures-ghcr-main`
-> reap the per-arch children and cosign signatures those leave behind
-> (the same untagged/orphan sweeps that run for the release repo).
+> pointers are kept forever. Five cooperating jobs handle it —
+> `prune-snapshot-tags-ghcr-main` + `prune-snapshot-tags-dh-main` remove
+> aged snapshots, then `prune-untagged-ghcr-main` (GHCR only; DH
+> auto-collects untagged manifests) and
+> `prune-orphan-signatures-{ghcr,dh}-main` reap the per-arch children
+> and cosign signatures those leave behind.
 
 **Event → variants → tags:**
 
@@ -2354,7 +2367,7 @@ as for the release GHCR images but against the `kronk-main` repo:
 | PR (no labels)         | `cpu` (linux/amd64 only)                             | no    | — (plus a `kronk --version` / `kronk --help` smoke test on cpu/amd64)    |
 | PR + label `build all` | all 5 (all supported arches)                         | no    | —                                                                        |
 | PR + label `build <v>` | `cpu` + each labeled variant (all supported arches)  | no    | —                                                                        |
-| Push to `main`         | all 5                                                | yes   | `main-<sha>-<variant>` + `main-latest-<variant>` on `ghcr.io/ardanlabs/kronk-main` (GHCR only, cosign-signed); smoke-tests cpu/amd64; refreshes the BuildKit cache |
+| Push to `main`         | all 5                                                | yes   | `main-<sha>-<variant>` + `main-latest-<variant>` on `ghcr.io/ardanlabs/kronk-main` **and** `ardanlabs/kronk-main` (both cosign-signed); smoke-tests cpu/amd64; refreshes the BuildKit cache |
 | Push to tag `v*`       | all 5                                                | yes   | `<tag>-<variant>` + `latest-<variant>`; plus `latest` → cpu (all signed) |
 | `workflow_dispatch`    | input `variants` (default `all`, or comma-separated) | no    | —                                                                        |
 

--- a/DockerHub.md
+++ b/DockerHub.md
@@ -61,6 +61,13 @@ Models download automatically on first use.
   [Dockerfile](https://github.com/ardanlabs/kronk/blob/main/zarf/docker/kronk/Dockerfile),
   not as part of the automatic build matrix. See the run example below.
 
+**Development snapshots** (bleeding edge, not for production) are published
+from every push to `main` in a separate repo,
+[`ardanlabs/kronk-main`](https://hub.docker.com/r/ardanlabs/kronk-main), as
+`main-<sha>-<variant>` (immutable per-commit) and `main-latest-<variant>`
+(floating). They are cosign-signed the same way as releases, with signatures
+in [`ardanlabs/kronk-main-signatures`](https://hub.docker.com/r/ardanlabs/kronk-main-signatures).
+
 ---
 
 ## Platform Support


### PR DESCRIPTION
## Summary

Turns `push → main` from build-only into a publish path. Every variant is built, smoke-tested, and pushed by-digest to a **separate** trunk-snapshot GHCR repo (`ghcr.io/ardanlabs/kronk-main`), then a new `merge_main` job assembles the multi-arch manifests, applies `main-<sha>-<variant>` (immutable) + `main-latest-<variant>` (floating) tags, and cosign-signs — full supply-chain parity with the release path. GHCR only; Docker Hub continues to carry release tags exclusively. The release path is unchanged (gating refactored from `push`→`is_tag`/`is_main`).

## Retention (`cache-cleanup.yml`)

So the new repo doesn't grow unbounded, three cooperating daily-cron jobs were added:

- **`prune-snapshot-tags-ghcr-main`** — ages out immutable `main-<sha>-<variant>` tags past the cutoff (default 15d) while *always* preserving the floating `main-latest-<variant>` pointers.
- **`prune-untagged-ghcr-main`** — reaps orphaned per-arch children left by snapshot deletion, plus any by-digest pushes from a main build whose `merge_main` never ran (e.g. a failed gate → no tags applied).
- **`prune-orphan-signatures-ghcr-main`** — reaps the `sha256-<hex>.{sig,att,sbom}` cosign versions those leave behind.

## Docs

- Document the trunk-snapshot tags, verification, and retention behavior.
- Flag the **one-time** manual step: GHCR makes a new package private by default, so a maintainer must set `kronk-main` visibility to public after the first main build before external consumers can pull/verify.

## Verification

- Both workflows validated as YAML.
- The snapshot-tag selection `jq` filter was unit-tested against sample data: it deletes only aged `main-<sha>` versions and correctly keeps any version carrying a `main-latest` tag, recent snapshots, and untagged versions.