### PR TITLE
MTP/speculative decoding: findings + failing regression pins

### DIFF
--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,268 @@
+# MTP / Speculative Decoding — Findings
+
+2026-08-01. Verified against this repo, `.extras/llama.cpp` (b10211), `.extras/yzma`, and live
+runs of `unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL`. **No source was modified.**
+
+> **yzma version note.** `.extras/yzma` is tagged **v1.21.0** — the same version `go.mod` pins.
+> Only `pkg/llama/draft.go` and `draft_test.go` differ from the module cache, via an
+> **uncommitted local patch** that inserts a `pMin float32` parameter into `DraftGenerate`
+> between `nDraft` and `greedy`. Kronk passes 10 args at `batchgen_speculative.go:242`, so
+> **adopting that local tree would break Kronk's build.** Everything else in `pkg/llama` is
+> byte-identical, so §§1-2, 4-6 below hold for both trees. See §6c and §6i for the patch's
+> behavioural impact.
+
+---
+
+## 1. MTP bonus token bypasses the sampler chain and the grammar — CRITICAL, reproduced
+
+`batchgen_speculative.go:353-356` forces `greedy = true` for every MTP request. The in-loop
+verify branch honours that by routing through `s.sampler` / `s.grammarSampler`. The
+bonus-token block at `:582-602` does not:
+
+```go
+case greedy:                                  // true for every MTP request
+    maskSuppressTokenLogits(targetLogits, e.model.suppressTokens)
+    bonusToken = argmax(targetLogits)         // :594-595
+```
+
+Every fully-accepted round emits a raw `argmax` token — no penalties, DRY, top-k/p, min-p,
+XTC, temperature, **no grammar**. At measured 0.71 acceptance with `defMTPNDraft = 2`, that
+is ~15-30% of all emitted tokens decoded greedily.
+
+- **Repeat loops**: greedy decoding is the canonical cause, and the bypass also removes
+  repeat-penalty on exactly those tokens. Self-reinforcing — greedy tokens are what the MTP
+  head predicts best, so acceptance stays high.
+- **Broken tool calls / crash**: `response_format` and `json_schema` set `p.Grammar`
+  (`params.go:469,478,490`). The unconstrained bonus token then reaches
+  `grammarSampler.Accept` (`batchgen_tokens.go:60`); `llama_grammar_accept_token` **throws**
+  (`llama-grammar.cpp:1517`), nothing catches it, and the C++ exception unwinds through
+  libffi into Go. Verified: `yzma.SamplerAccept` (`sampling.go:586-591`) has only a nil-handle
+  guard, and `grep -rn "recover()" pkg/` over all of yzma returns **zero hits**. This is not an
+  oversight that a defensive `recover()` could fix — a Go `recover()` cannot catch a C++
+  exception unwinding through libffi at all; `libc++abi` aborts before any Go frame runs.
+  **The only possible fix is to never hand an out-of-grammar token to `Accept`.**
+
+Reproduced — 5 identical `json_schema` requests, runs 0-1 valid JSON, run 2 killed the process:
+
+```
+libc++abi: terminating due to uncaught exception of type std::runtime_error:
+  Unexpected empty grammar stack after accepting piece: } (92)
+SIGABRT
+  llama_grammar_accept_token → SamplerAccept → grammarSampler.Accept (grammar.go:436)
+  → handleSampledToken (batchgen_tokens.go:60)
+  → finalizeSpeculativeTokens (batchgen_speculative.go:762)   ← bonus-token site
+```
+
+Kills the whole process, not just the request. No workaround: MTP auto-enables from
+`nextn_predict_layers` (`draft_mtp.go:460-508`) and no config key disables it.
+
+Upstream samples every position — including the bonus — through the same chain and grammar
+(`common/sampling.cpp:646-674`).
+
+**Fix**: one branch, mirroring `:425-467`.
+
+---
+
+## 2. `MemorySeqRm` return value discarded everywhere — HIGH
+
+`llama.MemorySeqRm` returns `(bool, error)`. There are **19** call sites in `sdk/kronk/`
+and **none** captures either value. yzma's doc comment (`memory.go:101-105`) is explicit:
+*"Returns false if a partial sequence cannot be removed. Removing a whole sequence never
+fails."* Note the `error` return is only the nil-handle guard — it is never non-nil after a
+successful FFI call, so the **bool** is the load-bearing value.
+
+That doc comment splits the sites into two groups:
+
+- **Partial-range — can genuinely return false, must be checked (6 sites):**
+  `batchgen_speculative.go:64,697,703,971,1012`, `batchgen_finish.go:159`
+- **Whole-sequence (`-1,-1`) — never fails, ignoring the bool is defensible (13 sites):**
+  `batchgen_speculative.go:24,60,1084`, `batchgen_finish.go:163,179`,
+  `batchgen_slot_start.go:296,322,330,412,421,455,457,494`
+
+So the actionable fix is 6 sites, not 19.
+
+On a hybrid target (`qwen35moe` is hybrid), `llama_memory_hybrid::seq_rm` tries the recurrent
+cache first and **returns false having mutated nothing — not even the attention KV**
+(`llama-memory-hybrid.cpp:143-150`), because `llama_memory_recurrent::seq_rm` refuses
+mid-sequence ranges unless `n_rs_seq > 0`.
+
+`MemorySeqPosMin` / `MemorySeqPosMax` (`memory.go:153,163`) return `(Pos, error)` and are
+unused by Kronk. They are the cheapest runtime assertion that a trim actually landed — and
+they catch the hybrid case where the bool is true but only one of the two caches was trimmed.
+
+So on the §3 fallback paths, rejected drafts stay in the attention KV while `s.nPast` rewinds.
+llama.cpp appends rather than overwrites by `(seq, pos)` — the sequence carries phantom
+rejected tokens forever. Textbook repeat-loop generator.
+
+---
+
+## 3. Snapshot / restore failures continue speculating — HIGH (latent)
+
+- **Capture** (`batchgen_engine.go:308-317`): logs `snapshot-error`, truncates
+  `specSnapshot`, keeps speculating → `hybridRestore == false` → the §2 no-op `MemorySeqRm`.
+- **Restore** (`batchgen_speculative.go:689-699`): logs `restore-error`, same fallback, then
+  sets `nPast` (`:740`) and streams the bonus token (`:762`). The comment "we'll likely fail
+  the slot below" is wrong — nothing below fails the slot.
+
+`disableMTPForRequestSpec` (`:1081`) and `mtpDisabledForRequest` exist but are not wired to
+either. Neither fired across ~2500 probe tokens, so these are latent, not the daily cause.
+
+---
+
+## 4. llama.cpp's recurrent-rollback support is unused — HIGH
+
+- **`n_rs_seq`**: `llm_arch_supports_rs_rollback` returns true for `QWEN35`/`QWEN35MOE`
+  (`llama-arch.cpp:989-997`). With `n_rs_seq >= n_draft`, `llama_memory_seq_rm` does the
+  partial recurrent rollback natively and no snapshot is needed. Upstream sets it from the
+  draft width (`common/common.cpp:1633`). Kronk never sets `NRsSeq` — always 0.
+- **`PARTIAL_ONLY`**: `llama_memory_hybrid::state_write/read` skip the attention KV under
+  `LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY` (`llama-memory-hybrid.cpp:190-202`); upstream's server
+  uses it for every speculative checkpoint. Kronk calls `StateSeq{GetSize,GetData,SetData}`
+  at `batchgen_speculative.go:784,797,823` with flags = 0 — full per-seq state incl. the
+  entire attention KV — **every speculative round**.
+
+**This is far cheaper to fix than it first appears — no FFI work is needed.** Verified against
+`.extras/yzma`:
+
+- `NRsSeq` is already exposed on `llama.ContextParams` (`llama.go:340`), and the Go struct
+  matches `llama_context_params` field-for-field, so it is a one-line assignment at the
+  context-params construction site. `CtxOther` (`:377`) and `CtxType` (`:344`) are likewise
+  correct.
+- yzma **already binds all three `_ext` entry points**: `StateSeqGetSizeExt`,
+  `StateSeqGetDataExt`, `StateSeqSetDataExt` (`state.go:343,353,368`), each taking
+  `flags uint32`, tested at `state_test.go:297-328`. Switching the three call sites above and
+  passing `uint32(1)` is a three-line change. (yzma exposes no named constant for the flag —
+  pass the literal with a comment.)
+- `llama.NRsSeq(ctx)` (`context.go:550`) reads back what llama.cpp actually honoured.
+  `model.go:640` currently logs the *requested* `ctxParams.NRsSeq`, which is always 0;
+  logging the read-back instead would report the value that determines whether partial
+  recurrent rollback works.
+
+---
+
+## 5. Flash Attention + MTP: it works
+
+Measured, Metal, b10211, 4096 ctx, 400-token generations:
+
+| flash-attention | nSeqMax | K/V | result | accept | TPS |
+|---|---|---|---|---|---|
+| enabled | 1 | f16 | OK | 0.73 | 69.1 |
+| disabled | 1 | f16 | OK | 0.69 | 65.6 |
+| enabled | 2 | f16 | OK | 0.71 | 68.6 |
+| disabled | 2 | f16 | OK | 0.72 | 68.5 |
+| auto | 1 | f16 | OK | 0.74 | 71.0 |
+| enabled | 1 | q8_0 | OK | 0.71 | 62.9 |
+| **disabled** | 1 | **q8_0** | **LOAD FAILS** | — | — |
+
+MTP auto-detected and loaded in every passing case. The only failure is FA *disabled* with a
+quantized V cache, which llama.cpp rejects by design (`llama-context.cpp:458-462, 3561-3570`).
+
+No rule anywhere in `config.go` / `analyze.go` / `kronkresolve.go` / catalog disables FA for
+hybrid or MTP. The belief traces to a comment — `testlib.go:394-395`, *"Hybrid target requires
+f16 KV and disabled flash-attention (see config.go)"* — which is wrong in both halves, and the
+config it annotates doesn't set `PtrFlashAttention` at all, so it runs with FA enabled.
+
+---
+
+## 6. Other correctness issues
+
+| # | Issue | Severity |
+|---|---|---|
+| 6a | **Temperature 0 unreachable.** `params.go:724` rewrites `temperature <= 0` → `0.8`; `params.go:372` drops a zero when converting `Params`→`D`. Blocks deterministic decoding, makes the classic-drafter `greedy` path dead code, and blocks any temp-0 equivalence test. | MED |
+| 6b | **No context guard during generation.** `MaxTokens` defaults to the full window (`params.go:706`); `s.nPast` is only checked on the prompt. Overrun → `llama_decode` fails → `batchgen_engine.go:464-475` **fails every active slot**, not just the offender. | MED |
+| 6c | **`rollbackDraft` off-by-one after EOG-truncated draft.** `DraftGenerate` increments `nPast` before the EOG check but breaks before `drafted++` (yzma `draft.go:121-126`), so `draftBasePast` at `:1002` is one too high. Draft KV keeps a stale cell; acceptance collapses for the rest of the request. Details in §6c-detail. | MED |
+| 6d | **`verifyH` fallback reads the wrong buffer.** On capture failure the mirror falls back to the live pre-norm buffer, which on hybrid holds the *rebatch* rows after a **successful** restore. Wrong hidden states into draft KV; comment at `:396-399` has the reasoning backwards. | MED |
+| 6e | **Stale logits index for bonus token** (`:762`) after a hybrid restore — valid indices are `[0, 1+accepted)`, not spec-batch offsets. Logprobs only. | LOW |
+| 6f | **`loadDraftModelMTP` drops `KVUnified`/`SwaFull`** (`draft_mtp.go:86-98`). At `nSeqMax>1` target gets `n_ctx_seq = 2*window` unified, MTP draft gets `window` non-unified. Shared-KV loader copies them and explains why. | LOW |
+| 6g | **`finishSlot` trims the target memory for shared-KV MTP.** `draft.core().mem` *is* the target's memory for `*sharedMTPDrafter`; `trimPos == 0` wipes the whole target seq. Harmless only because `:179` clears it anyway. | LOW |
+| 6h | **Dead code**: `s.specDraftProbs` is only ever `nil`, so `:556-574` and `sampleAdjustedInto` (`:885`) are unreachable. | LOW |
+| 6i | **`DraftGenerate` corrupts sampler state, not just `nPast`, on truncated non-greedy drafts.** The EOG `break` (`draft.go:123`) is *after* `samplerAcceptFunc.Call` (`:115`), so the chain accepts a token the caller never receives — repeat-penalty/DRY/grammar state advances past a phantom token. Currently masked because MTP forces `greedy = true` and the accept is gated on `if !greedy` (`:86`). **Becomes live the moment §1 or §6a is fixed.** | MED (latent) |
+
+### §6c-detail — exact contract
+
+Per-exit-path trace of `DraftGenerate`:
+
+| Exit path | `nPast++`? | `drafted++`? | `finalPast` vs `start+drafted` |
+|---|---|---|---|
+| decode error | No (`break` precedes it) | No | **exact — not affected** |
+| EOG hit | Yes | No | **+1 (leaks)** |
+| normal completion | Yes ×n | Yes ×n | exact |
+| *p_min stop (local patch only)* | Yes | No | **+1 (leaks)** |
+
+So the bug fires only on EOG today — and additionally on p_min if the uncommitted
+`.extras/yzma` patch is ever adopted.
+
+**This cannot be fixed by upgrading yzma.** Its own `draft_test.go:97-101` asserts
+`finalPast - start ∈ [drafted, drafted+1]` — upstream treats the ambiguity as contract, and a
+caller cannot distinguish the two cases from the return values.
+
+**The fix is already sitting in Kronk**: `generateDraftTokens` captures
+`draftStartPast := s.draftNPast` at `batchgen_speculative.go:238` and then uses it only for
+logging. `rollbackDraft` should take that saved base instead of recomputing
+`s.draftNPast - llama.Pos(nDraft)` at `:1002`.
+
+---
+
+## 7. Test coverage
+
+No unit test in `sdk/kronk/model/` touches `batchgen_speculative.go`, `batchgen_mtp.go`, or
+`draft*.go` — only `config_test.go:347` (config arithmetic) and `lora_test.go:23` (type switch).
+
+Integration = three smoke suites asserting the response contains "Gorilla", under
+`WithRetry`. A repetition loop containing "Gorilla" passes.
+
+`checkMTPUsage` *does* `t.Errorf` on `DraftTokens == 0`; only `DraftAcceptedTokens == 0` is a
+non-failing `t.Logf` — still the one signal that would catch silent MTP collapse.
+
+**Worse: the MTP suite has never run at all.** `testlib.go:72` resolved
+`mtp-Qwen3.6-35B-A3B-UD-Q2_K_XL`, and that ID **does not exist in the catalog** —
+`grep -c Q2_K_XL sdk/tools/defaults/yaml/catalog.yaml` returns 0. The only MTP entry is
+`unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL` (catalog line 321). So `testlib.MPMTP` was always
+empty and `tests/mtp/main_test.go` always took the `os.Exit(0)` skip — silently, behind a
+"not downloaded" message that reads like normal local-box behaviour.
+
+`tests/gemma4mtp` and `tests/draft` deserve the same audit.
+
+**Nothing exercises MTP with a grammar / `response_format`.** Combined with the above, that
+is why §1 shipped.
+
+---
+
+## 8. Stale or wrong comments
+
+| Location | Problem |
+|---|---|
+| `batchgen_speculative.go:348-352` | Claims the greedy branch uses the full sampler — false for the bonus token (§1). |
+| `batchgen_speculative.go:694-695` | "we'll likely fail the slot below" — nothing does. |
+| `batchgen_speculative.go:757-761` | Confuses sequence position with batch output index (§6e). |
+| `batchgen_speculative.go:396-399` | Failsafe reasoning backwards; the hazard is a *successful* restore (§6d). |
+| `batchgen_speculative.go:546-554` | Describes a live fallback that is dead code (§6h). |
+| `batchgen_speculative.go:948-954` | Mirror moved to `finalizeSpeculativeTokens` in the 2A/2B split. |
+| `batchgen_speculative.go:134-136` | References `batchEngine.newSlot`; no such method (it's `newBatchEngine`). |
+| `batchgen_engine.go:313-314` | "full-accept rounds still work" — they never call `MemorySeqRm`; partial rejects silently no-op (§2). |
+| `batchgen_slot.go:252-257` | "next llama_decode fails with -1" — it doesn't fail, it silently corrupts (§2). |
+| `models.go:47-49` | Partial delete *refuses* atomically; and `n_rs_seq` makes it work on qwen35 (§4). |
+| `draft_mtp.go:352` | "MemorySeqRm ... is a no-op for the shared layers" — it hits the target's memory (§6g). |
+| `testlib.go:394-395` | FA/f16 claim is wrong and unsourced (§5). |
+| `tests/mtp/suite_test.go:10-11` | "NRsSeq is logged by the loader" — never set (§4). |
+| `batchgen_tokens.go:183-184` | Hardcoded "line 55"; actual site is line 66. |
+
+---
+
+## 9. Suggested order
+
+1. **§1** — route the bonus token through `s.grammarSampler` / `s.sampler`. One branch; fixes
+   the crash, the grammar violations, and the dominant loop mechanism.
+2. **§4** — *moved up*: it needs no FFI work (yzma already binds everything). Set
+   `NRsSeq = nDraft` on the target context, switch the three `StateSeq*` calls to the `_ext`
+   forms with `flags = 1`, and checkpoint only when `n_rollback > n_rs_seq`. This also
+   partially subsumes §2 by making the hybrid partial `seq_rm` succeed natively.
+3. **§2** — check the bool at the 6 partial-range sites; fail the slot or disable speculation
+   on false. Consider a debug-mode `MemorySeqPosMax` assertion alongside it.
+4. **§3** — wire `disableMTPForRequestSpec` into `snapshot-error` / `restore-error`.
+5. **§6c** — use the already-captured `draftStartPast`; one line. Do it before §6a/§1 land,
+   since §6i goes live once non-greedy drafting becomes reachable.
+6. **§6a**, then a temp-0 MTP-on/off equivalence test and an MTP + `json_schema` regression test.
+7. Comments in §8.
+
+Per `AGENTS.md` all of this is a source change requiring `plan-change` and an approved plan.

--- a/sdk/kronk/model/doc_comment_claims_test.go
+++ b/sdk/kronk/model/doc_comment_claims_test.go
@@ -1,0 +1,275 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestDocCommentClaimsMatchCode pins findings2 §8: doc comments that make a
+// mechanically checkable claim about the code they annotate, and are wrong.
+//
+// Only claims that can be checked against the AST or the file itself are
+// asserted here. Purely narrative staleness (for example
+// batchgen_speculative.go:694-695 "we'll likely fail the slot below") is left
+// to human review — a fake assertion would be worse than none.
+//
+// Each subtest is a pin, not a style check: it fails while the comment and the
+// code disagree, and passes once either side is corrected.
+func TestDocCommentClaimsMatchCode(t *testing.T) {
+	root := kronkRepoRoot(t)
+
+	tests := []struct {
+		name  string
+		check func(t *testing.T, root string)
+	}{
+		{"testlib CfgMTPChatMultiSlot flash-attention claim", checkTestlibFlashAttentionClaim},
+		{"tests/mtp package doc NRsSeq claim", checkMTPSuiteNRsSeqClaim},
+		{"draft_mtp shared MemorySeqRm no-op claim", checkSharedMemorySeqRmNoOpClaim},
+		{"batchgen_tokens EOG line reference", checkBatchgenTokensEOGLineReference},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, root)
+		})
+	}
+}
+
+// checkTestlibFlashAttentionClaim pins sdk/kronk/tests/testlib/testlib.go:394-395:
+//
+//	"Hybrid target requires f16 KV and disabled flash-attention (see
+//	 config.go), inherited from the single-slot config."
+//
+// No such rule exists in config.go (verified: no branch in modelCtxParams or
+// adjustConfig keys FlashAttention off hybrid / MTP), and the config the
+// comment annotates never sets PtrFlashAttention. Config.FlashAttention()
+// forwards to DerefFlashAttention, which returns FlashAttentionEnabled for a
+// nil pointer (sdk/kronk/model/config.go:441-443, 1255-1260), so
+// CfgMTPChatMultiSlot in fact runs with flash-attention ENABLED — the exact
+// opposite of what the comment tells the next reader.
+func checkTestlibFlashAttentionClaim(t *testing.T, root string) {
+	// Ground the claim in the real default rather than restating it.
+	if got := DerefFlashAttention(nil); got != FlashAttentionEnabled {
+		t.Fatalf("precondition changed: DerefFlashAttention(nil) = %v, want FlashAttentionEnabled (config.go:1255)", got)
+	}
+
+	path := filepath.Join(root, "sdk", "kronk", "tests", "testlib", "testlib.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+	fd := findKronkFunc(t, file, path, "CfgMTPChatMultiSlot")
+
+	if fd.Doc == nil {
+		return
+	}
+
+	doc := strings.ToLower(fd.Doc.Text())
+	if !strings.Contains(doc, "disabled flash-attention") {
+		return
+	}
+
+	// The doc claims flash-attention is disabled. That is only true if the
+	// config literal actually sets PtrFlashAttention to a disabled value.
+	var setsFA bool
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		kv, ok := n.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "PtrFlashAttention" {
+			setsFA = true
+		}
+		return true
+	})
+
+	if !setsFA {
+		t.Errorf(`%s: doc comment on CfgMTPChatMultiSlot claims "disabled flash-attention (see config.go)" but the config never sets PtrFlashAttention.
+
+  bug:      findings2 §8 / §5 — the comment is wrong in both halves.
+  actual:   Config.FlashAttention() -> DerefFlashAttention(nil) ->
+            FlashAttentionEnabled (sdk/kronk/model/config.go:441-443,
+            1255-1260), so CfgMTPChatMultiSlot runs with FA ENABLED.
+  also:     there is no rule anywhere in sdk/kronk/model/config.go that
+            disables flash-attention for hybrid or MTP targets; the
+            "(see config.go)" pointer resolves to nothing.
+  measured: findings2 §5 — hybrid MTP loads and generates correctly with FA
+            enabled at nSeqMax 1 and 2. The only real constraint is the
+            inverse: FA *disabled* with a quantized V cache fails to load
+            (.extras/llama.cpp/src/llama-context.cpp:458-462, 3561-3570).
+  fix:      delete the claim, or set PtrFlashAttention explicitly.`,
+			srcPos(fset, root, commentClaimPos(fd.Doc, "flash-attention")))
+	}
+}
+
+// checkMTPSuiteNRsSeqClaim pins sdk/kronk/tests/mtp/suite_test.go:10-11:
+//
+//	"Recurrent-state snapshot allocation (NRsSeq) is logged by the loader and
+//	 visible in test output."
+//
+// The loader does print an NRsSeq field (sdk/kronk/model/model.go:637-640) but
+// it prints ctxParams.NRsSeq — the value kronk REQUESTED — and nothing in
+// sdk/kronk/model/ ever assigns it (findings2 §4). The comment therefore
+// advertises a diagnostic that is a hard-coded 0 for every run.
+func checkMTPSuiteNRsSeqClaim(t *testing.T, root string) {
+	path := filepath.Join(root, "sdk", "kronk", "tests", "mtp", "suite_test.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+
+	if file.Doc == nil || !strings.Contains(file.Doc.Text(), "NRsSeq") {
+		return
+	}
+
+	sites := fieldWriteSites(t, root, filepath.Join(root, "sdk", "kronk", "model"), "NRsSeq")
+	if len(sites) == 0 {
+		t.Errorf(`%s: package doc claims "Recurrent-state snapshot allocation (NRsSeq) is logged by the loader and visible in test output", but NRsSeq is never assigned in sdk/kronk/model/.
+
+  bug:      findings2 §8 / §4.
+  actual:   sdk/kronk/model/model.go:640 logs ctxParams.NRsSeq, the REQUESTED
+            value. modelCtxParams (sdk/kronk/model/config.go:841) never sets
+            it, so the logged value is 0 on every run and the suite's stated
+            observability does not exist.
+  fix:      set ctxParams.NRsSeq >= the MTP draft width and log the read-back
+            llama.NRsSeq(lctx) (yzma .extras/yzma/pkg/llama/context.go:550),
+            or delete the claim.`,
+			srcPos(fset, root, commentClaimPos(file.Doc, "NRsSeq")))
+	}
+}
+
+// checkSharedMemorySeqRmNoOpClaim pins sdk/kronk/model/draft_mtp.go:352:
+//
+//	"We keep the handle only for the safe ops (MemorySeqRm on the assistant's
+//	 own cells is a no-op for the shared layers)."
+//
+// It is not a no-op. The comment sits inside loadDraftModelMTPShared, which
+// builds the assistant context with params.CtxOther = targetCtx. The very next
+// statement takes mem from llama.GetMemory(lctx), and for a CtxOther context
+// that handle IS the target's llama_memory — the comment's own preceding
+// sentence says so ("Shared memory: this returns the TARGET's llama_memory").
+// So every MemorySeqRm through draft.core().mem for a *sharedMTPDrafter
+// operates on the TARGET's KV. That is what makes findings2 §6g
+// (finishSlot trimming the target memory, trimPos == 0 wiping the whole target
+// sequence) a real latent trap rather than a theoretical one.
+func checkSharedMemorySeqRmNoOpClaim(t *testing.T, root string) {
+	path := filepath.Join(root, "sdk", "kronk", "model", "draft_mtp.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+	fd := findKronkFunc(t, file, path, "loadDraftModelMTPShared")
+
+	// Does this function alias the target's memory via CtxOther?
+	var sharesMemory bool
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "CtxOther" {
+				sharesMemory = true
+			}
+		}
+		return true
+	})
+
+	if !sharesMemory {
+		return
+	}
+
+	for _, group := range file.Comments {
+		if group.Pos() < fd.Body.Pos() || group.End() > fd.Body.End() {
+			continue
+		}
+
+		text := group.Text()
+		if !strings.Contains(text, "MemorySeqRm") || !strings.Contains(text, "no-op") {
+			continue
+		}
+
+		t.Errorf(`%s: comment claims "MemorySeqRm on the assistant's own cells is a no-op for the shared layers", but loadDraftModelMTPShared sets params.CtxOther = targetCtx.
+
+  bug:      findings2 §8 / §6g.
+  actual:   with CtxOther set, llama.GetMemory(lctx) returns the TARGET's
+            llama_memory — the same comment block says so two sentences
+            earlier ("this returns the TARGET's llama_memory"). Every
+            MemorySeqRm via draft.core().mem for a *sharedMTPDrafter therefore
+            mutates the target's KV, not assistant-private cells.
+  impact:   finishSlot trims draft.core().mem; a trimPos of 0 wipes the entire
+            target sequence. Currently masked only because the target seq is
+            cleared right after anyway.
+  fix:      state that MemorySeqRm through this handle hits the target's KV
+            and must never be called with a shared-KV drafter.`,
+			srcPos(fset, root, commentClaimPos(group, "no-op")))
+	}
+}
+
+var eogLineRefRE = regexp.MustCompile(`line (\d+)`)
+
+// checkBatchgenTokensEOGLineReference pins sdk/kronk/model/batchgen_tokens.go:183-184:
+//
+//	"Count every token the model generates. EOG tokens are handled before the
+//	 state machine (line 55), so everything here is a real output token."
+//
+// The EOG handling site is llama.VocabIsEOG at line 66, not 55. Hard-coded line
+// numbers rot on the first insertion above them; this asserts the pointer still
+// resolves.
+func checkBatchgenTokensEOGLineReference(t *testing.T, root string) {
+	rel := filepath.Join("sdk", "kronk", "model", "batchgen_tokens.go")
+	path := filepath.Join(root, rel)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	actual := 0
+	for i, line := range lines {
+		if strings.Contains(line, "llama.VocabIsEOG(") {
+			actual = i + 1
+			break
+		}
+	}
+	if actual == 0 {
+		t.Fatalf("%s: no llama.VocabIsEOG call found; the test pins a site that no longer exists", rel)
+	}
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+
+	for _, group := range file.Comments {
+		text := group.Text()
+		if !strings.Contains(text, "EOG tokens are handled") {
+			continue
+		}
+
+		m := eogLineRefRE.FindStringSubmatch(text)
+		if m == nil {
+			continue
+		}
+
+		claimed, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("%s: unparsable line reference %q", rel, m[1])
+		}
+
+		if !strings.Contains(lines[min(claimed, len(lines))-1], "llama.VocabIsEOG(") {
+			t.Errorf(`%s: comment points at "line %d" for the EOG-handling site, but that site is line %d.
+
+  bug:      findings2 §8 — stale hard-coded line reference.
+  claimed:  %s:%d -> %q
+  actual:   %s:%d -> %q
+  fix:      reference handleSampledToken's VocabIsEOG branch by name, not by
+            line number.`,
+				srcPos(fset, root, commentClaimPos(group, m[0])), claimed, actual,
+				rel, claimed, strings.TrimSpace(lines[min(claimed, len(lines))-1]),
+				rel, actual, strings.TrimSpace(lines[actual-1]))
+		}
+	}
+}

