### PR TITLE
Fix/batch engine shutdown submit race

### DIFF
--- a/sdk/kronk/model/batch_engine.go
+++ b/sdk/kronk/model/batch_engine.go
@@ -22,6 +22,11 @@ type batchEngine struct {
 	wg         sync.WaitGroup
 	stopped    atomic.Bool
 
+	// submitMu is held for read across an in-flight submit and taken for
+	// write by stop, so stop can wait for every in-flight submit to leave
+	// before it treats requestQ as frozen. See submit and stop.
+	submitMu sync.RWMutex
+
 	// pendingJobs holds jobs that were dequeued from requestQ but couldn't
 	// be assigned to a slot yet (e.g., all slots busy, media slot occupied).
 	// Checked before reading requestQ in fillSlots.
@@ -89,13 +94,42 @@ func (e *batchEngine) start(ctx context.Context) {
 
 // stop signals shutdown and waits for completion.
 func (e *batchEngine) stop(ctx context.Context) {
+	// Only the CAS winner owns draining and cleanup; a loser just waits for
+	// processLoop to exit. This is safe because stop is never called
+	// concurrently with itself (Model.Unload calls it once; the load-path
+	// error branches call it sequentially in one goroutine) — a loser is a
+	// repeat call, not a racing one, so the winner has already frozen the
+	// queue by the time the loser returns.
 	if !e.stopped.CompareAndSwap(false, true) {
 		e.wg.Wait() // Still wait for processLoop to exit
 		return
 	}
 
+	// stopped is already true and shutdownCh closes before the write lock
+	// is taken, so a submit parked in its select is released by the
+	// shutdownCh arm and drops its read lock rather than deadlocking
+	// against the Lock below.
 	close(e.shutdownCh)
+
+	// Wait out every in-flight submit and keep later submits blocked until
+	// requestQ has been drained. Every later submit observes stopped after
+	// the lock is released, so nothing further can be enqueued.
+	e.submitMu.Lock()
+
 	e.wg.Wait()
+
+	// processLoop drains requestQ before it exits, but a submit that had
+	// already passed the stopped check could have enqueued after that
+	// drain and before the queue froze. No reader remains, so those jobs
+	// are this goroutine's to fail. A nonzero count here is the only signal
+	// that the concurrent-submit window actually fired on live traffic, so
+	// log it even though it is usually zero.
+	drained := e.drainQueue(fmt.Errorf("stop: engine shutting down"))
+	e.submitMu.Unlock()
+
+	if drained > 0 {
+		e.model.log(ctx, "batch-engine", "status", "stop-drained-straggler", "drained", drained)
+	}
 
 	// Free samplers - batch is freed separately in Unload.
 	for _, s := range e.slots {
@@ -120,7 +154,38 @@ func (e *batchEngine) freeBatch() {
 }
 
 // submit adds a job to the processing queue.
+//
+// A nil return means the engine has taken ownership of the job and will
+// complete it (finishSlot or failJob, either of which closes job.ch and
+// decrements activeStreams). ChatStreaming relies on that: its
+// batching=true path returns without closing ch and without decrementing
+// activeStreams. A job accepted but never completed would therefore hang
+// its caller on ch forever and pin activeStreams above zero, which makes
+// Model.Unload fail with "cannot unload N active streams".
+//
+// Honouring that contract takes more than selecting on shutdownCh. Once
+// shutdownCh is closed, a bare select has both `requestQ <- job` (the
+// buffer has room) and `<-shutdownCh` ready at once, and Go picks a ready
+// case uniformly at random — so roughly half of all post-shutdown submits
+// would enqueue onto a queue processLoop will never read again. Checking
+// stopped first removes that coin flip, and holding submitMu for read
+// lets stop wait out the submits that already passed the check.
+//
+// The read lock is deliberately held across the blocking `requestQ <- job`
+// send below, not just around the stopped check. That is what lets stop's
+// write lock prove no send is in flight before it drains. The send can block
+// (the buffer is nSlots*2), but only ever until processLoop drains it or
+// shutdownCh closes, so a reader never pins the lock indefinitely and stop's
+// close(shutdownCh) always releases a parked submit before it takes the write
+// lock. Narrowing this hold to the check alone would reopen the window.
 func (e *batchEngine) submit(job *chatJob) error {
+	e.submitMu.RLock()
+	defer e.submitMu.RUnlock()
+
+	if e.stopped.Load() {
+		return fmt.Errorf("submit: engine shutting down")
+	}
+
 	select {
 	case e.requestQ <- job:
 		select {

--- a/sdk/kronk/model/batch_engine_shutdown_test.go
+++ b/sdk/kronk/model/batch_engine_shutdown_test.go
@@ -1,0 +1,215 @@
+package model
+
+// These tests pin the ownership contract of batchEngine.submit:
+//
+//	A nil return from submit means the batch engine has taken ownership of
+//	the job and WILL complete it (finishSlot or failJob, either of which
+//	closes job.ch and decrements activeStreams).
+//
+// The contract matters because ChatStreaming's batching=true path returns
+// without closing ch and without decrementing activeStreams (chat.go) —
+// it hands both responsibilities to the engine. A job the engine accepts
+// but never completes therefore hangs the caller forever on ch AND pins
+// activeStreams above zero, which makes Model.Unload fail with
+// "cannot unload N active streams" and wedges the pool entry.
+//
+// At the model layer stop() and submit() can run concurrently: Model.Unload
+// calls batch.stop() before its own activeStreams drain. End to end, though,
+// production reaches submit only through Kronk.acquireModel, which holds the
+// shutdown lock while it gates on shutdownFlag and increments the SDK-level
+// activeStreams, and Kronk.Unload drains those streams under that same lock
+// before it ever calls model.Unload — so the concurrent window is closed one
+// layer up today. These tests pin the batch engine's OWN invariant so it
+// stops silently depending on that caller: stop must freeze requestQ and
+// complete every job it finds, whether or not an upstream lock also guards
+// the door.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/ardanlabs/kronk/sdk/kronk/applog"
+)
+
+// newTestEngine builds a batchEngine with only the channels populated.
+// submit and the shutdown synchronization touch no other field, so no
+// llama context or Model is needed.
+func newTestEngine(qcap int) *batchEngine {
+	return &batchEngine{
+		requestQ:   make(chan *chatJob, qcap),
+		wakeCh:     make(chan struct{}, 1),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+// newTestEngineWithModel is newTestEngine plus a minimal Model, needed by any
+// test that drives drainQueue/failJob (they log, touch metrics, and decrement
+// activeStreams). A discard logger and the zero-value ModelInfo are enough;
+// metrics keyed by an empty model ID are harmless in a unit test.
+func newTestEngineWithModel(qcap int) *batchEngine {
+	e := newTestEngine(qcap)
+	e.model = &Model{log: applog.DiscardLogger}
+	return e
+}
+
+// TestSubmitRejectsAfterShutdown is the deterministic form of the defect.
+//
+// It puts the engine in the state stop() leaves behind — stopped set,
+// shutdownCh closed, processLoop gone — and requires submit to reject
+// every job, because nothing will ever read requestQ again.
+//
+// Selecting on shutdownCh alone is not enough to get this right: with the
+// buffer non-full, `requestQ <- job` and a closed `<-shutdownCh` are both
+// ready, and Go picks a ready case uniformly at random. Without the
+// stopped check this fails on roughly half of the attempts.
+func TestSubmitRejectsAfterShutdown(t *testing.T) {
+	const attempts = 200
+
+	e := newTestEngine(attempts)
+
+	// Exactly what stop() establishes, in stop()'s order.
+	e.stopped.Store(true)
+	close(e.shutdownCh)
+
+	accepted := 0
+	for range attempts {
+		job := &chatJob{ctx: context.Background()}
+		if err := e.submit(job); err == nil {
+			accepted++
+		}
+	}
+
+	if accepted != 0 {
+		t.Fatalf("submit accepted %d/%d jobs after shutdown; each is a job the "+
+			"engine will never complete, so the caller blocks forever on job.ch "+
+			"and activeStreams never reaches zero (Model.Unload then fails)",
+			accepted, attempts)
+	}
+}
+
+// TestSubmitStopRaceFreezesQueue reproduces the production interleaving:
+// Model.Unload calls batch.stop() while an in-flight ChatStreaming
+// goroutine is calling submit.
+//
+// It follows stop()'s sequence — set stopped, close shutdownCh, lock out
+// submits, then drain — and asserts the property that sequence exists to
+// provide: once the drain under the write lock has run, requestQ
+// is frozen, so no job can arrive afterwards with no reader left to
+// complete it.
+func TestSubmitStopRaceFreezesQueue(t *testing.T) {
+	const trials = 2000
+
+	stranded := 0
+	acceptedButNotQueued := 0
+
+	for range trials {
+		e := newTestEngine(4)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		var accepted bool
+		go func() {
+			defer wg.Done()
+			job := &chatJob{ctx: context.Background()}
+			accepted = e.submit(job) == nil
+		}()
+
+		// stop(): signal shutdown, lock out submits, then drain. Draining by
+		// hand rather than via drainQueue, whose failJob needs a Model; the
+		// ordering under test is the same, and TestDrainQueueCompletesJobs
+		// covers the failJob completion half separately.
+		e.stopped.Store(true)
+		close(e.shutdownCh)
+		e.submitMu.Lock()
+
+		drained := 0
+		for draining := true; draining; {
+			select {
+			case <-e.requestQ:
+				drained++
+			default:
+				draining = false
+			}
+		}
+		e.submitMu.Unlock()
+
+		wg.Wait()
+
+		// The queue is frozen and the drain is over. Anything that shows
+		// up now was accepted by submit but has no reader left.
+		if len(e.requestQ) > 0 {
+			stranded++
+		}
+
+		// An accepted job must have been in the queue for the drain to
+		// find, since failJob is what closes ch and releases the caller.
+		if accepted && drained == 0 {
+			acceptedButNotQueued++
+		}
+	}
+
+	if stranded > 0 || acceptedButNotQueued > 0 {
+		t.Fatalf("queue not frozen by stop's sequence: %d/%d trials enqueued a job "+
+			"after the locked drain, %d/%d reported success without the job "+
+			"reaching the drain. Either way submit returned nil (caller set "+
+			"batching=true and returned without closing ch) for a job nothing will "+
+			"complete, so the request hangs and Model.Unload cannot drain "+
+			"activeStreams", stranded, trials, acceptedButNotQueued, trials)
+	}
+}
+
+// TestDrainQueueCompletesJobs pins the completion half of the ownership
+// contract: for every job drainQueue takes off requestQ it must close job.ch
+// and decrement activeStreams. That is the exact mechanism that releases a
+// caller blocked on ch and lets Model.Unload's drain loop reach zero — freezing
+// the queue (the other two tests) is only useful if the frozen-out jobs are
+// then actually completed.
+func TestDrainQueueCompletesJobs(t *testing.T) {
+	const jobs = 8
+
+	e := newTestEngineWithModel(jobs)
+
+	// One activeStream per in-flight job, as ChatStreaming establishes before
+	// handing the job to the engine.
+	e.model.activeStreams.Store(int32(jobs))
+
+	// Each job carries a buffered response channel so failJob's error send
+	// completes without a reader, mirroring the buffered channel ChatStreaming
+	// hands over.
+	chans := make([]chan ChatResponse, jobs)
+	for i := range chans {
+		ch := make(chan ChatResponse, 1)
+		chans[i] = ch
+		e.requestQ <- &chatJob{
+			id:     "test-job",
+			ctx:    context.Background(),
+			ch:     ch,
+			object: ObjectChatText,
+		}
+	}
+
+	drained := e.drainQueue(fmt.Errorf("drain-test: engine shutting down"))
+
+	if drained != jobs {
+		t.Fatalf("drainQueue drained %d jobs, want %d", drained, jobs)
+	}
+
+	if got := e.model.activeStreams.Load(); got != 0 {
+		t.Fatalf("activeStreams = %d after draining %d jobs, want 0; a caller whose "+
+			"stream is never decremented pins the count above zero and Model.Unload "+
+			"cannot drain it", got, jobs)
+	}
+
+	// Every channel must be closed. A closed channel yields ok=false once its
+	// buffered value is consumed; a channel left open would block here, so the
+	// receive-with-ok both proves closure and can't hang the test.
+	for i, ch := range chans {
+		<-ch // the buffered error response failJob sent
+		if _, ok := <-ch; ok {
+			t.Fatalf("job %d channel not closed by failJob; the caller blocks on it forever", i)
+		}
+	}
+}

--- a/sdk/kronk/model/batch_engine_shutdown_test.go
+++ b/sdk/kronk/model/batch_engine_shutdown_test.go
@@ -1,41 +1,14 @@
 package model
 
-// These tests pin the ownership contract of batchEngine.submit:
-//
-//	A nil return from submit means the batch engine has taken ownership of
-//	the job and WILL complete it (finishSlot or failJob, either of which
-//	closes job.ch and decrements activeStreams).
-//
-// The contract matters because ChatStreaming's batching=true path returns
-// without closing ch and without decrementing activeStreams (chat.go) —
-// it hands both responsibilities to the engine. A job the engine accepts
-// but never completes therefore hangs the caller forever on ch AND pins
-// activeStreams above zero, which makes Model.Unload fail with
-// "cannot unload N active streams" and wedges the pool entry.
-//
-// At the model layer stop() and submit() can run concurrently: Model.Unload
-// calls batch.stop() before its own activeStreams drain. End to end, though,
-// production reaches submit only through Kronk.acquireModel, which holds the
-// shutdown lock while it gates on shutdownFlag and increments the SDK-level
-// activeStreams, and Kronk.Unload drains those streams under that same lock
-// before it ever calls model.Unload — so the concurrent window is closed one
-// layer up today. These tests pin the batch engine's OWN invariant so it
-// stops silently depending on that caller: stop must freeze requestQ and
-// complete every job it finds, whether or not an upstream lock also guards
-// the door.
-
 import (
 	"context"
 	"fmt"
 	"sync"
 	"testing"
-
-	"github.com/ardanlabs/kronk/sdk/kronk/applog"
 )
 
-// newTestEngine builds a batchEngine with only the channels populated.
-// submit and the shutdown synchronization touch no other field, so no
-// llama context or Model is needed.
+// newTestEngine builds a batchEngine with only the channels populated; submit
+// and the shutdown synchronization touch no other field.
 func newTestEngine(qcap int) *batchEngine {
 	return &batchEngine{
 		requestQ:   make(chan *chatJob, qcap),
@@ -44,60 +17,38 @@ func newTestEngine(qcap int) *batchEngine {
 	}
 }
 
-// newTestEngineWithModel is newTestEngine plus a minimal Model, needed by any
-// test that drives drainQueue/failJob (they log, touch metrics, and decrement
-// activeStreams). A discard logger and the zero-value ModelInfo are enough;
-// metrics keyed by an empty model ID are harmless in a unit test.
+// newTestEngineWithModel adds a minimal Model, needed by tests that drive
+// drainQueue/failJob (they log and decrement activeStreams).
 func newTestEngineWithModel(qcap int) *batchEngine {
 	e := newTestEngine(qcap)
-	e.model = &Model{log: applog.DiscardLogger}
+	e.model = &Model{log: noopLog}
 	return e
 }
 
-// TestSubmitRejectsAfterShutdown is the deterministic form of the defect.
-//
-// It puts the engine in the state stop() leaves behind — stopped set,
-// shutdownCh closed, processLoop gone — and requires submit to reject
-// every job, because nothing will ever read requestQ again.
-//
-// Selecting on shutdownCh alone is not enough to get this right: with the
-// buffer non-full, `requestQ <- job` and a closed `<-shutdownCh` are both
-// ready, and Go picks a ready case uniformly at random. Without the
-// stopped check this fails on roughly half of the attempts.
+// TestSubmitRejectsAfterShutdown verifies submit rejects every job once stop
+// has set stopped and closed shutdownCh, since nothing reads requestQ again.
 func TestSubmitRejectsAfterShutdown(t *testing.T) {
 	const attempts = 200
 
 	e := newTestEngine(attempts)
-
-	// Exactly what stop() establishes, in stop()'s order.
 	e.stopped.Store(true)
 	close(e.shutdownCh)
 
 	accepted := 0
 	for range attempts {
-		job := &chatJob{ctx: context.Background()}
-		if err := e.submit(job); err == nil {
+		if err := e.submit(&chatJob{ctx: context.Background()}); err == nil {
 			accepted++
 		}
 	}
 
 	if accepted != 0 {
-		t.Fatalf("submit accepted %d/%d jobs after shutdown; each is a job the "+
-			"engine will never complete, so the caller blocks forever on job.ch "+
-			"and activeStreams never reaches zero (Model.Unload then fails)",
-			accepted, attempts)
+		t.Errorf("submit accepted = %d, want 0 (jobs the engine will never complete)", accepted)
 	}
 }
 
-// TestSubmitStopRaceFreezesQueue reproduces the production interleaving:
-// Model.Unload calls batch.stop() while an in-flight ChatStreaming
-// goroutine is calling submit.
-//
-// It follows stop()'s sequence — set stopped, close shutdownCh, lock out
-// submits, then drain — and asserts the property that sequence exists to
-// provide: once the drain under the write lock has run, requestQ
-// is frozen, so no job can arrive afterwards with no reader left to
-// complete it.
+// TestSubmitStopRaceFreezesQueue verifies that a submit racing stop cannot
+// leave a job on requestQ after stop's locked drain, since no reader remains
+// to complete it.
 func TestSubmitStopRaceFreezesQueue(t *testing.T) {
 	const trials = 2000
 
@@ -113,14 +64,11 @@ func TestSubmitStopRaceFreezesQueue(t *testing.T) {
 		var accepted bool
 		go func() {
 			defer wg.Done()
-			job := &chatJob{ctx: context.Background()}
-			accepted = e.submit(job) == nil
+			accepted = e.submit(&chatJob{ctx: context.Background()}) == nil
 		}()
 
-		// stop(): signal shutdown, lock out submits, then drain. Draining by
-		// hand rather than via drainQueue, whose failJob needs a Model; the
-		// ordering under test is the same, and TestDrainQueueCompletesJobs
-		// covers the failJob completion half separately.
+		// stop(): signal shutdown, lock out submits, then drain by hand
+		// (drainQueue's failJob needs a Model; the ordering is the same).
 		e.stopped.Store(true)
 		close(e.shutdownCh)
 		e.submitMu.Lock()
@@ -138,78 +86,50 @@ func TestSubmitStopRaceFreezesQueue(t *testing.T) {
 
 		wg.Wait()
 
-		// The queue is frozen and the drain is over. Anything that shows
-		// up now was accepted by submit but has no reader left.
 		if len(e.requestQ) > 0 {
 			stranded++
 		}
-
-		// An accepted job must have been in the queue for the drain to
-		// find, since failJob is what closes ch and releases the caller.
 		if accepted && drained == 0 {
 			acceptedButNotQueued++
 		}
 	}
 
-	if stranded > 0 || acceptedButNotQueued > 0 {
-		t.Fatalf("queue not frozen by stop's sequence: %d/%d trials enqueued a job "+
-			"after the locked drain, %d/%d reported success without the job "+
-			"reaching the drain. Either way submit returned nil (caller set "+
-			"batching=true and returned without closing ch) for a job nothing will "+
-			"complete, so the request hangs and Model.Unload cannot drain "+
-			"activeStreams", stranded, trials, acceptedButNotQueued, trials)
+	if stranded != 0 {
+		t.Errorf("jobs stranded on requestQ = %d, want 0", stranded)
+	}
+	if acceptedButNotQueued != 0 {
+		t.Errorf("submits accepted but not queued = %d, want 0", acceptedButNotQueued)
 	}
 }
 
-// TestDrainQueueCompletesJobs pins the completion half of the ownership
-// contract: for every job drainQueue takes off requestQ it must close job.ch
-// and decrement activeStreams. That is the exact mechanism that releases a
-// caller blocked on ch and lets Model.Unload's drain loop reach zero — freezing
-// the queue (the other two tests) is only useful if the frozen-out jobs are
-// then actually completed.
+// TestDrainQueueCompletesJobs verifies drainQueue completes every job it takes
+// off requestQ: closing job.ch and decrementing activeStreams, the mechanism
+// that releases a blocked caller and lets Model.Unload's drain reach zero.
 func TestDrainQueueCompletesJobs(t *testing.T) {
 	const jobs = 8
 
 	e := newTestEngineWithModel(jobs)
+	e.model.activeStreams.Store(jobs)
 
-	// One activeStream per in-flight job, as ChatStreaming establishes before
-	// handing the job to the engine.
-	e.model.activeStreams.Store(int32(jobs))
-
-	// Each job carries a buffered response channel so failJob's error send
-	// completes without a reader, mirroring the buffered channel ChatStreaming
-	// hands over.
+	// Buffered channels so failJob's error send completes without a reader.
 	chans := make([]chan ChatResponse, jobs)
 	for i := range chans {
-		ch := make(chan ChatResponse, 1)
-		chans[i] = ch
-		e.requestQ <- &chatJob{
-			id:     "test-job",
-			ctx:    context.Background(),
-			ch:     ch,
-			object: ObjectChatText,
-		}
+		chans[i] = make(chan ChatResponse, 1)
+		e.requestQ <- &chatJob{id: "test-job", ctx: context.Background(), ch: chans[i], object: ObjectChatText}
 	}
 
 	drained := e.drainQueue(fmt.Errorf("drain-test: engine shutting down"))
 
 	if drained != jobs {
-		t.Fatalf("drainQueue drained %d jobs, want %d", drained, jobs)
+		t.Errorf("drained = %d, want %d", drained, jobs)
 	}
-
 	if got := e.model.activeStreams.Load(); got != 0 {
-		t.Fatalf("activeStreams = %d after draining %d jobs, want 0; a caller whose "+
-			"stream is never decremented pins the count above zero and Model.Unload "+
-			"cannot drain it", got, jobs)
+		t.Errorf("activeStreams = %d, want 0", got)
 	}
-
-	// Every channel must be closed. A closed channel yields ok=false once its
-	// buffered value is consumed; a channel left open would block here, so the
-	// receive-with-ok both proves closure and can't hang the test.
 	for i, ch := range chans {
-		<-ch // the buffered error response failJob sent
+		<-ch // the buffered error response
 		if _, ok := <-ch; ok {
-			t.Fatalf("job %d channel not closed by failJob; the caller blocks on it forever", i)
+			t.Errorf("job %d channel not closed", i)
 		}
 	}
 }

--- a/sdk/kronk/model/batch_shutdown.go
+++ b/sdk/kronk/model/batch_shutdown.go
@@ -34,17 +34,26 @@ func (e *batchEngine) drainSlots() {
 	}
 	e.pendingJobs = nil
 
-	// Drain pending jobs still in the request queue.
+	// Drain pending jobs still in the request queue. This is not the last
+	// word: a submit already past its stopped check can still enqueue
+	// after this returns, so stop drains again once the queue is frozen.
+	drained := e.drainQueue(shutdownErr)
+	e.model.log(ctx, "batch-engine", "status", "drain-finished", "drained_pending", drained)
+}
+
+// drainQueue fails every job currently in requestQ and reports how many
+// it drained. Callers own the jobs they drain: failJob closes job.ch and
+// decrements activeStreams, which is what unblocks the waiting caller.
+func (e *batchEngine) drainQueue(err error) int {
 	drained := 0
 	for {
 		select {
 		case job := <-e.requestQ:
-			e.failJob(job, shutdownErr)
+			e.failJob(job, err)
 			drained++
 
 		default:
-			e.model.log(ctx, "batch-engine", "status", "drain-finished", "drained_pending", drained)
-			return
+			return drained
 		}
 	}
 }


### PR DESCRIPTION
Submit could enqueue onto requestQ after stop, leaking the job's stream and wedging Model.Unload. Reject submits once stopped, drain under lock.
        