--- a/sdk/kronk/model/memory_seqrm_checked_test.go
+++ b/sdk/kronk/model/memory_seqrm_checked_test.go
@@ -1,0 +1,199 @@
+package model
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// parseModelPackage parses every non-test .go file in this package's directory
+// and returns the file set plus the parsed files, sorted by name for stable
+// output. Comments are retained so doc-comment assertions can use the result.
+//
+// `go test` runs with the working directory set to the package directory, so
+// "." is this package's source directory.
+func parseModelPackage(t *testing.T) (*token.FileSet, []*ast.File) {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	if len(names) == 0 {
+		t.Fatal("no non-test .go files found in the package directory")
+	}
+
+	fset := token.NewFileSet()
+	files := make([]*ast.File, 0, len(names))
+	for _, name := range names {
+		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		files = append(files, f)
+	}
+
+	return fset, files
+}
+
+// isLlamaCall reports whether call is a call to llama.<name>.
+func isLlamaCall(call *ast.CallExpr, name string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+
+	pkg, ok := sel.X.(*ast.Ident)
+
+	return ok && pkg.Name == "llama"
+}
+
+// isNegativeOne reports whether expr is the literal -1, including when it is
+// wrapped in a single-argument conversion such as llama.Pos(-1).
+func isNegativeOne(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.ParenExpr:
+		return isNegativeOne(e.X)
+
+	case *ast.CallExpr:
+		// Conversion, e.g. llama.Pos(-1).
+		if len(e.Args) != 1 {
+			return false
+		}
+		return isNegativeOne(e.Args[0])
+
+	case *ast.UnaryExpr:
+		if e.Op != token.SUB {
+			return false
+		}
+		lit, ok := e.X.(*ast.BasicLit)
+
+		return ok && lit.Kind == token.INT && lit.Value == "1"
+	}
+
+	return false
+}
+
+// posOf renders a node's position as file:line relative to the package
+// directory.
+func posOf(fset *token.FileSet, n ast.Node) string {
+	p := fset.Position(n.Pos())
+
+	return fmt.Sprintf("%s:%d", filepath.Base(p.Filename), p.Line)
+}
+
+// TestMemorySeqRmPartialRangeResultIsChecked pins findings2 §2.
+//
+// llama.MemorySeqRm returns (bool, error). Its yzma doc comment
+// (yzma pkg/llama/memory.go:101-105) states:
+//
+//	"Returns false if a partial sequence cannot be removed.
+//	 Removing a whole sequence never fails."
+//
+// On a hybrid target llama_memory_hybrid::seq_rm consults the recurrent cache
+// first; llama_memory_recurrent::seq_rm refuses a mid-sequence range unless
+// n_rs_seq > 0 and the hybrid wrapper then returns false having mutated
+// NOTHING — not even the attention KV. A partial-range call whose result is
+// discarded therefore silently leaves rejected draft tokens in the KV while the
+// slot's nPast rewinds past them. llama.cpp appends rather than overwrites by
+// (seq, pos), so the sequence carries phantom tokens for the rest of the
+// request: a repeat-loop generator.
+//
+// This test locates the calls by AST rather than by line number so it survives
+// line drift. Whole-sequence wipes (p0 == -1 && p1 == -1) are exempt because
+// the documented contract says they cannot fail.
+//
+// Today the offending sites are the partial-range calls in
+// batchgen_speculative.go (draft-KV trims and the hybrid rollback fallback) and
+// batchgen_finish.go (the draft-KV trim on slot finish). Each must capture the
+// bool and act on false — fail the slot or disable speculation for the request.
+func TestMemorySeqRmPartialRangeResultIsChecked(t *testing.T) {
+	fset, files := parseModelPackage(t)
+
+	var (
+		discardedPartial []string
+		exemptWholeSeq   []string
+		allCallSites     []string
+	)
+
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			// An ExprStmt wrapping the call means both return values were
+			// discarded; anywhere else (assignment, if-statement init, ...)
+			// the result is at least bound to something.
+			stmt, ok := n.(*ast.ExprStmt)
+			if !ok {
+				return true
+			}
+
+			call, ok := stmt.X.(*ast.CallExpr)
+			if !ok || !isLlamaCall(call, "MemorySeqRm") {
+				return true
+			}
+
+			// Signature: MemorySeqRm(mem, seqID, p0, p1).
+			if len(call.Args) == 4 && isNegativeOne(call.Args[2]) && isNegativeOne(call.Args[3]) {
+				exemptWholeSeq = append(exemptWholeSeq, posOf(fset, call))
+				return true
+			}
+
+			discardedPartial = append(discardedPartial, posOf(fset, call))
+
+			return true
+		})
+
+		// Count every appearance so the test fails loudly if the matcher
+		// stops recognising the call entirely.
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isLlamaCall(call, "MemorySeqRm") {
+				return true
+			}
+			allCallSites = append(allCallSites, posOf(fset, call))
+
+			return true
+		})
+	}
+
+	if len(allCallSites) == 0 {
+		t.Fatal("no llama.MemorySeqRm call sites found: the AST matcher is stale, " +
+			"fix it before trusting this test")
+	}
+
+	if len(exemptWholeSeq) == 0 {
+		t.Errorf("no whole-sequence llama.MemorySeqRm(mem, seq, -1, -1) call sites found; " +
+			"the -1/-1 exemption is untested, so the matcher may be misclassifying calls")
+	}
+
+	if len(discardedPartial) > 0 {
+		t.Errorf("llama.MemorySeqRm called with a partial range and both return values "+
+			"discarded at %d site(s):\n\t%s\n\n"+
+			"MemorySeqRm returns (bool, error) and the bool is false when a partial range "+
+			"cannot be removed. On a hybrid target (llama_memory_hybrid::seq_rm) that false "+
+			"is returned after mutating nothing, so the rejected draft tokens stay in the KV "+
+			"while nPast rewinds past them and the sequence is silently corrupted.\n"+
+			"Each site must bind the bool and handle false (fail the slot or disable "+
+			"speculation for the request). Whole-sequence wipes (-1, -1) are exempt: "+
+			"per the yzma contract they never fail.\n"+
+			"Exempt whole-sequence sites seen: %s",
+			len(discardedPartial), strings.Join(discardedPartial, "\n\t"),
+			strings.Join(exemptWholeSeq, ", "))
+	}
+}

--- a/sdk/kronk/model/mtp_ctxparams_source_test.go
+++ b/sdk/kronk/model/mtp_ctxparams_source_test.go
@@ -1,0 +1,478 @@
+package model
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"maps"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Shared source-analysis helpers.
+//
+// The three regressions pinned in this file all live inside functions that
+// cannot be exercised without a loaded llama shared library AND a loaded GGUF:
+//
+//   - modelCtxParams (sdk/kronk/model/config.go:841) opens with
+//     llama.ContextDefaultParams(), a raw FFI call with no nil-handle guard
+//     (yzma .extras/yzma/pkg/llama/context.go:347-351). Without a prior
+//     dlopen it panics with "invalid memory address or nil pointer
+//     dereference". Even with the library loaded, the MTP branch is gated on
+//     mtpNextNLayers(mdl) > 0 && MTPAvailable(), which needs a real model
+//     handle plus the pre-norm symbols.
+//   - captureTargetSpecSnapshot / restoreTargetSpecSnapshot need a live
+//     llama.Context with populated KV.
+//   - loadDraftModelMTP / loadDraftModelMTPShared build their llama.ContextParams
+//     inline and hand them straight to llama.InitFromModel, so the params are
+//     never observable from the outside.
+//
+// Loading the 39 GB MTP target is out of scope for a unit test, so these are
+// AST assertions over the checked-in source instead. They locate everything by
+// declaration name, never by line number, so they survive unrelated edits.
+
+// kronkRepoRoot returns the absolute path of the kronk repository root.
+func kronkRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	if _, thisFile, _, ok := runtime.Caller(0); ok {
+		root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			return root
+		}
+	}
+
+	if ws := os.Getenv("GITHUB_WORKSPACE"); ws != "" {
+		if _, err := os.Stat(filepath.Join(ws, "go.mod")); err == nil {
+			return ws
+		}
+	}
+
+	t.Fatal("cannot locate the kronk repo root; set GITHUB_WORKSPACE")
+
+	return ""
+}
+
+// parseKronkSource parses path with comments attached.
+func parseKronkSource(t *testing.T, fset *token.FileSet, path string) *ast.File {
+	t.Helper()
+
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	return f
+}
+
+// findKronkFunc returns the declaration named name, failing the test when the
+// declaration has been renamed out from under the assertion.
+func findKronkFunc(t *testing.T, f *ast.File, path string, name string) *ast.FuncDecl {
+	t.Helper()
+
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if ok && fd.Name.Name == name {
+			return fd
+		}
+	}
+
+	t.Fatalf("func %s not found in %s: the test pins a declaration that no longer exists; re-point it", name, path)
+
+	return nil
+}
+
+// commentClaimPos returns the position of the individual comment line inside
+// group that carries want, so failures point at the sentence rather than at the
+// top of a long comment block.
+func commentClaimPos(group *ast.CommentGroup, want string) token.Pos {
+	for _, c := range group.List {
+		if strings.Contains(c.Text, want) {
+			return c.Pos()
+		}
+	}
+
+	return group.Pos()
+}
+
+// srcPos renders a token.Pos as a repo-relative "file:line".
+func srcPos(fset *token.FileSet, root string, p token.Pos) string {
+	pos := fset.Position(p)
+
+	rel, err := filepath.Rel(root, pos.Filename)
+	if err != nil {
+		rel = pos.Filename
+	}
+
+	return fmt.Sprintf("%s:%d", rel, pos.Line)
+}
+
+// nonTestGoFiles lists the non-test .go files in dir.
+func nonTestGoFiles(t *testing.T, dir string) []string {
+	t.Helper()
+
+	all, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+
+	var out []string
+	for _, p := range all {
+		if !strings.HasSuffix(p, "_test.go") {
+			out = append(out, p)
+		}
+	}
+
+	if len(out) == 0 {
+		t.Fatalf("no non-test go files under %s", dir)
+	}
+
+	return out
+}
+
+// fieldWriteSites returns every repo-relative "file:line" in dir's non-test
+// sources that writes a struct field named field, either as `x.Field = ...`
+// or as a `Field:` element of a composite literal.
+func fieldWriteSites(t *testing.T, root string, dir string, field string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	var sites []string
+	for _, path := range nonTestGoFiles(t, dir) {
+		f := parseKronkSource(t, fset, path)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for _, lhs := range node.Lhs {
+					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == field {
+						sites = append(sites, srcPos(fset, root, sel.Pos()))
+					}
+				}
+
+			case *ast.CompositeLit:
+				for _, elt := range node.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					if key, ok := kv.Key.(*ast.Ident); ok && key.Name == field {
+						sites = append(sites, srcPos(fset, root, kv.Pos()))
+					}
+				}
+			}
+
+			return true
+		})
+	}
+
+	return sites
+}
+
+// =============================================================================
+
+// TestModelCtxParamsAssignsNRsSeq pins findings2 §4: kronk never assigns
+// llama.ContextParams.NRsSeq, so llama.cpp's bounded partial recurrent-state
+// rollback is permanently disabled on hybrid MTP targets.
+//
+// llama.cpp b10211's llm_arch_supports_rs_rollback
+// (.extras/llama.cpp/src/llama-arch.cpp:989-997) returns true for
+// LLM_ARCH_QWEN35 and LLM_ARCH_QWEN35MOE. When n_rs_seq >= n_draft,
+// llama_memory_seq_rm performs the partial recurrent rollback natively and the
+// expensive per-round state snapshot in batchgen_speculative.go is unnecessary.
+// Upstream derives it from the draft width
+// (.extras/llama.cpp/common/common.cpp:1633, common/common.h:386-393).
+//
+// yzma already exposes the field (.extras/yzma/pkg/llama/llama.go:340) and a
+// read-back accessor llama.NRsSeq (context.go:550). Kronk's only reference is
+// the debug log at sdk/kronk/model/model.go:640, which prints the REQUESTED
+// value — permanently 0 — so nothing in the logs reveals the miss.
+//
+// BUG PINNED: sdk/kronk/model/config.go:841 (modelCtxParams) never sets
+// ctxParams.NRsSeq. It should be set to at least the MTP draft width
+// (mtpNDraft(cfg)) whenever the target is an MTP-capable hybrid.
+func TestModelCtxParamsAssignsNRsSeq(t *testing.T) {
+	root := kronkRepoRoot(t)
+	dir := filepath.Join(root, "sdk", "kronk", "model")
+
+	sites := fieldWriteSites(t, root, dir, "NRsSeq")
+	if len(sites) == 0 {
+		t.Errorf(`llama.ContextParams.NRsSeq is never assigned anywhere in sdk/kronk/model/.
+
+  bug:      findings2 §4 — partial recurrent-state rollback is disabled.
+  pinned:   sdk/kronk/model/config.go:841 (modelCtxParams) builds the target
+            llama.ContextParams and returns without touching NRsSeq, so
+            llama.cpp receives n_rs_seq == 0 for every model.
+  effect:   llm_arch_supports_rs_rollback is true for QWEN35 / QWEN35MOE
+            (.extras/llama.cpp/src/llama-arch.cpp:989-997), but with
+            n_rs_seq == 0 llama_memory_recurrent::seq_rm refuses every
+            mid-sequence range, so llama_memory_hybrid::seq_rm returns false
+            having mutated nothing (llama-memory-hybrid.cpp:143-150). Kronk
+            then falls back to a full per-seq state snapshot every
+            speculative round (batchgen_speculative.go:784,797,823).
+  expected: modelCtxParams sets ctxParams.NRsSeq >= the MTP draft width
+            (mtpNDraft(cfg)) for MTP-capable targets, mirroring upstream
+            .extras/llama.cpp/common/common.cpp:1633.
+  note:     sdk/kronk/model/model.go:640 logs ctxParams.NRsSeq — the REQUESTED
+            value, always 0. Logging llama.NRsSeq(lctx) (yzma context.go:550)
+            instead would report what llama.cpp actually honoured.`)
+	}
+
+	// Once the assignment lands this guards against it being logged-only.
+	for _, s := range sites {
+		t.Logf("NRsSeq write site: %s", s)
+	}
+}
+
+// TestSpecSnapshotUsesPartialOnlyStateExt pins findings2 §4: the speculative
+// snapshot/restore path saves and reloads the FULL per-sequence state —
+// including the entire attention KV — on every speculative round.
+//
+// llama_memory_hybrid::state_write / state_read
+// (.extras/llama.cpp/src/llama-memory-hybrid.cpp:190-202) skip the attention
+// KV entirely when LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY (value 1,
+// .extras/llama.cpp/include/llama.h:898) is set, which is exactly what is
+// wanted for a speculative checkpoint: only the recurrent state cannot be
+// trimmed per-position. Upstream's server passes the flag for every
+// speculative checkpoint (tools/server/server-context.cpp:2381-2382, 3042,
+// 3061, 3073, 3888-3891).
+//
+// yzma already binds the flags-accepting variants —
+// StateSeqGetSizeExt / StateSeqGetDataExt / StateSeqSetDataExt
+// (.extras/yzma/pkg/llama/state.go:343,353,368) — so this is a three-line
+// change, not FFI work.
+//
+// BUG PINNED: sdk/kronk/model/batchgen_speculative.go:784, 797, 823 call the
+// non-_ext forms (flags implicitly 0).
+func TestSpecSnapshotUsesPartialOnlyStateExt(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "batchgen_speculative.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+
+	// Non-_ext call -> the _ext form that must replace it.
+	wantExt := map[string]string{
+		"StateSeqGetSize": "StateSeqGetSizeExt",
+		"StateSeqGetData": "StateSeqGetDataExt",
+		"StateSeqSetData": "StateSeqSetDataExt",
+	}
+
+	funcs := []struct {
+		name    string
+		require []string
+	}{
+		{"captureTargetSpecSnapshot", []string{"StateSeqGetSize", "StateSeqGetData"}},
+		{"restoreTargetSpecSnapshot", []string{"StateSeqSetData"}},
+	}
+
+	for _, fn := range funcs {
+		fd := findKronkFunc(t, file, path, fn.name)
+
+		seen := make(map[string]bool)
+
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			seen[sel.Sel.Name] = true
+
+			ext, bad := wantExt[sel.Sel.Name]
+			if !bad {
+				return true
+			}
+
+			t.Errorf(`%s: %s calls llama.%s (flags implicitly 0) instead of llama.%s(..., 1).
+
+  bug:      findings2 §4 — every speculative round snapshots the full per-seq
+            state, attention KV included.
+  fix:      llama.%s(..., uint32(1)) — LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY,
+            .extras/llama.cpp/include/llama.h:898. llama_memory_hybrid then
+            skips the attention KV (llama-memory-hybrid.cpp:190-202).
+  binding:  yzma already exports %s (.extras/yzma/pkg/llama/state.go).`,
+				srcPos(fset, root, sel.Pos()), fn.name, sel.Sel.Name, ext, ext, ext)
+
+			return true
+		})
+
+		// The _ext form must actually be present, so that deleting the
+		// checkpoint altogether does not make this test pass. Only report it
+		// when the non-_ext call is absent too — otherwise the violation above
+		// already says everything.
+		for _, base := range fn.require {
+			ext := wantExt[base]
+			if !seen[ext] && !seen[base] {
+				t.Errorf("%s: %s calls neither llama.%s nor llama.%s; the PARTIAL_ONLY checkpoint (findings2 §4) is not implemented",
+					srcPos(fset, root, fd.Pos()), fn.name, base, ext)
+			}
+		}
+	}
+}
+
+// TestLoadDraftModelMTPCopiesTargetCtxParams pins findings2 §6f:
+// loadDraftModelMTP (the own-KV Qwen embedded-MTP path) forwards eleven fields
+// from the target's llama.ContextParams but silently drops KVUnified and
+// SwaFull.
+//
+// The shared-KV loader loadDraftModelMTPShared copies both and documents why at
+// sdk/kronk/model/draft_mtp.go:330-337: "They MUST match the target: ... a
+// stream-layout mismatch ... makes llama_kv_cache::get_k compute a 4-D view
+// that overruns the shared tensor".
+//
+// The own-KV path is not immune. modelCtxParams sets ctxParams.KVUnified = 1
+// whenever nSeqMax > 1 (sdk/kronk/model/config.go:936-939) and
+// NCtx = ContextWindow * nSeqMax (config.go:862). So at nSeqMax == 2 the target
+// runs unified with n_ctx_seq == 2*window while the MTP draft context inherits
+// the same NCtx but runs non-unified with n_stream == 2, giving
+// n_ctx_seq == window: a different cache topology and half the per-sequence
+// draft capacity the target has.
+//
+// Both loaders build their params inline and pass them straight to
+// llama.InitFromModel, so the values are unobservable without a loaded model.
+// This compares the two functions' copy sets instead, which also catches future
+// drift in either direction.
+//
+// BUG PINNED: sdk/kronk/model/draft_mtp.go:86-98 (loadDraftModelMTP).
+func TestLoadDraftModelMTPCopiesTargetCtxParams(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "draft_mtp.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+
+	// CtxOther is genuinely shared-KV-only: it is what makes the assistant
+	// context borrow the target's llama_memory, and it is assigned from the
+	// target *context* handle, not from the target's ContextParams. An own-KV
+	// draft context must NOT set it. Everything else the shared loader
+	// inherits describes cache geometry that both loaders need.
+	exempt := map[string]bool{
+		"CtxOther": true,
+	}
+
+	own := copiedCtxParamFields(t, fset, file, path, "loadDraftModelMTP")
+	shared := copiedCtxParamFields(t, fset, file, path, "loadDraftModelMTPShared")
+
+	var missing []string
+	for field := range shared {
+		if !exempt[field] && own[field] == token.NoPos {
+			missing = append(missing, field)
+		}
+	}
+	slices.Sort(missing)
+
+	if len(missing) > 0 {
+		ownFn := findKronkFunc(t, file, path, "loadDraftModelMTP")
+
+		var detail strings.Builder
+		for _, field := range missing {
+			fmt.Fprintf(&detail, "\n              %-20s copied by loadDraftModelMTPShared at %s",
+				field, srcPos(fset, root, shared[field]))
+		}
+
+		t.Errorf(`loadDraftModelMTP (%s) drops %d target context param(s) that loadDraftModelMTPShared copies: %s
+
+  bug:      findings2 §6f — the own-KV embedded-MTP draft context does not
+            inherit the target's KV cache topology.
+  missing:%s
+  copied:   %s
+  why it matters:
+            modelCtxParams sets KVUnified = 1 when nSeqMax > 1
+            (sdk/kronk/model/config.go:936-939) and NCtx = ContextWindow*nSeqMax.
+            At nSeqMax == 2 the target is unified with n_ctx_seq == 2*window,
+            while the MTP draft inherits NCtx but stays non-unified with
+            n_stream == 2, i.e. n_ctx_seq == window. Different topology and
+            half the per-seq draft capacity.
+            loadDraftModelMTPShared spells out the hazard at
+            sdk/kronk/model/draft_mtp.go:330-337.
+  exempt:   CtxOther (shared-KV only: it aliases the target's llama_memory and
+            comes from the target context handle, not from ContextParams).`,
+			srcPos(fset, root, ownFn.Pos()), len(missing), strings.Join(missing, ", "),
+			detail.String(), strings.Join(slices.Sorted(maps.Keys(own)), ", "))
+	}
+}
+
+// copiedCtxParamFields returns, for the function named name, every field
+// assigned directly from the function's llama.ContextParams parameter, mapped
+// to the position of the assignment.
+func copiedCtxParamFields(t *testing.T, fset *token.FileSet, file *ast.File, path string, name string) map[string]token.Pos {
+	t.Helper()
+
+	fd := findKronkFunc(t, file, path, name)
+
+	// Recover the identifier of the llama.ContextParams parameter rather than
+	// hard-coding "targetCtxParams", so a rename does not silently pass.
+	var src string
+	for _, p := range fd.Type.Params.List {
+		sel, ok := p.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		x, ok := sel.X.(*ast.Ident)
+		if !ok || x.Name != "llama" || sel.Sel.Name != "ContextParams" {
+			continue
+		}
+		if len(p.Names) > 0 {
+			src = p.Names[0].Name
+			break
+		}
+	}
+
+	if src == "" {
+		t.Fatalf("%s: %s has no named llama.ContextParams parameter; the test pins a signature that changed",
+			fset.Position(fd.Pos()), name)
+	}
+
+	out := make(map[string]token.Pos)
+
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+
+		for i, lhs := range assign.Lhs {
+			if i >= len(assign.Rhs) {
+				break
+			}
+
+			lsel, ok := lhs.(*ast.SelectorExpr)
+			if !ok {
+				continue
+			}
+
+			rsel, ok := assign.Rhs[i].(*ast.SelectorExpr)
+			if !ok {
+				continue
+			}
+
+			rx, ok := rsel.X.(*ast.Ident)
+			if !ok || rx.Name != src {
+				continue
+			}
+
+			out[lsel.Sel.Name] = lsel.Pos()
+		}
+
+		return true
+	})
+
+	if len(out) == 0 {
+		t.Fatalf("%s: found no `x.F = %s.F` assignments in %s", fset.Position(fd.Pos()), src, name)
+	}
+
+	return out
+}

--- a/sdk/kronk/model/params_temperature_test.go
+++ b/sdk/kronk/model/params_temperature_test.go
@@ -1,0 +1,150 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// newTempTestModel builds the minimum *Model needed to exercise the
+// parameter-resolution path. No GGUF is loaded: parseParams / adjustParams
+// only touch m.cfg, m.log and m.parser.
+func newTempTestModel() *Model {
+	return &Model{
+		cfg: Config{
+			PtrContextWindow: new(4096),
+		},
+		log: func(ctx context.Context, msg string, args ...any) {},
+	}
+}
+
+// TestParseParamsExplicitTemperatureZeroIsPreserved pins the temperature-0
+// rewrite bug described in findings2 §6a.
+//
+// sdk/kronk/model/params.go:725-727
+//
+//	if p.Temperature <= 0 {
+//		p.Temperature = DefTemp
+//	}
+//
+// adjustParams cannot distinguish "temperature was not supplied" (the zero
+// value of Params.Temperature) from "the caller explicitly asked for 0". An
+// explicit "temperature": 0 in the request document is therefore silently
+// rewritten to DefTemp (0.8), which makes deterministic / greedy decoding
+// unreachable through the public API.
+//
+// Greedy decoding is not cosmetic here: verifySpeculativeTokens
+// (batchgen_speculative.go:335) selects its verification branch with
+// `greedy := temperature == 0`, so the classic-drafter greedy verify path is
+// dead code as long as this rewrite stands, and no temperature-0 equivalence
+// test can be written for MTP.
+//
+// The non-zero and unset sub-tests are controls: they document the behaviour
+// that must NOT change when the guard is fixed.
+func TestParseParamsExplicitTemperatureZeroIsPreserved(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  D
+		want float32
+	}{
+		{name: "explicit zero float64", doc: D{"temperature": float64(0)}, want: 0},
+		{name: "explicit zero float32", doc: D{"temperature": float32(0)}, want: 0},
+		{name: "explicit zero int", doc: D{"temperature": 0}, want: 0},
+		{name: "explicit zero string", doc: D{"temperature": "0"}, want: 0},
+		{name: "explicit non-zero", doc: D{"temperature": 0.25}, want: 0.25},
+		{name: "unset falls back to DefTemp", doc: D{}, want: DefTemp},
+	}
+
+	m := newTempTestModel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// parseParams mirrors resolved values back into d, so render
+			// the request document before the call.
+			input := fmt.Sprintf("%#v", tt.doc)
+
+			p, err := m.parseParams(tt.doc)
+			if err != nil {
+				t.Fatalf("parseParams(%s): unexpected error: %v", input, err)
+			}
+
+			if p.Temperature != tt.want {
+				t.Errorf("parseParams(%s): resolved Temperature = %v, want %v\n"+
+					"params.go:725-727 rewrites any temperature <= 0 to DefTemp (%v), so an\n"+
+					"explicitly requested temperature of 0 cannot reach the sampler and\n"+
+					"deterministic/greedy decoding is unreachable via the public API.\n"+
+					"The guard must only apply when the caller did not supply a temperature.",
+					input, p.Temperature, tt.want, DefTemp)
+			}
+		})
+	}
+}
+
+// TestAdjustParamsKeepsExplicitTemperatureZero pins the same defect one layer
+// down, at sdk/kronk/model/params.go:725-727, without going through document
+// parsing. Config.DefaultParams flows straight into adjustParams, so a
+// deployment that configures a deterministic default temperature of 0 is
+// silently overridden to DefTemp too.
+func TestAdjustParamsKeepsExplicitTemperatureZero(t *testing.T) {
+	m := newTempTestModel()
+	m.cfg.DefaultParams = Params{Temperature: 0}
+
+	got := m.adjustParams(m.cfg.DefaultParams)
+
+	if got.Temperature != 0 {
+		t.Errorf("adjustParams(Params{Temperature: 0}).Temperature = %v, want 0\n"+
+			"params.go:725-727 uses `p.Temperature <= 0` as the not-set sentinel and\n"+
+			"rewrites a deliberate 0 to DefTemp (%v). Temperature 0 is a valid, meaningful\n"+
+			"request (greedy decoding), not an absent value.",
+			got.Temperature, DefTemp)
+	}
+}
+
+// TestAddParamsRoundTripsTemperatureZero pins the second half of findings2 §6a.
+//
+// sdk/kronk/model/params.go:372-374
+//
+//	if params.Temperature != 0 {
+//		d["temperature"] = params.Temperature
+//	}
+//
+// AddParams treats the zero value as "unset" for every field, but temperature 0
+// is a meaningful request (greedy decoding). Converting a typed Params back into
+// a D therefore drops it, so a Params carrying an explicit 0 cannot be
+// round-tripped through the document form that parseParams consumes.
+//
+// The non-zero sub-test is a control.
+func TestAddParamsRoundTripsTemperatureZero(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Params
+		want float32
+	}{
+		{name: "explicit zero", in: Params{Temperature: 0}, want: 0},
+		{name: "explicit non-zero", in: Params{Temperature: 0.25}, want: 0.25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := D{}
+			AddParams(tt.in, d)
+
+			val, exists := d["temperature"]
+			if !exists {
+				t.Fatalf("AddParams(Params{Temperature: %v}): key %q missing from D\n"+
+					"params.go:372-374 only copies a non-zero temperature, so an explicit 0 is\n"+
+					"dropped and the Params -> D conversion is lossy for greedy decoding.",
+					tt.in.Temperature, "temperature")
+			}
+
+			got, ok := val.(float32)
+			if !ok {
+				t.Fatalf("AddParams: d[\"temperature\"] has type %T, want float32", val)
+			}
+
+			if got != tt.want {
+				t.Errorf("AddParams: d[\"temperature\"] = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/kronk/model/rollback_draft_test.go
+++ b/sdk/kronk/model/rollback_draft_test.go
@@ -1,0 +1,151 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// rollbackDraftBasePast is a VERBATIM MIRROR of the base-position arithmetic
+// inside (*batchEngine).rollbackDraft:
+//
+//	sdk/kronk/model/batchgen_speculative.go:1002
+//		draftBasePast := s.draftNPast - llama.Pos(nDraft)
+//
+//	sdk/kronk/model/batchgen_speculative.go:969   (own-draft-KV MTP branch)
+//		draftBasePast := s.draftNPast - llama.Pos(nDraft)
+//
+// rollbackDraft itself calls llama.MemorySeqRm on a live draft context, so it
+// cannot be invoked without a loaded model. This mirror isolates the one piece
+// of the function that is pure arithmetic so the contract can be pinned in a
+// unit test.
+//
+// MAINTAINER: when batchgen_speculative.go:969/1002 is fixed, update this
+// mirror in the same commit so it keeps tracking the production formula.
+func rollbackDraftBasePast(draftNPast llama.Pos, nDraft int) llama.Pos {
+	return draftNPast - llama.Pos(nDraft)
+}
+
+// TestRollbackDraftBasePastRecoversDraftStartPast pins findings2 §6c: the
+// rollbackDraft off-by-one after an EOG-truncated draft.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_speculative.go:1002 (classic drafter)
+//   - sdk/kronk/model/batchgen_speculative.go:969  (own-draft-KV MTP)
+//
+// Both recompute the draft round's base KV position as
+// `s.draftNPast - llama.Pos(nDraft)`, i.e. they assume the draft context
+// advanced exactly one KV cell per RETURNED draft token.
+//
+// That assumption does not match llama.DraftGenerate's contract. yzma's
+// pkg/llama/draft.go increments its internal nPast immediately after a
+// successful llama_decode but BEFORE the EOG check, and on EOG it breaks out of
+// the loop before `drafted++`:
+//
+//	decode -> nPast++ -> sample -> [p_min early stop: break] ->
+//	  [EOG: break] -> outTokens[drafted] = token; drafted++
+//
+// So the number of decodes performed is `drafted` on a full round and on a
+// decode failure, but `drafted+1` when the round was truncated by EOG (or by
+// the p_min early stop). yzma's own draft_test.go encodes exactly this
+// ambiguity by asserting finalPast-startPast is in [drafted, drafted+1]. The
+// ambiguity is an upstream CONTRACT, not an upstream bug — the caller is
+// responsible for remembering where the round started.
+//
+// Kronk does capture it: generateDraftTokens saves
+// `draftStartPast := s.draftNPast` at batchgen_speculative.go:238, but then
+// only uses it for a log line at :286. It is never persisted on the slot, so
+// rollbackDraft has to reconstruct it — and reconstructs it wrong on every
+// EOG-truncated round. `draftBasePast` comes out one cell too high, the
+// MemorySeqRm trim leaves a stale cell behind, and s.draftNPast stays
+// misaligned with the target for the rest of the request.
+//
+// nDraft at the rollbackDraft call site is len(s.specDraftTokens)
+// (batchgen_speculative.go:331 via batchgen_engine.go:281), which is
+// s.draftTokensBuf[:drafted] — i.e. nDraft == drafted exactly.
+//
+// The fix is to persist generateDraftTokens' draftStartPast on the slot and use
+// it in rollbackDraft instead of subtracting nDraft.
+func TestRollbackDraftBasePastRecoversDraftStartPast(t *testing.T) {
+	// decodes is the number of successful llama_decode calls DraftGenerate
+	// made, i.e. finalPast-startPast. drafted is what it returned, which is
+	// what Kronk passes to rollbackDraft as nDraft.
+	tests := []struct {
+		name      string
+		startPast llama.Pos
+		nDraftReq int
+		decodes   int
+		drafted   int
+	}{
+		{
+			name:      "full round, no truncation",
+			startPast: 1000,
+			nDraftReq: 4,
+			decodes:   4,
+			drafted:   4,
+		},
+		{
+			name:      "EOG truncated after the third decode",
+			startPast: 1000,
+			nDraftReq: 4,
+			decodes:   3,
+			drafted:   2,
+		},
+		{
+			name:      "EOG truncated after the second decode",
+			startPast: 1000,
+			nDraftReq: 4,
+			decodes:   2,
+			drafted:   1,
+		},
+		{
+			name:      "decode error on the third iteration",
+			startPast: 1000,
+			nDraftReq: 4,
+			decodes:   2,
+			drafted:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Post-conditions of llama.DraftGenerate, as implemented in
+			// yzma pkg/llama/draft.go.
+			finalPast := tt.startPast + llama.Pos(tt.decodes)
+
+			if delta := int(finalPast - tt.startPast); delta != tt.drafted && delta != tt.drafted+1 {
+				t.Fatalf("bad test case: finalPast-startPast = %d, must be drafted (%d) or drafted+1 (%d)",
+					delta, tt.drafted, tt.drafted+1)
+			}
+
+			if tt.drafted > tt.nDraftReq || tt.decodes > tt.nDraftReq {
+				t.Fatalf("bad test case: DraftGenerate loops at most nDraft (%d) times, "+
+					"got decodes=%d drafted=%d", tt.nDraftReq, tt.decodes, tt.drafted)
+			}
+
+			// generateDraftTokens (batchgen_speculative.go:256-257) stores
+			// finalPast on the slot and truncates the token buffer to
+			// drafted, so this is the state rollbackDraft observes.
+			draftNPast := finalPast
+			nDraft := tt.drafted
+
+			got := rollbackDraftBasePast(draftNPast, nDraft)
+
+			if got != tt.startPast {
+				t.Errorf("rollbackDraft base position = %d, want %d (off by %d)\n"+
+					"batchgen_speculative.go:1002 (and :969) computes\n"+
+					"\tdraftBasePast := s.draftNPast - llama.Pos(nDraft)\n"+
+					"which assumes one draft-KV cell per RETURNED token. DraftGenerate performed "+
+					"%d decode(s) but returned %d token(s): on an EOG-truncated round it advances "+
+					"nPast before the EOG check and breaks before drafted++, so it consumed one "+
+					"more KV position than it reported.\n"+
+					"The recomputed base is too high, MemorySeqRm trims the wrong range and leaves "+
+					"a stale draft cell, and s.draftNPast stays misaligned with the target for the "+
+					"rest of the request.\n"+
+					"Fix: persist generateDraftTokens' draftStartPast (batchgen_speculative.go:238) "+
+					"on the slot and use it here instead of subtracting nDraft.",
+					got, tt.startPast, int(got-tt.startPast), tt.decodes, tt.drafted)
+			}
+		})
+	}
+}

--- a/sdk/kronk/model/speculative_deadcode_test.go
+++ b/sdk/kronk/model/speculative_deadcode_test.go
@@ -1,0 +1,198 @@
+package model
+
+import (
+	"go/ast"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestSpecDraftProbsIsReachable pins findings2 §6h: the dense probabilistic
+// verify path in batchgen_speculative.go is dead code.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_speculative.go:329
+//     draftProbs := s.specDraftProbs
+//   - sdk/kronk/model/batchgen_speculative.go:556-574
+//     the `qDraft := draftProbs[i][draftToken]` residual-sampling branch
+//   - sdk/kronk/model/batchgen_speculative.go:885
+//     sampleAdjustedInto, only called from that branch
+//
+// slot.specDraftProbs (batchgen_slot.go:156) is declared as the per-position
+// dense draft distribution used by rigorous speculative sampling, but every
+// assignment in the package sets it to nil:
+//
+//	batchgen_speculative.go:184, :261, :264, :378 and batchgen_slot.go:330
+//
+// With no producer, draftProbs at :329 is always nil, the residual-sampling
+// branch at :556-574 can never be taken, and sampleAdjustedInto at :885 is
+// unreachable. The comment at :546-554 describes this branch as a live
+// fallback, which is not true.
+//
+// This test walks the package AST rather than grepping so it survives line
+// drift, and it reports the nil-only assignment sites it found so a maintainer
+// can see the evidence. It passes once a producer assigns a real distribution,
+// or once the field and its dead consumers are deleted (in which case the
+// "field no longer exists" branch below reports that and the test should be
+// removed with them).
+func TestSpecDraftProbsIsReachable(t *testing.T) {
+	fset, files := parseModelPackage(t)
+
+	const field = "specDraftProbs"
+
+	var (
+		nilAssignments    []string
+		nonNilAssignments []string
+		referenced        bool
+	)
+
+	// assignsField reports whether lhs is a selector ending in .specDraftProbs.
+	assignsField := func(lhs ast.Expr) bool {
+		sel, ok := lhs.(*ast.SelectorExpr)
+
+		return ok && sel.Sel.Name == field
+	}
+
+	isNil := func(expr ast.Expr) bool {
+		ident, ok := expr.(*ast.Ident)
+
+		return ok && ident.Name == "nil"
+	}
+
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.SelectorExpr:
+				if node.Sel.Name == field {
+					referenced = true
+				}
+
+			case *ast.AssignStmt:
+				for i, lhs := range node.Lhs {
+					if !assignsField(lhs) {
+						continue
+					}
+
+					// A tuple assignment (len(Rhs) == 1, len(Lhs) > 1) cannot
+					// be proven nil, so treat it as a real producer.
+					if len(node.Rhs) != len(node.Lhs) || !isNil(node.Rhs[i]) {
+						nonNilAssignments = append(nonNilAssignments, posOf(fset, lhs))
+						continue
+					}
+
+					nilAssignments = append(nilAssignments, posOf(fset, lhs))
+				}
+
+			case *ast.KeyValueExpr:
+				// Composite-literal form: slot{specDraftProbs: x}.
+				key, ok := node.Key.(*ast.Ident)
+				if !ok || key.Name != field {
+					break
+				}
+
+				if isNil(node.Value) {
+					nilAssignments = append(nilAssignments, posOf(fset, node))
+					break
+				}
+
+				nonNilAssignments = append(nonNilAssignments, posOf(fset, node))
+			}
+
+			return true
+		})
+	}
+
+	if !referenced {
+		t.Fatalf("no reference to %s found in the package: the field was removed, "+
+			"so delete this test along with it", field)
+	}
+
+	if len(nonNilAssignments) == 0 {
+		t.Errorf("slot.%s is only ever assigned nil (%d site(s): %s), so the "+
+			"probabilistic verify path is unreachable dead code.\n"+
+			"batchgen_speculative.go:329 reads it into draftProbs, which is therefore always "+
+			"nil; the residual-sampling branch at :556-574 (qDraft := draftProbs[i][draftToken]) "+
+			"can never execute, and sampleAdjustedInto at :885 is never called. The comment at "+
+			":546-554 describes this as a live fallback.\n"+
+			"Either produce the dense draft distribution (so speculative sampling is actually "+
+			"rigorous) or delete the field, the branch and sampleAdjustedInto.",
+			field, len(nilAssignments), strings.Join(nilAssignments, ", "))
+	}
+}
+
+// docIdentifierRefs matches "batchEngine.someMethod" style references inside a
+// doc comment.
+var docIdentifierRefs = regexp.MustCompile(`batchEngine\.([A-Za-z_][A-Za-z0-9_]*)`)
+
+// TestChooseNDraftDocCommentReferencesRealMethods pins findings2 §8: the
+// chooseNDraft doc comment cites a method that does not exist.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_speculative.go:133-134
+//     "// The EMA is initialized to 1.0 at slot construction (see
+//     //  batchEngine.newSlot) and PERSISTS across requests on the same slot,"
+//
+// There is no batchEngine.newSlot. Slots — including the specAccEMA: 1.0
+// initialisation the comment is describing — are constructed inline in
+// newBatchEngine (batchgen_engine.go:51-57). A reader chasing the cited symbol
+// finds nothing, and the actual initialisation site is the one place a change
+// to the EMA's starting value would have to land.
+func TestChooseNDraftDocCommentReferencesRealMethods(t *testing.T) {
+	fset, files := parseModelPackage(t)
+
+	// Collect every method declared on batchEngine / *batchEngine.
+	var methods []string
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+				continue
+			}
+
+			recv := fn.Recv.List[0].Type
+			if star, ok := recv.(*ast.StarExpr); ok {
+				recv = star.X
+			}
+
+			if ident, ok := recv.(*ast.Ident); ok && ident.Name == "batchEngine" {
+				methods = append(methods, fn.Name.Name)
+			}
+		}
+	}
+
+	if len(methods) == 0 {
+		t.Fatal("no methods found on batchEngine: the AST matcher is stale, " +
+			"fix it before trusting this test")
+	}
+
+	var target *ast.FuncDecl
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "chooseNDraft" {
+				target = fn
+			}
+		}
+	}
+
+	if target == nil {
+		t.Fatal("chooseNDraft not found in the package")
+	}
+
+	if target.Doc == nil {
+		t.Fatal("chooseNDraft has no doc comment")
+	}
+
+	for _, match := range docIdentifierRefs.FindAllStringSubmatch(target.Doc.Text(), -1) {
+		if slices.Contains(methods, match[1]) {
+			continue
+		}
+
+		t.Errorf("%s: chooseNDraft's doc comment references batchEngine.%s, "+
+			"which does not exist.\n"+
+			"Slots (and the specAccEMA: 1.0 initialisation this sentence describes) are "+
+			"constructed inline in newBatchEngine, batchgen_engine.go:51-57. Point the "+
+			"comment at newBatchEngine.",
+			posOf(fset, target.Doc), match[1])
+	}
+}

--- a/sdk/kronk/tests/mtp/bonus_test.go
+++ b/sdk/kronk/tests/mtp/bonus_test.go
@@ -1,0 +1,239 @@
+package mtp_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// specSourceRel is the file under test, relative to the module root.
+const specSourceRel = "sdk/kronk/model/batchgen_speculative.go"
+
+// findModuleFile walks up from the working directory until it finds a
+// directory containing rel, and returns the joined path. Walking beats
+// runtime.Caller here because -trimpath rewrites compiled-in paths, and it
+// beats GITHUB_WORKSPACE because it works for a plain `go test ./...`.
+func findModuleFile(t *testing.T, rel string) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(dir, rel)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate %s by walking up from the test directory", rel)
+		}
+		dir = parent
+	}
+}
+
+// findFunc returns the top-level function declaration named name.
+func findFunc(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+
+	t.Fatalf("function %s not found in %s", name, specSourceRel)
+
+	return nil
+}
+
+// findBonusTokenBlock returns the `if accepted == nDraft { ... }` statement
+// inside fn — the block that samples the bonus token after a fully accepted
+// speculative round.
+func findBonusTokenBlock(t *testing.T, fn *ast.FuncDecl) *ast.IfStmt {
+	t.Helper()
+
+	var found *ast.IfStmt
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if found != nil {
+			return false
+		}
+
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+
+		bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok || bin.Op != token.EQL {
+			return true
+		}
+
+		x, xok := bin.X.(*ast.Ident)
+		y, yok := bin.Y.(*ast.Ident)
+		if xok && yok && x.Name == "accepted" && y.Name == "nDraft" {
+			found = ifStmt
+		}
+
+		return true
+	})
+
+	if found == nil {
+		t.Fatalf("could not find the `if accepted == nDraft` bonus-token block in "+
+			"verifySpeculativeTokens (%s). If the block was renamed or restructured, "+
+			"update this test to point at whatever now samples the bonus token.", specSourceRel)
+	}
+
+	return found
+}
+
+// callNames returns every function/method name called anywhere under n, as
+// the trailing identifier of the call target (so `llama.SamplerSample` and
+// `s.grammarSampler.SampleWithGrammar` come back as "SamplerSample" and
+// "SampleWithGrammar").
+func callNames(n ast.Node) map[string][]token.Pos {
+	out := map[string][]token.Pos{}
+
+	ast.Inspect(n, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			out[fn.Name] = append(out[fn.Name], call.Pos())
+		case *ast.SelectorExpr:
+			out[fn.Sel.Name] = append(out[fn.Sel.Name], call.Pos())
+		}
+
+		return true
+	})
+
+	return out
+}
+
+// positions renders fset positions as "file:line" for a failure message.
+func positions(fset *token.FileSet, ps []token.Pos) string {
+	var out []string
+	for _, p := range ps {
+		pos := fset.Position(p)
+		out = append(out, filepath.Base(pos.Filename)+":"+strconv.Itoa(pos.Line))
+	}
+
+	return strings.Join(out, ", ")
+}
+
+// =========================================================================
+
+// TestMTPBonusTokenGoesThroughSampler pins the second half of the
+// bonus-token bug: even when no grammar is attached, the token emitted after
+// a fully accepted speculative round skips the entire sampler chain.
+//
+// sdk/kronk/model/batchgen_speculative.go:353-356 forces greedy = true for
+// every MTP request. The `case greedy:` arm of the `if accepted == nDraft`
+// block at :582-602 then does:
+//
+//	maskSuppressTokenLogits(targetLogits, e.model.suppressTokens)
+//	bonusToken = argmax(targetLogits)          // :594-595
+//
+// so that token is a raw argmax over unfiltered target logits — no
+// repeat/frequency/presence penalties, no DRY, no top-k/top-p/min-p, no XTC,
+// no temperature, no dist sampler, no grammar. At the measured ~0.71
+// acceptance rate with defMTPNDraft = 2 that is roughly 15-30% of every
+// emitted token stream. The in-loop verify branch at :425-467 already does
+// the right thing; this block was simply not taught the same lesson.
+//
+// Upstream llama.cpp routes every position including the bonus through the
+// same chain — .extras/llama.cpp/common/sampling.cpp:646-674,
+// common_sampler_sample_and_accept_n.
+//
+// This is a source-analysis test on purpose. The behavioural alternatives —
+// "a repeat_penalty of 1.9 over 512 tokens should suppress repetition" or
+// "high temperature should produce more diversity than this" — are all
+// distributional claims over a sampled LLM, and none of them separate the
+// bug from ordinary model behaviour at a sample size that fits in a test
+// suite. A flaky test is worse than no test, so this asserts the invariant
+// directly and deterministically instead. The grammar half of the same bug
+// IS testable behaviourally and is covered by TestMTPGrammarBonusToken.
+//
+// NOTE: this test needs no model, but it lives in package mtp_test whose
+// TestMain skips the package when no MTP GGUF is present. Move it to
+// sdk/kronk/model if you want it to run on every CI machine.
+func TestMTPBonusTokenGoesThroughSampler(t *testing.T) {
+	src := findModuleFile(t, specSourceRel)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", src, err)
+	}
+
+	fn := findFunc(t, file, "verifySpeculativeTokens")
+	block := findBonusTokenBlock(t, fn)
+
+	blockLine := fset.Position(block.Pos()).Line
+	calls := callNames(block)
+
+	// The invariant: nothing in the bonus-token block may pick a token by
+	// raw argmax. Every emitted token must come from the slot's sampler
+	// chain, exactly like the in-loop verify branch at :425-467.
+	if ps, ok := calls["argmax"]; ok {
+		t.Errorf(`bonus-token block at %s:%d calls argmax() at %s.
+
+The token emitted after a fully accepted speculative round is therefore chosen
+by raw argmax over unfiltered target logits: no repeat/frequency/presence
+penalty, no DRY, no top-k/top-p/min-p, no XTC, no temperature, no dist sampler
+and no grammar. greedy is forced true for EVERY MTP request at
+%s:353-356, so this arm is taken on every fully accepted
+round — roughly 15-30%% of emitted tokens at the measured ~0.71 acceptance
+with defMTPNDraft = 2.
+
+Fix: mirror the in-loop branch at %s:425-467 —
+
+    switch {
+    case s.grammarSampler != nil && s.reasonFlag == 0:
+        bonusToken = s.grammarSampler.SampleWithGrammar(e.model.lctx, s.sampler, baseBatch+int32(nDraft))
+    default:
+        bonusToken = llama.SamplerSample(s.sampler, e.model.lctx, baseBatch+int32(nDraft))
+    }
+
+Upstream does the same for every position including the bonus:
+.extras/llama.cpp/common/sampling.cpp:646-674 (common_sampler_sample_and_accept_n).`,
+			specSourceRel, blockLine, positions(fset, ps), specSourceRel, specSourceRel)
+	}
+
+	// And the grammar must be consulted on every path out of this block.
+	if _, ok := calls["SampleWithGrammar"]; !ok {
+		t.Errorf(`bonus-token block at %s:%d never calls SampleWithGrammar.
+
+At least one path out of this block emits a token without asking the grammar
+sampler, so a grammar-constrained request can emit a token the grammar forbids.
+That token later reaches grammarSampler.Accept (grammar.go:436) via
+handleSampledToken (batchgen_tokens.go:60), where llama_grammar_accept_token
+throws an uncaught C++ std::runtime_error and aborts the process.
+
+Every arm of this block must go through
+s.grammarSampler.SampleWithGrammar when s.grammarSampler != nil &&
+s.reasonFlag == 0, and llama.SamplerSample otherwise — same as :425-467.`,
+			specSourceRel, blockLine)
+	}
+
+	if _, ok := calls["SamplerSample"]; !ok {
+		t.Errorf(`bonus-token block at %s:%d never calls llama.SamplerSample.
+
+The non-grammar path must still run the slot's sampler chain (penalties, DRY,
+top-k/top-p/min-p, XTC, temperature, dist) rather than reading logits directly.`,
+			specSourceRel, blockLine)
+	}
+}

--- a/sdk/kronk/tests/mtp/grammar_test.go
+++ b/sdk/kronk/tests/mtp/grammar_test.go
@@ -1,0 +1,595 @@
+package mtp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ardanlabs/kronk/sdk/kronk"
+	"github.com/ardanlabs/kronk/sdk/kronk/model"
+	"github.com/ardanlabs/kronk/sdk/kronk/tests/testlib"
+)
+
+// =========================================================================
+// Regression coverage for: MTP bonus token bypasses the sampler chain and
+// the grammar.
+//
+// sdk/kronk/model/batchgen_speculative.go:353-356 forces greedy = true for
+// every MTP request. The in-loop verify branch (:425-467) honours that
+// correctly and routes through s.grammarSampler.SampleWithGrammar or
+// llama.SamplerSample. The bonus-token block at :582-602 does not:
+//
+//	case greedy:                                   // true for every MTP request
+//	    maskSuppressTokenLogits(targetLogits, e.model.suppressTokens)
+//	    bonusToken = argmax(targetLogits)          // :594-595
+//
+// So on every fully-accepted speculative round the emitted bonus token is a
+// raw argmax over unfiltered target logits, bypassing penalties, DRY,
+// top-k/top-p/min-p, XTC, temperature, the dist sampler AND the grammar.
+//
+// When response_format / json_schema is in play (params.go:469,478,490 set
+// p.Grammar) the unconstrained bonus token then reaches
+// grammarSampler.Accept (grammar.go:436, via batchgen_tokens.go:60, via
+// finalizeSpeculativeTokens at batchgen_speculative.go:762).
+// llama_grammar_accept_token throws std::runtime_error, the C++ exception
+// unwinds through libffi, and the whole process dies on SIGABRT:
+//
+//	libc++abi: terminating due to uncaught exception of type std::runtime_error:
+//	  Unexpected empty grammar stack after accepting piece: } (92)
+//
+// Upstream llama.cpp samples every position INCLUDING the bonus through the
+// same sampler chain and grammar — see
+// .extras/llama.cpp/common/sampling.cpp:646-674
+// (common_sampler_sample_and_accept_n).
+//
+// Because the failure mode is a process abort rather than a Go panic (yzma
+// has no recover() in pkg/, and a Go recover() cannot catch a C++ exception
+// unwinding through libffi anyway), the model work runs in a CHILD copy of
+// this test binary. The parent inspects the child's exit status and output
+// so a SIGABRT produces an actionable failure instead of silently taking the
+// package down.
+// =========================================================================
+
+const (
+	// grammarChildEnv gates the child worker. The parent sets it when it
+	// re-executes this test binary.
+	grammarChildEnv = "KRONK_MTP_GRAMMAR_CHILD"
+
+	// grammarChildTest is the only test the child is allowed to run.
+	grammarChildTest = "TestMTPGrammarChildWorker"
+
+	// grammarRuns is how many identical json_schema requests the child
+	// issues. The original repro aborted on run 2 of 5; 8 keeps the wall
+	// clock sane (~65 tok/s, 300 max_tokens) while giving the ~15-30% of
+	// bonus-sampled tokens plenty of chances to leave the grammar.
+	grammarRuns = 8
+
+	// Markers the child prints on stdout for the parent to parse. They are
+	// deliberately greppable and survive interleaving with llama.cpp's own
+	// stderr chatter.
+	markerRun     = "MTPGRAMMAR-RUN:"
+	markerInvalid = "MTPGRAMMAR-INVALID:"
+	markerChatErr = "MTPGRAMMAR-CHATERR:"
+	markerDone    = "MTPGRAMMAR-DONE:"
+)
+
+// grammarChildTimeout bounds the whole child run: one ~39 GB model load plus
+// grammarRuns generations.
+const grammarChildTimeout = 25 * time.Minute
+
+// grammarSchema is a strict object schema. Every field is required and
+// additionalProperties is false, so any token the grammar would have
+// forbidden is either rejected by llama_grammar_accept_token (abort) or
+// shows up as malformed JSON.
+func grammarSchema() model.D {
+	return model.D{
+		"type": "object",
+		"properties": model.D{
+			"planet":   model.D{"type": "string"},
+			"diameter": model.D{"type": "number"},
+			"moons":    model.D{"type": "integer"},
+			"summary":  model.D{"type": "string"},
+		},
+		"required":             []string{"planet", "diameter", "moons", "summary"},
+		"additionalProperties": false,
+	}
+}
+
+// grammarRequest builds the json_schema chat request used by both the MTP
+// child and the non-MTP control.
+func grammarRequest() model.D {
+	return model.D{
+		"messages": []model.D{
+			{"role": "user", "content": "Describe Jupiter with a two-sentence summary."},
+		},
+		"max_tokens":      300,
+		"enable_thinking": false,
+		"response_format": model.D{
+			"type": "json_schema",
+			"json_schema": model.D{
+				"name":   "planet",
+				"strict": true,
+				"schema": grammarSchema(),
+			},
+		},
+	}
+}
+
+// =========================================================================
+
+// grammarOutcome is the parent's view of one child run.
+type grammarOutcome struct {
+	// aborted is true when the child was killed by the uncaught C++ grammar
+	// exception — either observed as a signal in the wait status or as the
+	// runtime's SIGABRT traceback in its output (see abortNeedles).
+	aborted  bool
+	signal   syscall.Signal
+	exitCode int
+
+	// runsSeen / runsValid count the markers the child managed to print
+	// before it died (or finished).
+	runsSeen  int
+	runsValid int
+
+	// invalid holds one line per run whose output failed encoding/json
+	// parsing — the grammar was bypassed but the process survived.
+	invalid []string
+
+	// chatErrs holds one line per run whose Chat call returned an error.
+	chatErrs []string
+
+	// completed is true when the child printed its DONE marker.
+	completed bool
+
+	stdout string
+	stderr string
+	err    error
+}
+
+// abortNeedles are the strings that identify a process death inside
+// llama_grammar_accept_token. Matching on output rather than only on the
+// wait status matters: the Go runtime installs its own fatal-signal handler,
+// prints "SIGABRT: abort" plus a traceback, and then exits with status 2
+// instead of re-raising, so WaitStatus.Signaled() is false even though the
+// process was killed by the uncaught C++ exception.
+var abortNeedles = []string{
+	"empty grammar stack",
+	"uncaught exception",
+	"libc++abi",
+	"llama_grammar_accept_token",
+	"SIGABRT",
+}
+
+// death describes how the child process ended.
+func (o grammarOutcome) death() string {
+	if o.signal != 0 {
+		return "signal " + o.signal.String()
+	}
+
+	return "exit status " + strconv.Itoa(o.exitCode)
+}
+
+// abortEvidence returns the lines that prove the child died inside
+// llama_grammar_accept_token, or "" when none are present.
+func (o grammarOutcome) abortEvidence() string {
+	var hits []string
+
+	for line := range strings.SplitSeq(o.stdout+"\n"+o.stderr, "\n") {
+		for _, n := range abortNeedles {
+			if strings.Contains(line, n) {
+				hits = append(hits, strings.TrimSpace(line))
+				break
+			}
+		}
+	}
+
+	return strings.Join(hits, "\n\t")
+}
+
+// crashExcerpt returns the n lines of the child's output starting at the
+// first abort marker — the C++ message plus the head of the Go traceback,
+// which is the part a maintainer needs. Plain tailing lands in the register
+// dump at the end and shows nothing useful.
+func (o grammarOutcome) crashExcerpt(n int) string {
+	lines := strings.Split(o.stdout+"\n"+o.stderr, "\n")
+
+	start := -1
+	for i, line := range lines {
+		for _, needle := range abortNeedles {
+			if strings.Contains(line, needle) {
+				start = i
+				break
+			}
+		}
+		if start >= 0 {
+			break
+		}
+	}
+
+	if start < 0 {
+		return tail(o.stderr, n)
+	}
+
+	end := min(start+n, len(lines))
+
+	return strings.Join(lines[start:end], "\n\t")
+}
+
+// runGrammarChild re-executes this test binary with only the child worker
+// selected, and reports what happened. It is memoized because a single child
+// run costs one ~39 GB model load and both TestMTPGrammarBonusToken and
+// TestMTPGrammarValidityMatchesNonMTP need the same evidence. Loading the
+// target twice would be pure waste.
+var runGrammarChild = sync.OnceValue(func() grammarOutcome {
+	exe, err := os.Executable()
+	if err != nil {
+		return grammarOutcome{err: fmt.Errorf("locating test binary: %w", err)}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), grammarChildTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe,
+		"-test.run=^"+grammarChildTest+"$",
+		"-test.v",
+		"-test.count=1",
+		"-test.timeout="+grammarChildTimeout.String(),
+	)
+	cmd.Env = append(os.Environ(), grammarChildEnv+"=1")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	o := grammarOutcome{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+	}
+
+	var ee *exec.ExitError
+	switch {
+	case runErr == nil:
+	case errors.As(runErr, &ee):
+		o.exitCode = ee.ExitCode()
+		if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			o.aborted = true
+			o.signal = ws.Signal()
+		}
+	default:
+		o.err = fmt.Errorf("running child %s: %w", grammarChildTest, runErr)
+		return o
+	}
+
+	for line := range strings.SplitSeq(o.stdout, "\n") {
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.Contains(line, markerRun):
+			o.runsSeen++
+			if strings.Contains(line, "valid=true") {
+				o.runsValid++
+			}
+
+		case strings.Contains(line, markerInvalid):
+			o.invalid = append(o.invalid, line)
+
+		case strings.Contains(line, markerChatErr):
+			o.chatErrs = append(o.chatErrs, line)
+
+		case strings.Contains(line, markerDone):
+			o.completed = true
+		}
+	}
+
+	// The Go runtime swallows the signal and exits 2 (see abortNeedles), so
+	// treat matching output as an abort even when Signaled() is false.
+	if !o.aborted && o.abortEvidence() != "" {
+		o.aborted = true
+	}
+
+	return o
+})
+
+// tail returns the last n lines of s, for embedding child output in a
+// failure message without dumping the entire llama.cpp load log.
+func tail(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	return strings.Join(lines, "\n\t")
+}
+
+// =========================================================================
+
+// TestMTPGrammarChildWorker is the worker half of the subprocess harness. It
+// is a no-op unless the parent set grammarChildEnv, so a normal `go test`
+// run of this package skips it and the parent drives it explicitly.
+//
+// It issues grammarRuns identical response_format=json_schema requests
+// against the MTP target and validates every response with encoding/json. It
+// may be killed mid-run by SIGABRT from llama_grammar_accept_token — that is
+// the point, and why the assertions live in the parent.
+func TestMTPGrammarChildWorker(t *testing.T) {
+	if os.Getenv(grammarChildEnv) == "" {
+		t.Skipf("worker for the subprocess harness; set %s to run directly", grammarChildEnv)
+	}
+
+	cfg := testlib.CfgMTPChat()
+	if len(cfg.ModelFiles) == 0 {
+		t.Skip("no MTP model available")
+	}
+
+	krn, err := kronk.New(model.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("loading MTP target %v: %v", cfg.ModelFiles, err)
+	}
+
+	defer func() {
+		if err := krn.Unload(context.Background()); err != nil {
+			t.Errorf("unloading model: %v", err)
+		}
+	}()
+
+	d := grammarRequest()
+
+	for i := range grammarRuns {
+		ctx, cancel := context.WithTimeout(context.Background(), testlib.TestDuration)
+		resp, err := krn.Chat(ctx, d)
+		cancel()
+
+		if err != nil {
+			fmt.Printf("%s run=%d err=%v\n", markerChatErr, i, err)
+			continue
+		}
+
+		var body string
+		if len(resp.Choices) > 0 {
+			body = resp.Choices[0].Message.Content
+		}
+
+		var out map[string]any
+		jsonErr := json.Unmarshal([]byte(body), &out)
+
+		var draft, accepted int
+		if resp.Usage != nil {
+			draft, accepted = resp.Usage.DraftTokens, resp.Usage.DraftAcceptedTokens
+		}
+
+		fmt.Printf("%s run=%d valid=%t draft=%d accepted=%d\n",
+			markerRun, i, jsonErr == nil, draft, accepted)
+
+		if jsonErr != nil {
+			fmt.Printf("%s run=%d err=%q body=%q\n",
+				markerInvalid, i, jsonErr.Error(), body)
+		}
+	}
+
+	fmt.Printf("%s runs=%d\n", markerDone, grammarRuns)
+}
+
+// TestMTPGrammarBonusToken pins the headline bug: with an MTP drafter
+// active, a grammar-constrained request emits tokens the grammar forbids,
+// because the bonus token at batchgen_speculative.go:582-602 takes the
+// `case greedy:` arm and is produced by argmax over raw target logits
+// instead of s.grammarSampler / s.sampler.
+//
+// Two distinct observable failures, same root cause:
+//
+//	(a) the child dies on SIGABRT — the out-of-grammar token reached
+//	    grammarSampler.Accept and llama_grammar_accept_token threw;
+//	(b) the child survives but returns malformed JSON — the grammar was
+//	    bypassed and the emitted text left the schema.
+//
+// Either one fails this test. The fix is to route the bonus token through
+// the same branch the in-loop verify uses at :425-467.
+func TestMTPGrammarBonusToken(t *testing.T) {
+	o := runGrammarChild()
+	if o.err != nil {
+		t.Fatalf("subprocess harness failed to run: %v", o.err)
+	}
+
+	t.Logf("child: runs=%d valid=%d invalid=%d chat-errors=%d completed=%t exit=%d",
+		o.runsSeen, o.runsValid, len(o.invalid), len(o.chatErrs), o.completed, o.exitCode)
+
+	if o.aborted {
+		t.Errorf(`MTP + grammar aborted the process (%s) after %d/%d completed requests.
+
+An out-of-grammar token reached llama_grammar_accept_token. Source:
+  sdk/kronk/model/batchgen_speculative.go:582-602 — the "case greedy:" arm of the
+  "accepted == nDraft" block emits argmax(targetLogits) (:594-595) with no grammar
+  and no sampler chain. greedy is forced true for every MTP request at :353-356.
+  The token then flows finalizeSpeculativeTokens (:762) -> handleSpeculativeToken ->
+  handleSampledToken (batchgen_tokens.go:60) -> grammarSampler.Accept (grammar.go:436)
+  -> llama.SamplerAccept -> llama_grammar_accept_token, which throws.
+
+The C++ exception cannot be recovered from Go, so this kills the whole process,
+not just the request.
+
+Fix: mirror the in-loop branch at :425-467 — sample the bonus token with
+s.grammarSampler.SampleWithGrammar (or llama.SamplerSample) instead of argmax.
+Upstream does exactly this for every position including the bonus:
+.extras/llama.cpp/common/sampling.cpp:646-674.
+
+Child evidence:
+	%s
+
+Child crash excerpt:
+	%s`, o.death(), o.runsSeen, grammarRuns, o.abortEvidence(), o.crashExcerpt(40))
+
+		return
+	}
+
+	for _, line := range o.invalid {
+		t.Errorf(`MTP + grammar produced output that is not valid JSON, so the grammar did not
+constrain every emitted token: %s
+
+Source: sdk/kronk/model/batchgen_speculative.go:594-595 emits the bonus token as
+argmax over raw target logits, bypassing s.grammarSampler.`, line)
+	}
+
+	for _, line := range o.chatErrs {
+		t.Errorf("MTP + grammar request failed: %s", line)
+	}
+
+	if !o.completed {
+		t.Errorf(`child worker did not reach its DONE marker (exit=%d, %d/%d runs reported)
+without a signal — it exited early for an unexpected reason.
+
+Child stdout tail:
+	%s
+
+Child stderr tail:
+	%s`, o.exitCode, o.runsSeen, grammarRuns, tail(o.stdout, 25), tail(o.stderr, 25))
+
+		return
+	}
+
+	if o.runsSeen != grammarRuns {
+		t.Errorf("child reported %d runs, want %d", o.runsSeen, grammarRuns)
+	}
+}
+
+// TestMTPGrammarValidityMatchesNonMTP is the guard: a json_schema request is
+// a hard constraint, so its validity rate must be 1.0 regardless of whether
+// a drafter is attached. It runs the identical request against a NON-MTP
+// target in this process to establish that 1.0 is achievable with the same
+// schema and prompt, then compares it against the MTP child's rate.
+//
+// A gap between the two rates is the signature of the bonus-token bypass at
+// sdk/kronk/model/batchgen_speculative.go:582-602: the non-MTP path never
+// forces greedy (:353-356 is skipped) so every token stays inside
+// s.grammarSampler.
+func TestMTPGrammarValidityMatchesNonMTP(t *testing.T) {
+	// Preference order: the same Qwen3.6-35B-A3B base WITHOUT the MTP head
+	// isolates the drafter as the only variable; Qwen3-8B is an acceptable
+	// second choice when only it is on disk.
+	candidates := []struct {
+		name string
+		cfg  model.Config
+	}{
+		{"Qwen3.6-35B-A3B (no MTP head)", testlib.CfgHybridChat()},
+		{"Qwen3-8B", testlib.CfgThinkToolChat()},
+	}
+
+	var ctlName string
+	var ctlCfg model.Config
+	for _, c := range candidates {
+		if len(c.cfg.ModelFiles) != 0 {
+			ctlName, ctlCfg = c.name, c.cfg
+			break
+		}
+	}
+
+	if ctlName == "" {
+		t.Skip("no non-MTP control model downloaded")
+	}
+
+	t.Logf("non-MTP control: %s (%v)", ctlName, ctlCfg.ModelFiles)
+
+	ctlValid, ctlRuns := grammarControlRate(t, ctlCfg)
+
+	o := runGrammarChild()
+	if o.err != nil {
+		t.Fatalf("subprocess harness failed to run: %v", o.err)
+	}
+
+	ctlRate := float64(ctlValid) / float64(ctlRuns)
+	mtpRate := float64(o.runsValid) / float64(grammarRuns)
+
+	t.Logf("json_schema validity: non-MTP %d/%d (%.2f), MTP %d/%d (%.2f, aborted=%t)",
+		ctlValid, ctlRuns, ctlRate, o.runsValid, grammarRuns, mtpRate, o.aborted)
+
+	if ctlRate != 1.0 {
+		t.Fatalf(`non-MTP control produced %d/%d valid JSON responses — the control itself is
+broken, so this test cannot attribute anything to MTP. Investigate the grammar
+path before reading the MTP result below.`, ctlValid, ctlRuns)
+	}
+
+	switch {
+	case o.aborted:
+		t.Errorf(`non-MTP + grammar: %d/%d valid. MTP + grammar: process died after
+%d/%d requests.
+
+The same request is a 100%% hard constraint without a drafter and kills the
+process with one. Root cause: sdk/kronk/model/batchgen_speculative.go:594-595
+emits the bonus token as argmax over raw target logits with no grammar, and
+:353-356 forces that arm for every MTP request.
+
+Child evidence:
+	%s`,
+			ctlValid, ctlRuns, o.runsSeen, grammarRuns, o.abortEvidence())
+
+	case mtpRate != 1.0:
+		t.Errorf(`json_schema validity dropped with MTP enabled: non-MTP %d/%d (%.2f) vs
+MTP %d/%d (%.2f). A grammar is a hard constraint — both must be 1.00.
+
+Root cause: sdk/kronk/model/batchgen_speculative.go:594-595 emits the bonus
+token as argmax over raw target logits with no grammar; :353-356 forces that
+arm for every MTP request. Invalid runs:
+	%s`,
+			ctlValid, ctlRuns, ctlRate, o.runsValid, grammarRuns, mtpRate,
+			strings.Join(o.invalid, "\n\t"))
+	}
+}
+
+// grammarControlRate runs the same json_schema request against a non-MTP
+// target and reports how many responses parsed as JSON. It loads and unloads
+// the control model itself so the MTP child never shares the box with it.
+func grammarControlRate(t *testing.T, cfg model.Config) (valid int, runs int) {
+	t.Helper()
+
+	krn, err := kronk.New(model.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("loading non-MTP control %v: %v", cfg.ModelFiles, err)
+	}
+
+	defer func() {
+		if err := krn.Unload(context.Background()); err != nil {
+			t.Errorf("unloading control model: %v", err)
+		}
+	}()
+
+	d := grammarRequest()
+
+	for i := range grammarRuns {
+		ctx, cancel := context.WithTimeout(context.Background(), testlib.TestDuration)
+		resp, err := krn.Chat(ctx, d)
+		cancel()
+
+		runs++
+
+		if err != nil {
+			t.Errorf("control run %d: chat: %v", i, err)
+			continue
+		}
+
+		var body string
+		if len(resp.Choices) > 0 {
+			body = resp.Choices[0].Message.Content
+		}
+
+		var out map[string]any
+		if err := json.Unmarshal([]byte(body), &out); err != nil {
+			t.Logf("control run %d: invalid JSON: %v: %q", i, err, body)
+			continue
+		}
+
+		valid++
+	}
+
+	return valid, runs
+}


### PR DESCRIPTION
findings.md document the investigation (verified against llama.cpp b10211, yzma v1.21.0, and live Qwen3.6-35B MTP runs); the tests below pin each finding and FAIL on purpose until it's fixed.

The headline bug is batchgen_speculative.go:593-595: MTP's bonus token is a raw argmax over unfiltered logits, bypassing the sampler chain and the grammar. With json_schema active it aborts the process (reproduced, run 2 of 5).

- params_temperature_test.go       temperature 0 rewritten to 0.8, dropped by AddParams
- rollback_draft_test.go           rollbackDraft off-by-one after EOG-truncated draft
- memory_seqrm_checked_test.go     partial-range MemorySeqRm result discarded
- speculative_deadcode_test.go     specDraftProbs always nil; dead verify branch
- mtp_ctxparams_source_test.go     NRsSeq unset; StateSeq* missing PARTIAL_ONLY
- doc_comment_claims_test.go       four stale comments that contradict the code
- tests/mtp/bonus_test.go          AST: bonus block must route through the sampler
- tests/mtp/grammar_test.go        live json_schema repro, re-exec'd child survives SIGABRT

Reviewer notes: model/ tests have no build tag and will go red in CI. tests/mtp/ has never run at all — testlib.go:72 resolves a Q2_K_XL model that isn't in the catalog, so TestMain always skips.