### PR TITLE
tests: pin audit findings for MTP reasoning derailment

### DIFF
--- a/findings2.md
+++ b/findings2.md
@@ -1,0 +1,872 @@
+# Kronk — MTP / reasoning-derailment findings
+
+`unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL` (hybrid recurrent+attention MoE, MTP speculative decoding,
+Metal), verified against llama.cpp **b10211** and yzma **v1.21.0**. llama.cpp's own `server`/`common`
+code is the reference; each finding is a divergence from it. No production source was modified. Every
+finding is pinned by a test that fails on purpose until fixed.
+
+yzma defects are in **`yzma-findings.md`** (separate, standalone). Round 1 is in `findings.md`.
+
+Reported symptoms: (1) the model contradicts what it said earlier; (2) it starts a task and drops it
+mid-way. **(2) is reproduced and attributed to Kronk — §14.** (1) is partially reproduced but
+statistically underpowered — §14e.
+
+| # | Issue | Sev | Explains |
+|---|---|---|---|
+| §14 | Completed tool call discarded, reported as a clean `stop` | HIGH | **task abandonment (reproduced)** |
+| §14a | No `length` finish reason, so truncation is undetectable | HIGH | task abandonment |
+| §8a/§8b | Post-render regex mangles assistant headers, deletes bytes from user messages | HIGH | contradiction |
+| §8c | In-turn `reasoning_content` deleted where the template replays it | HIGH | contradiction |
+| §5 | IMC decode treats `llama_decode` failure as success → permanently truncated context | HIGH | both |
+| §2 | Model's own `general.sampling.*` defaults read then discarded | HIGH | contradiction/looping |
+| §9 | Every token accepted into the sampler chain twice | HIGH | looping |
+| §6a/§12c | Released slot's staged rows decoded into a reassigned sequence | HIGH | both |
+| §12a | Tool call held in the parser buffer discarded at EOG — no drain | HIGH | task abandonment |
+| §11a | Embedding NULL result escalated to a permanent engine kill | HIGH | — |
+| §10a | MTP never deactivates when Kronk's own throttle/disable logic fires | MED-HIGH | both |
+| §2b/§2d/§12b | DRY unusable; penalty window never seeded with the prompt | MED-HIGH | looping |
+| §3 | Draft width never clamped by remaining context or token budget | MED-HIGH | — |
+| §6b | Engine-global `promptBuf` aliased onto every slot | MED-HIGH | both |
+| §2e | Speculative verify samples from an unpenalized distribution | MED | looping |
+| §11b | Rerank pair omits the `[EOS][SEP]` boundary | MED | — |
+| §3b, §3c, §4, §8d, §9b, §10c, §12d, §12e, §1a, §1b, §5b, §6c, §8e | see sections | MED–LOW | — |
+
+Marked **(may be intended — confirm)**: §1a, §2, §3c, §4, §8c. Kronk deliberately provides no way to
+disable MTP from configuration; that is not reported (§10 covers only the deactivation defects).
+
+Fix order: §5 and §12a/§14 first (small, localized, silently destroy user-visible work), then §8a-§8c
+(one function, corrupts every agentic turn), then §2 with §9 (they interact — the anti-repetition
+machinery is currently either off or corrupt), then §10a.
+
+Per `AGENTS.md` this is a source change requiring `plan-change` and an approved plan.
+
+---
+
+## 0. Verified facts about the model itself
+
+Read directly from the GGUF with a strict parser (all 55 KV pairs consumed cleanly — the
+vendored `gguf-py` dump script is unusable here, it needs numpy which isn't installed):
+
+| Key | Value |
+|---|---|
+| `general.sampling.top_k` | **20** |
+| `general.sampling.top_p` | **0.95** |
+| `general.sampling.temp` | **1.0** |
+| `qwen35moe.nextn_predict_layers` | **1** |
+| `qwen35moe.context_length` | 262144 |
+| `qwen35moe.rope.freq_base` | 10000000.0 |
+| `qwen35moe.rope.dimension_sections` | [11, 11, 10, 0] |
+| `tokenizer.ggml.add_bos_token` | **False** |
+| `tokenizer.ggml.eos_token_id` | 248046 |
+
+Three of these directly contradict Kronk's behaviour and drive §2 and §3 below. There are **no
+SWA / sliding-window keys in the file at all**, which is the first half of the answer to the
+sliding-window hypothesis.
+
+---
+
+## 1. Sliding-window attention — two SWA bookkeeping defects
+
+*This model has `n_swa == 0` (no `attention.sliding_window` key; hybrid attention + recurrent), so SWA
+is not a source of wrong output here. The two defects below are real regardless: they concern how Kronk
+reports and sizes SWA state, and they will matter on any model that does use a window.*
+
+### 1a. `calculateVRAMDiag` sizes the SWA KV cache with the wrong nil-default — MED
+
+`model.go:1331` passes `SWAFull: cfg.SWAFull()`, and that accessor (`config.go:445-448`) returns
+`boolOr(PtrSWAFull, false)` — its own doc says callers needing the *effective* value must inspect
+`PtrSWAFull` directly. Since `config.go:961-967` only overwrites when the pointer is non-nil, unset
+means **true** at runtime. `gguf/kvcache.go:83-89` (a faithful port of the upstream allocator) then
+shrinks SWA layers to `PAD(min(base, n_swa*seq+n_ubatch), 256)`, under-reporting
+`ModelInfo.SlotMemory` / `VRAMTotal` — while `pool/llama.go:315-319` and
+`sdk/tools/models/analyze.go:271` resolve nil to **true** for the same config, so the two estimates
+disagree with each other. Pinned by `TestCalculateVRAMDiagResolvesEffectiveSWAFull`.
+
+### 1b. Effective `n_swa` is never surfaced — LOW
+
+`model.go:637-643` logs only the *requested* `ctxParams.SwaFull`, and `sdk/kronk/init.go:134-140`
+mutes llama.cpp's own load banner by default (which prints `n_swa = %u` at
+`llama-model.cpp:1785`). yzma already exports `llama.ModelNSWA`
+(`.extras/yzma/pkg/llama/model.go:534`) and **nothing under `sdk/` calls it**. Establishing the
+headline fact above required dumping the GGUF and reading llama.cpp's per-arch loader by hand — an
+operator cannot distinguish a windowed model on a compact cache from a non-SWA model.
+Pinned by `TestKronkSurfacesEffectiveNSWA`.
+
+Adjacent, not pinned: `gguf.ParseAttentionFacts` / `CalculateKVCache` have no notion of recurrent
+layers, so all 41 `qwen35moe` blocks are sized as attention KV though only ~10 are (over-estimates,
+so safe).
+
+---
+
+## 2. Kronk ignores the model's own recommended sampling parameters — HIGH
+
+*Distinct from `findings.md` §6a: that finding is that temperature 0 is unreachable (a clamp bug).
+This one is that the model's own shipped defaults are read and then thrown away.*
+
+`params.go:688-760` hardcodes `DefTemp = 0.8`, `DefTopK = 40`, `DefTopP = 0.9`. The model ships
+`general.sampling.temp = 1.0`, `top_k = 20`, `top_p = 0.95` (§0), and
+**`models.go:119-146` already loads those keys** — they are read and then never used for defaults.
+
+llama.cpp copies GGUF sampling metadata into `common_params_sampling` on every model load unless
+the caller explicitly overrode that field (`common/common.cpp:1142-1198`, called at `:1266`).
+
+So the default serving configuration runs Qwen3.6 at a **lower temperature on a more aggressively
+nucleus-clipped candidate set** than the model was tuned for. That is the documented
+repetition-and-derailment regime for Qwen reasoning models, and it applies to every request that
+doesn't override all three values.
+
+Pinned by `TestSamplingDefaultsHonorGGUFMetadata`.
+
+### 2b. DRY is a silent no-op unless explicitly given a positive window — MED-HIGH
+
+`DefDryPenaltyLast = 0` (`params.go:37`, applied `:701-703`, used `:791`). Both "unset" and
+llama.cpp's `-1` sentinel (= context size) collapse to `0`, and `0` means **DRY disabled** — a
+zero-length ring buffer whose `apply()` returns immediately (`src/llama-sampler.cpp:3200-3205`,
+`:2939`). Meanwhile `params.go:792` **logs DRY as active**.
+
+The one anti-repetition sampler a user would reach for to fix a loop cannot be turned on.
+Reference: `common/common.h:245`, `server-schema.cpp:151-155`, `:557-559`.
+Pinned by `TestParseParamsDryPenaltyLastKeepsDryEnabled`.
+
+### 2c. `repeat_last_n` loses both of llama.cpp's sentinels — MED
+
+`params.go:717-719` maps anything `<= 0` to `64`. Upstream: `-1` = penalize the whole context,
+`0` = penalties **off** (`common/common.h:238`, `server-schema.cpp:126-128`, `:552-555`). A caller
+disabling the repeat penalty instead gets it applied over a 64-token window — which in long
+reasoning output suppresses exactly the connective and identifier tokens that hold a chain of
+thought together. Pinned by `TestParseParamsRepeatLastNSentinels`.
+
+### 2d. Penalty / DRY history is never seeded with the prompt — MED
+
+The only accept site is `batchgen_tokens.go:63`; the chain is created at
+`batchgen_slot_start.go:96-97`. llama.cpp accepts **every prompt token** into the chain before
+generation begins (`server-context.cpp:375-393`, `init_sampler`, called at `:3571`), so penalties
+and DRY span the whole conversation.
+
+Kronk's penalty window contains only the current turn's output. Each new turn therefore starts
+penalty-free over everything it just said — so the model is free to re-say it. For a multi-turn
+reasoning conversation this is a direct mechanism for the reported "I already said that" loop.
+Pinned by `TestSamplerPenaltyHistoryIsSeededWithPrompt`.
+
+(Per-request reset itself is correct: a fresh chain per request, freed at `batchgen_finish.go:444`.)
+
+### 2e. Speculative verification samples from a different distribution than the real chain — MED
+
+`logprobs.go:129` (`applySamplerFilters`, called from `batchgen_speculative.go:498`, `:543`, `:599`)
+is a hand-rolled filter: suppress → top-k → top-p → min-p → temp. **No Penalties, no DRY, no XTC.**
+The chain the request actually uses is built at `params.go:783-825`.
+
+So `p_target` / `q_draft` and the rejection resample all come from an *unpenalized* distribution.
+Enabling MTP silently disables repetition control on the verified positions. llama.cpp verifies
+every draft position through the identical full chain
+(`server-context.cpp:3862` → `common/sampling.cpp:646-674`).
+
+This is **distinct from** the round-1 bonus-token bypass — that was one token per fully-accepted
+round; this is every verified position. Pinned by `TestSpeculativeVerifyTargetProbsIncludePenalties`.
+
+### 2f. Adaptive-p is mis-ordered and then discarded — MED-LOW
+
+`params.go:813-816` appends adaptive-p, then `:819-821` appends temp and `:823-825` appends `dist`
+unconditionally. adaptive-p is a *selecting* sampler that overwrites all logits with a
+peak-at-target curve; llama.cpp appends it **last and instead of** `dist`
+(`common/sampling.cpp:363-381`, `src/llama-sampler.cpp:3311-3373`). As written, adaptive-p's pick is
+thrown away, its EMA never updates, and the emitted token is drawn from its synthetic curve by a
+downstream `dist`. Pinned by `TestToSamplerAdaptivePIsTheFinalSelector`.
+
+### 2g. DRY built with no sequence breakers — LOW-MED
+
+`params.go:791` passes `nil`; llama.cpp defaults to `{"\n", ":", "\"", "*"}`
+(`common/common.h:257`, `common/sampling.cpp:329-339`, `server-task.cpp:115`). DRY then matches
+n-grams *across* line, quote and colon boundaries, so lists, repeated JSON keys and echoed
+identifiers accumulate `base^(len-allowed)` penalties on structurally required tokens.
+Pinned by `TestToSamplerDryUsesDefaultSequenceBreakers`.
+
+### 2h. `top_k` cannot be disabled — LOW
+
+`params.go:733-735` maps `<= 0` to `40`; upstream documents `0` = disabled
+(`common/common.h:229`, `server-schema.cpp:89-91`). `{"top_k": 0}` from an OpenAI-style client
+becomes a hard 40-token truncation on a 248320-token vocab.
+Pinned by `TestParseParamsTopKDisableSentinel`.
+
+## 3. Draft width is never clamped by remaining context or token budget — MED-HIGH
+
+*Related to but distinct from `findings.md` §6b. Round 1 observed that nothing guards `s.nPast`
+during generation. This is the specific upstream mechanism that is missing — a per-round draft-width
+ceiling — and it makes the §6b overrun reachable `nDraft` tokens earlier than a plain round would.*
+
+`chooseNDraft` (`batchgen_speculative.go:147`) branches **only** on `s.specAccEMA`. It cannot see
+`s.nPast`, `ContextWindow`, or `MaxTokens`. Call sites: `batchgen_speculative.go:181`,
+`batchgen_mtp.go:258`, `batchgen_mtp.go:671`.
+
+llama.cpp computes a hard ceiling every round (`server-context.cpp:473-478`):
+
+```cpp
+int n_draft_max = n_ctx - prompt.n_tokens() - 2;   // reserves 2 cells
+if (n_remaining > 0) n_draft_max = std::min(n_draft_max, n_remaining - 1);
+```
+
+A speculative round writes positions `nPast..nPast+nDraft`, so it needs `nDraft` more KV cells than
+the plain round it replaces. At `nPast == CW-2` Kronk still drafts 2, `llama_decode` returns 1, and
+`batchgen_engine.go:464-475` **fails every active slot** — any co-resident conversation dies with
+it. The same gap makes Kronk draft a full round with one token of budget left, so the slot finishes
+mid-verify and the work is discarded.
+
+Pinned by `TestChooseNDraftClampsToRemainingContext`.
+
+### 3b. Prompt admission gate is off by one — MED
+
+`batchgen_slot_start.go:839` (also `:1012`, `:1112`) uses `s.nPrompt > cfg.ContextWindow()`.
+llama.cpp uses `>=` (`server-context.cpp:3188`: `slot.task->n_tokens() >= slot.n_ctx` →
+`ERROR_TYPE_EXCEED_CONTEXT_SIZE` + `slot.release()`) precisely because a slot needs one free cell to
+decode into.
+
+A prompt of exactly `ContextWindow` tokens is admitted, pays for a full-window prefill, and then the
+first generation decode requests position `ContextWindow`; `llama_decode` returns 1 and every active
+slot is failed with the generic "context window is full" (`batchgen_errors.go:81`) instead of an
+actionable up-front rejection. Pinned by `TestPromptAtExactContextWindowIsRejected`.
+
+### 3c. An explicit `ContextWindow` is never capped at the trained context — MED
+
+`adjustContextWindow` (`config.go:804-807`) returns immediately for any explicitly-set window; the
+GGUF `context_length` read at `:811-818` and the `min()` at `:825` are auto-pick-only, and
+`validateConfig` (`config.go:525`) never inspects it. llama.cpp caps `n_ctx_slot` at `n_ctx_train`
+(`server-context.cpp:1294-1297`) and assigns the capped value to every slot (`:1349`); the C API
+alone only warns (`llama-context.cpp:320-322`).
+
+That value is both the prompt limit (`batchgen_slot_start.go:839`) and the default `MaxTokens`
+(`params.go:705-706`), so `WithContextWindow(N)` beyond `n_ctx_train` silently generates out to
+positions RoPE never saw — no error, just degradation that reads as the model losing the thread.
+This model advertises 262144, so the auto-pick (8192) is safe; the explicit path is not.
+Pinned by `TestPickedContextWindowNeverExceedsTrainedContext`.
+
+## 4. Flash Attention is forced ON, bypassing llama.cpp's capability probe — MED
+
+**The premise that "Kronk doesn't enable FA for this model" is false.** With default config Kronk
+passes `flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED` (1):
+
+- `config.go:1255-1259` — `DerefFlashAttention(nil)` → `FlashAttentionEnabled`
+- `config.go:441-443` — an unset `PtrFlashAttention` derefs to that zero value
+- `config.go:880-881` — mapped to `llama.FlashAttentionTypeEnabled`
+
+llama.cpp's own default is `LLAMA_FLASH_ATTN_TYPE_AUTO` (-1) — `llama-context.cpp:3493`,
+`common/common.h:496`. Enum values confirmed at `llama.h:190-194` (AUTO=-1, DISABLED=0,
+ENABLED=1); yzma's constants (`llama.go:163-165`) match exactly.
+
+**Why forcing ENABLED is not equivalent to AUTO.** `ENABLED` sets `cparams.auto_fa = false`, so
+`resolve_fused_ops`' FLASH_ATTN capability probe never runs (`llama-context.cpp:246-247`,
+`:549-552`). That probe compares the fused node's device against the layer's device and, on a
+mismatch, logs *"Flash Attention not supported, set to disabled"* and falls back to the non-FA
+graph. Forced ENABLED keeps `ggml_flash_attn_ext` in the graph and lets the scheduler place it on
+whatever backend accepts it — typically CPU — while K/V live on the accelerator. The result is a
+silent per-layer, per-token round trip with no error on either side. It also suppresses the
+AUTO-only promotions at `:3546-3548` and `:3562-3564`.
+
+Pinned by `TestFlashAttentionUnsetResolvesToLlamaAuto`. Note `config_test.go:104` currently pins
+the *wrong* default and must be updated in the same commit as the fix.
+
+### 4b. No pre-flight guard for quantized V cache + FA disabled — MED
+
+`config.go:525-674` has no validation rule for the one combination llama.cpp rejects outright
+(`llama-context.cpp:3561-3569`: DISABLED → error + `nullptr`, re-checked at `:458-461`).
+
+Default config is safe (`CacheTypeV` stays `GGMLTypeAuto` → F16). But AutoTune can *generate* the
+invalid pair on a CPU-only, RAM-tight host: `sdk/tools/models/analyze.go:374-381` hardcodes
+`flash-attention: disabled` when no GPU is present, while an independent f16→q8_0 fallback
+(`analyze.go:439`, `:462-464`, `:622-650`) sets `cache-type-v: q8_0`. Nothing validates the
+combination, so it surfaces as a generic nil-context error with llama.cpp's actual explanation
+buried in the C log.
+
+Pinned by `TestValidateConfigRejectsQuantizedVCacheWithFlashAttentionDisabled`.
+
+### 4d. Observability gap (no test possible)
+
+`logContextParamsTrace` (`model.go:623-645`) logs only the *requested* mode, and `llama.h` exposes
+no getter for the resolved value (only `llama_flash_attn_type_name`, `llama.h:196`). Once §1 is
+fixed to AUTO, the effective mode will be visible only in llama.cpp's own stderr.
+
+### 4e. Adjacent, out-of-area
+
+`model.go:892-898` (the non-MTP draft loader) copies FA/threads/batch but drops `TypeK`/`TypeV`, so
+a quantized target KV cache silently gives the draft an F16 cache.
+
+---
+
+## 5. IMC prompt-cache decode treats every `llama_decode` failure as success — HIGH
+
+`caching_imc.go:118` and `batchgen_mtp.go:407` (the latter is the path actually taken for this MTP
+model — dispatch at `batchgen_slot_start.go:447-452`) both write:
+
+```go
+if _, err := llama.Decode(m.lctx, batch); err != nil {
+```
+
+yzma returns the `llama_decode` status as the **first** result and a non-nil error *only* when the
+context handle is 0 (`.extras/yzma/pkg/llama/context.go:381-390`). The `err != nil` guard is
+therefore dead code, and both functions always return nil.
+
+`llama.h:964-976` is explicit that the status matters: `1` = could not find a KV slot, `-1` = invalid
+input batch (reachable on this hybrid IMROPE target via `llama-batch.cpp:255-270`), `2` = aborted
+with partial ubatches left in memory.
+
+On a discarded failure, `startSlot` sets `cacheIdx = job.imcNewTotalCached`
+(`batchgen_slot_start.go:471`), commits that token count to the session (`:474`), and snapshots a KV
+that is **missing those cells**. The session now advertises a prefix that isn't resident, the suffix
+is decoded over the hole, and **every later turn restores the same truncated snapshot** — so earlier
+messages are permanently gone from the model's context while the conversation transcript still shows
+them. That is precisely "it contradicts what it already said" and "it drops the task mid-way".
+
+llama.cpp instead binds `ret`, classifies it, and calls `slot.prompt_clear()`
+(`server-context.cpp:3639-3691`).
+
+The three sibling decoders in `caching_imc_media.go` (`:236-244`, `:312-323`, `:377-388`) already do
+this correctly — `ret, err := llama.Decode(...)` then `if err != nil || ret != 0`. So this is an
+isolated oversight on the two text paths, not a systemic pattern.
+
+Pinned by `TestIMCCacheDecodeChecksLlamaDecodeStatus`.
+
+### 5b. Documented `cachedRenderInputHash` pure-hit guard does not exist — LOW
+
+The field is written at 3 sites (`model.go:94`, `caching.go:205`, `batchgen_slot_start.go:157`) and
+compared at **0**. Both staleness predicates (`batchgen_slot_start.go:169-176`, `:541-551`) omit it,
+and there is no `IMCPureHitSnapshotSkip` symbol. `caching_imc_pure_hit_test.go:308-323` is named for
+a guard it never asserts. Not wrong output today — the token-exact prefix compare subsumes every
+fingerprint input — but the next relaxation of the skip predicate will be made believing a backstop
+exists. Reference: `server-common.cpp:471-518` + `server-context.cpp:3197-3207`.
+Pinned by `TestIMCPureHitSkipGuardReadsCachedRenderInputHash`.
+
+## 6. Slot / sequence cross-request contamination
+
+### 6a. A released slot's already-staged batch rows are decoded into the sequence `finishSlot` just cleared — HIGH
+
+`batchgen_engine.go:375`/`:381` release a slot from *inside* the prefill staging loop (`:366-396`),
+which makes multiple passes staging rows into the shared `e.batch` via `addPrefillChunk`.
+
+A client disconnect between passes releases the slot mid-iteration. `finishSlot` does
+`MemorySeqRm(seq,-1,-1)` (`batchgen_finish.go:179`) but **cannot un-stage the rows already in
+`e.batch`**, and `e.batch` is only cleared at the top of the *next* iteration. So the single
+`llama.Decode` at `batchgen_engine.go:458` writes the dead request's prompt back into the
+just-wiped sequence. Worse, `fillSlots` (`:418`) runs before that decode and may already have started
+the next conversation on the same slot/seq — both row sets then land in one sequence. Because KV
+appends by slot rather than by `(seq,pos)`, the stale cells are never overwritten, and the causal
+mask admits them as generation walks past.
+
+llama.cpp avoids this three ways: `prompt_clear()` wipes KV and token bookkeeping atomically
+(`server-context.cpp:291-296`), cancellations are applied *before* `update_slots` builds the batch
+(`:1449-1450`), and it re-trims past the validated prefix (`:3418-3423`) — Kronk has no equivalent.
+Pinned by `TestPrefillStagingLoopDoesNotReleaseSlots`.
+
+### 6b. Engine-global `draftCore.promptBuf` is aliased onto every slot's `draftPromptTokens` — MED-HIGH
+
+`batchgen_slot_start.go:935` (refill at `:916-932`) hands out a reslice of one engine-global array
+(field at `model.go:137`). `fillSlots` starts every pending job in one pass, so two `startSlotText`
+calls run back-to-back and the second refills the *same* array in place — slot 0's
+`draftPromptTokens` then reads job B's tokens.
+
+`prefillDraft` (deferred to the next iteration, gated on `prefillDone`) decodes that mixed sequence
+into slot 0's draft KV and persists it as `draftCachedTokens`, which `reset()` deliberately keeps —
+so a wrong-conversation prefix is "reused" on later requests, and the persisting `specAccEMA` latches
+speculation off. Upstream keeps prompt tokens in the per-slot `server_slot::task`
+(`server-context.cpp:3116`), reset at `:364`.
+
+Scope limit: classic separate-GGUF drafting only. **MTP skips `prefillDraft`**, so this does not fire
+on the MTP path. Pinned by `TestDraftPromptTokensAreSlotOwned`.
+
+### 6c. `slot.reset()` omits `startTime` and `specSnapshot` — LOW
+
+`batchgen_slot.go:300` (fields at `:293`, `:263`). `startTime` is set only on the first output token
+(`batchgen_tokens.go:97`) but read unconditionally at `batchgen_finish.go:149-150`, so a request that
+dies before its first token reports the *previous* request's `elapsed` / `TokensPerSecond`.
+`specSnapshot` survives as a restorable serialized copy of the previous conversation's sequence
+state; `len(specSnapshot) > 0` is the "snapshot exists" gate at `batchgen_speculative.go:684` and
+those bytes are fed to `StateSeqSetData` at `:823`. Upstream clears both
+(`server-context.cpp:3124`, `:351`). Pinned by `TestSlotResetClearsPerRequestClockAndSpecSnapshot`.
+
+## 8. Post-render reasoning strip corrupts the prompt — HIGH
+
+**Two independent agents converged on this from opposite directions** (reasoning-history and
+tokenization/template). It is the strongest explanation found for the *reasoning-specific* nature of
+the symptom, and it is a plain-text bug with no KV cache involved.
+
+Ground truth established first: the GGUF's embedded `tokenizer.chat_template` is **byte-identical**
+to `.extras/templates/qwen3.6.jinja` (sha256 `55d4931433…`), `general.architecture = qwen35moe` (so
+`parsers/qwen` is selected correctly — the `mtp-` id prefix is never consulted), `<think>`/`</think>`
+are single tokens 248068/248069, and the generation prompt force-opens `<think>\n` when
+`enable_thinking` — which Kronk already handles correctly at `batchgen_slot_start.go:37-53`.
+Kronk's Jinja engine was verified byte-for-byte against Jinja2 3.1.6 across 21 conversation shapes,
+so **the template engine itself is faithful**. The damage is done *after* rendering.
+
+`prompts.go:177-181` rewrites the finished prompt with `StripEmptyReasoning` →
+`parsers/standard/reasoning.go:35` (`StripEmptyThink`) → `:43` (`StripExceptTrailing`), a bare regex
+pass over the whole string. llama.cpp's only post-render edit is BOS/EOS de-duplication
+(`common/chat.cpp:926-940`); it never rewrites template output.
+
+### 8a. Assistant role headers mangled in agentic history — HIGH
+
+Template line 104 emits `'<|im_start|>' + role + '\n<think>\n' + reasoning + '\n</think>\n\n' + content`
+as one literal, for every turn where `loop.index0 > ns.last_query_index`. The regex deletes only the
+`<think>…</think>` span and leaves the surrounding `\n\n`, so the turn reaches the model as:
+
+```
+<|im_start|>assistant\n\n\n<tool_call>        ← actual
+<|im_start|>assistant\n<think>\n\n</think>\n\n<tool_call>   ← what the template emitted
+```
+
+Two special tokens (248068/248069) degrade into ordinary newlines on **every assistant turn of a
+tool-calling loop**. Gated only on `IncrementalCache()` (default on), so no client cooperation is
+needed to trigger it. Pinned by `TestQwen36PostRenderReasoningStripBreaksAssistantTurns` (3 failing
+subtests; a plain-chat control subtest passes, which is what proves the Jinja engine is innocent) and
+by `TestQwen36EmptyThinkScaffoldStrippedFromInTurnAssistant`.
+
+### 8b. The same pass deletes bytes out of USER message content — HIGH
+
+`StripExceptTrailing` has **no role awareness** — it regexes the entire rendered prompt. A user who
+writes `explain <think>\n</think> markers` has those bytes silently removed and receives
+`explain  markers`. Unlogged, and nothing upstream escapes user content against this because upstream
+has no such pass. Pinned by `TestQwen36PostRenderReasoningStripDeletesUserContent`.
+
+### 8c. In-turn `reasoning_content` deleted where the template would replay it — MED-HIGH
+
+`normalizeHistoryReasoning` (`reasoning.go:91-92`, gated at `:36-38`) deletes `reasoning` and
+`reasoning_content` from **every** assistant message. But template line 103 deliberately replays
+reasoning when `loop.index0 > ns.last_query_index`, and llama.cpp passes `inputs.messages` verbatim
+(`common/chat.cpp:895-900`) with no stripping pass at all.
+
+In a multi-step tool loop, the reasoning that justified a tool call belongs to the *same logical
+turn* as the tool result. Kronk deletes it, so the model resumes having lost its own justification
+and re-derives a different one — **this is the "I already said that / that's a contradiction" mode
+directly.** The doc comment at `reasoning.go:8-18` assumes templates always drop reasoning once a
+newer turn arrives; false for this template. Pinned by
+`TestQwen36InTurnReasoningContentNotReplayed`.
+
+### 8d. `addBOSToken` re-derived from a metadata string instead of the vocab flag — MED (latent here)
+
+`model.go:297-302`, `:336` initialise `addBOSToken := true` and lower it only when the GGUF string is
+literally `"false"`. llama.cpp's `add_bos` defaults **false** and is raised only for SPM/WPM
+(`src/llama-vocab.cpp:2374-2394`, `:2547-2568`), and it force-overrides `add_bos = true` for Gemma 4 —
+which a string check cannot see. So a gpt2/BPE GGUF that omits the key gets a spurious BOS from
+Kronk. Kronk already calls `llama.VocabGetAddBOS` correctly on the media path
+(`prompt_plan.go:35`), so the two paths can disagree for one model.
+
+Latent for *this* model (`add_bos_token = false` is present explicitly, so both implementations skip
+BOS). Pinned by `TestAddBOSTokenUsesTheVocabFlag`.
+
+### 8e. Streaming and non-streaming messages disagree — LOW-MED
+
+`batchgen_tokens.go:212-222` writes content to `finalContent`/`finalReasoning` *before* `:225-230`
+decides via `isUnnecessaryCRLF` whether to stream it, so a suppressed newline survives only in the
+non-streaming message: `Chat()` returns `"\n\nB"` where `ChatStreaming()` delivers `"B"` (and
+`"\nA"` vs `"A"` on the reasoning channel). Upstream streams diffs of the accumulated parsed message
+(`server-task.cpp:1021` → `compute_diffs` at `:177`), so deltas concatenate to the final message by
+construction. Pinned by `TestQwen36StreamedAndFinalMessageAgree`.
+
+## 9. Every emitted token is accepted into the sampler chain TWICE — HIGH
+
+`llama_sampler_sample` **ends with `llama_sampler_accept(smpl, token)`**
+(`src/llama-sampler.cpp:810-875`, accept at `:873`). That is exactly why upstream's
+`common_sampler_sample_and_accept_n` uses `llama_sampler_apply` plus exactly **one** explicit accept
+per emitted token (`common/sampling.cpp:646-676`).
+
+*Distinct from `findings.md` §6i, which is about `DraftGenerate` accepting a token internally that
+the caller never receives. This is Kronk's own call sites accepting a token that llama.cpp already
+accepted for them — and unlike §6i it is not latent.*
+
+Kronk calls `llama.SamplerSample` (yzma `sampling.go:574`, a thin wrapper on
+`llama_sampler_sample`) and then calls `llama.SamplerAccept` **again** in `handleSampledToken`
+(`batchgen_tokens.go:63`).
+
+**Not speculative-specific** — it reaches the plain decode path at three sites:
+`batchgen_tokens.go:25`→`:28`, `batchgen_tokens.go:265`→`:271`, and
+`batchgen_engine.go:259`→`:261`, in addition to the verify loop
+(`batchgen_speculative.go:433`, `:442`, `:493`, `:536`, `:590`).
+
+**Exactly what it corrupts — both the window length and the weights, but not uniformly:**
+
+- The penalty ring buffer's capacity *is* `penalty_last_n` (`llama-sampler.cpp:2782`,
+  `ring_buffer::push_back` `:55-68`), so `penalty_last_n = 64` covers only **32 real output tokens**.
+- `token_count[token]` reaches 2 (`:2663`), which doubles only the **frequency** penalty
+  (`float(count) * penalty_freq`, `:2715`). Repeat and presence penalties are membership-only and are
+  therefore unaffected in weight.
+- **DRY is hit worst** (`:2937-2944`, ring at `:3245`): its window is halved *and* its contents are
+  poisoned into `a a b b c c`, **fabricating repeats that never occurred** — an anti-repetition
+  sampler actively being told the model is repeating itself.
+- **Grammar is NOT double-accepted.** `grammar.go:390-427` only calls `SamplerApply`, never
+  `SamplerAccept`, so the stack-machine corruption / process-abort hypothesis is **dropped**.
+
+It is also **non-uniform** across tokens — the fully-accepted-round MTP bonus token comes from
+`argmax` and is accepted only once (`batchgen_speculative.go:595`), so the penalty window advances at
+a rate that varies with the acceptance rate.
+
+**Not unconditional:** `params.go:785`/`:792` omit penalties and DRY under defaults
+(`RepeatPenalty = 1.0`, freq/presence/dry `= 0`) and every remaining default sampler has
+`.accept == nullptr`. So this bites only callers who enable a penalty — which, combined with §2b
+(DRY cannot be enabled at all), means the anti-repetition machinery is either off or corrupt, never
+simply working. Pinned by `TestVerifyLoopSamplerAcceptIsNotDoubled` and
+`TestSamplerAcceptedTwicePerTokenCorruptsPenaltyWindow`.
+
+### 9b. Phase-A verify loop sets `s.nPast` one KV cell short — MED
+
+`batchgen_speculative.go:454` (also `:507`, `:564`) vs the authoritative `:740`. The spec batch puts
+`s.sampled` at `basePast` and `draft[k]` at `basePast+1+k` (`batchgen_engine.go:284-287`), so
+accepting `draft[i]` (⇒ `accepted == i+1`) leaves the next write position at `basePast+2+i`.
+Phase A writes `basePast+1+i`; Phase B writes `basePast+1+accepted`, which is what upstream's
+`prompt.tokens.pos_next()` yields (`server-context.cpp:3936-3942`) and what the KV is actually
+trimmed to.
+
+Masked today only because Phase B overwrites it — but **Phase B is skipped whenever Phase A's
+`handleSpeculativeToken` (`:455`) reaches `finishSlot`** (EOG, MaxTokens, stream error). It also
+contradicts Phase A's own documented "does NOT advance s.nPast" contract.
+Pinned by `TestVerifyLoopNPastAgreesWithFinalizeNPast`.
+
+## 10. MTP deactivation and coverage defects
+
+*Scope note: Kronk deliberately provides no way to disable MTP from configuration — that is intended
+design and is not reported here. The defects below are different: Kronk's own internal logic decides to
+stand speculation down and then doesn't, plus two coverage/upgrade defects that are independent of the
+design decision.*
+
+### 10a. MTP does not actually deactivate when Kronk's own logic throttles it — MED-HIGH, IN SCOPE
+
+*This is **not** the config question. Kronk has internal machinery whose stated purpose is to stand
+speculation down — the `chooseNDraft` EMA throttle, and `disableMTPForRequestSpec` /
+`mtpDisabledForRequest`. When that machinery fires, MTP does not actually stand down.*
+
+`specAccEMA` is initialised to **1.0** (`batchgen_slot.go`), so early rounds always draft at the full
+ceiling. A zero-draft round then skips only the verify/rollback/hybrid-snapshot block (gated on
+`len(draftTokens) > 0`, `batchgen_engine.go:277-455`) while **still** claiming an MTP target-batch
+range and running `syncAfterTargetDecode` mirror-replay every round
+(`batchgen_engine.go:328-332`, `:533-541`), with the target context permanently in pre-norm mode and
+`NOutputsMax` still sized `nSeqMax*(1+nDraft)`. The recovery probe
+(`mtpProbeInterval`, `batchgen_speculative.go:126-166`) re-enables drafting every 32 rounds, so it can
+never latch off.
+
+Round 1's §3 is the same class and reinforces it: `disableMTPForRequestSpec`
+(`batchgen_speculative.go:1081`) and `mtpDisabledForRequest` **exist but are wired to nothing**, so a
+`snapshot-error` or `restore-error` — the exact conditions under which speculation should be abandoned
+for the request — leaves MTP running.
+
+So the defect is: **every internal path that is supposed to stand speculation down is either a no-op or
+self-reversing.** A fix here needs a real deactivation path (a `nDraft == 0` bail in
+`selectAndLoadDraft` at `draft_mtp.go:493-499`, skipping the mirror-replay, and honouring
+`mtpDisabledForRequest`) — none of which requires adding a config key, so none of it conflicts with the
+design decision above.
+
+### 10c. Two integration suites have never executed a single test — MED
+
+*This closes the open question `findings.md` §7 left ("`tests/gemma4mtp` and `tests/draft` deserve
+the same audit"). The `tests/mtp` fact itself is round 1's; what is new here is the discarded error
+that hides it, the verdict on the other two suites, and a regression test.*
+
+- **`tests/mtp`**: `sdk/kronk/tests/testlib/testlib.go:97` resolves
+  `mtp-Qwen3.6-35B-A3B-UD-Q2_K_XL`, absent from the catalog (only
+  `unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL` at `catalog.yaml:321`). `resolveModel`
+  (`testlib.go:110-116`) **discards the error**, leaving a zero `models.Path`, and
+  `tests/mtp/main_test.go:20` reads that as "not downloaded" and `os.Exit(0)`. Green, silent, zero
+  tests — which is how the MTP divergences from `common/speculative.cpp` shipped.
+  Pinned by `TestTestlibResolvesOnlyCatalogModelIDs`.
+- **`tests/gemma4mtp`**: `main_test.go:19` requires `MPMoEVision.MTPFile`, but `MPMoEVision` is
+  `gemma-4-26B-A4B-it-UD-Q4_K_M` (`testlib.go:89`) whose catalog record
+  (`catalog.yaml:127-145`) has no `mtp:` key — that sidecar is declared only on the Q8_K_XL entry
+  (`catalog.yaml:352`), and `MTPFile` comes solely from that key
+  (`sdk/tools/models/catalog.go:787-789`). So the only coverage of the shared-KV drafter
+  (`draft_mtp.go:438-458`) never runs. Pinned by `TestGemma4MTPSuiteTargetShipsMTPSidecar`.
+- **`tests/draft` is clean** — `Qwen3-0.6B-Q8_0` and `Qwen3-8B-Q8_0` both exist in the catalog.
+
+---
+
+## 11. `batchseq` engine (embed/rerank only) — two defects
+
+`batchseq` is **not on the chat path**. It is reached only by
+`(*Model).Embeddings` (`embed.go:91`) and `(*Model).Rerank` (`rerank.go:95`), selected at
+`model.go:376` via `useBatchSeq` → `supportsBatchSeq` (`batchseq_compat.go:7`,
+`mi.IsEmbedModel || mi.IsRerankModel`). `Chat` / `ChatStreaming` / batch-pooled generation never touch
+it, so **neither reported symptom can originate here.** The two findings below are
+embedding/reranking-quality bugs, reported because the audit was asked for.
+
+### 11a. No `LLAMA_POOLING_TYPE_NONE` path; a NULL result permanently kills the engine — HIGH
+
+`batchseq_engine.go:476` calls `llama.GetEmbeddingsSeq` unconditionally, treats a nil result as
+`fatal = true` (`:478`), and fatal → `terminate` with the engine never rebuilt (`:343-347`).
+
+Kronk sets `ctxParams.PoolingType` for **rerank only** (`config.go:844-850`), so any embed GGUF
+missing `<arch>.pooling_type` — a key only written when the HF repo ships `1_Pooling/config.json`
+(`conversion/base.py:2062-2075`) — resolves to NONE (`llama-context.cpp:232-236`,
+`llama-hparams.h:272`). llama.cpp fills `embd_seq` only for MEAN/CLS/LAST/RANK
+(`llama-context.cpp:1489-1531`, `:1934-1981`) and returns nullptr otherwise (`:924-931`).
+
+Upstream handles both cases: it branches `NONE → llama_get_embeddings_ith`
+(`server-context.cpp:2202-2207`) and degrades a NULL to a zero vector for that one request
+(`:2209-2214`). Kronk instead reports "returned 0 outputs" as fatal, and **every subsequent
+`Embeddings()` call fails permanently** with the stored engine error. `llama.GetEmbeddingsIth` and
+`GetPoolingType` are bound by yzma but referenced nowhere under `sdk/`.
+Pinned by `TestBatchSeqEmbeddingHandlesNonePooling`.
+
+### 11b. Rerank pair omits the `[EOS][SEP]` segment boundary — MED
+
+`rerank.go:261-263` builds the pair as `fmt.Sprintf("%s %s", query, document)`, consumed at `:157-158`
+and `:209-211`. Upstream's contract is `[BOS]query[EOS][SEP]doc[EOS]`
+(`server-common.h:378`), implemented by `format_prompt_rerank`
+(`server-common.cpp:1553-1594`), which prefers the model's own `"rerank"` chat template and otherwise
+builds it at token level gated on `llama_vocab_get_add_bos/_eos/_sep`.
+
+`llama.Tokenize(vocab, pairText, addBOS, true)` adds only BOS/EOS at the ends, never an interior SEP,
+so a `bge-reranker-v2-m3` XLM-RoBERTa cross-encoder — trained on `<s> q </s></s> d </s>` — is fed one
+run-on sentence. RANK pooling still emits a score and `sigmoid` still maps it to [0,1], so **the
+ordering is confidently wrong with no error**. A model-side `"rerank"` template is ignored.
+Pinned by `TestFormatRerankPairSeparatesQueryFromDocument`.
+
+## 12. Plain non-speculative path defects
+
+**Answer to "would disabling MTP avoid this?": no — and per §10 you cannot disable it anyway.** A
+plain `Chat()` always runs the `batchgen_*` engine. The defects below need no speculation to fire.
+
+### 12a. Tool calls held in the parser buffer are silently discarded at end-of-generation — HIGH
+
+The Qwen/standard state machines buffer tool-call bytes until they see `</tool_call>`
+(`parsers/qwen/state_machine.go:88-89`, `:47-68`). `parser.go:73-80` exposes only Classify + Reset —
+there is **no drain**. `finishSlot` flushes only `utf8Buf` (`batchgen_finish.go:261-278`), and
+`batchgen_slot.go:379-381` calls `Reset()`, which discards.
+
+So if EOG or MaxTokens arrives before the closing tag, the **entire tool call is thrown away**:
+`finishSlot`'s tool branch (`batchgen_finish.go:282`) runs over an empty `finalTooling` and produces
+an empty response with **no error**. The model announced and began an action; the caller sees nothing.
+Upstream treats `generated_text` as authoritative and ships the remainder in `send_final_response`
+(`server-context.cpp:1868-1898`). Pinned by `TestGenerationEndDrainsParserHeldBackContent`.
+
+### 12b. Prompt tokens are never primed into the sampler chain — MED
+
+`batchgen_tokens.go:63` is the **only** `SamplerAccept` on a request sampler in the whole package;
+nothing in `startSlotText` (`batchgen_slot_start.go:791`) or `addPrefillChunk` primes it. Upstream's
+`init_sampler()` accepts every prompt token (`server-context.cpp:375-397`).
+
+The penalty/DRY window therefore starts empty on **every turn**, so in a long multi-turn conversation
+the entire prior transcript is invisible to the repetition machinery — and it compounds with the
+halved window from §9. Pinned by `TestPromptTokensArePrimedIntoTheSamplerChain`.
+(Independently found as §2d; same defect, two agents.)
+
+### 12c. Released slot's rows stay in the pending batch while its seqID is reassigned — HIGH
+
+Independent confirmation of §6a from a second agent, with a sharper mechanism: round-robin prefill
+runs multiple passes per `processBatch`, so a cancel landing between passes releases a slot whose rows
+are already in `e.batch` (`batchgen_engine.go:373-383`). `finishSlot` clears the KV sequence but not
+the batch (`batchgen_finish.go:176-182`), then `fillSlots` (`batchgen_engine.go:418`) hands the same
+slot/seqID to a queued request which adds its own rows **at overlapping positions**. One
+`llama_decode` (`:458`) commits two conversations into one sequence, and the new request attends to the
+cancelled one's tokens. Also fires on an IMC hit, since restore runs inside `startSlot`, pre-decode.
+
+Upstream guarantees assignment strictly precedes batch building — *"all tasks in the current loop is
+processed, slots data is now ready"* (`server-queue.cpp:139-163`, `server-context.cpp:137`).
+Pinned by `TestReleasedSlotRowsAreRemovedFromPendingBatch`.
+
+### 12d. The token that reaches MaxTokens has its text discarded — LOW-MED
+
+`batchgen_tokens.go:205-210` (and the partial-UTF-8 twin at `:146-151`) finish the slot **before** the
+content store at `:213-222` and the delta at `:233`. The token is counted in `Usage` but never
+delivered on either transport. Upstream emits the token, then checks the budget
+(`server-context.cpp:1895-1899` before `:1913-1918`).
+Pinned by `TestMaxTokensKeepsTheLimitReachingTokensText`.
+
+### 12e. M-RoPE generation applies grammar during reasoning but never accepts it — LOW
+
+`batchgen_engine.go:255-260` lacks the `&& s.reasonFlag == 0` guard that `batchgen_tokens.go:21` and
+`:261` have (the Accept at `:59` *is* gated). With vision + JSON schema + reasoning, thinking tokens
+are sampled from grammar-masked logits (`grammar.go:419-425` writes the −inf mask back into the
+context row) while the grammar stack never advances. Upstream governs apply and accept with the same
+`grammar_should_apply` predicate (`common/sampling.cpp:630-643`).
+Pinned by `TestMRoPEGenerationGrammarIsGatedOnReasonFlag`.
+
+## 13. Reproduction status — plain-conversation differential
+
+Plain multi-turn conversation does **not** reproduce either symptom, on Kronk or upstream, so §1-§12
+are verified defects with **no measured link** to observed behaviour. Only §14 (tool-calling) reproduced.
+
+Identical GGUF/quant/build — upstream `llama-server` at b10211 from
+`~/.kronk/libraries/darwin/arm64/metal/`, the same libs Kronk loads. n_ctx 16384, probes P1-P5,
+temp 0.7 / top-k 40 / top-p 0.9 / min-p 0 / rep-pen 1.0, f16 KV, `-fa off`, n_seq_max 1. A second run at
+n_ctx 131072, 32 turns, ~19k depth scored identically across all three legs.
+
+| Leg | Derailments | Acceptance |
+|---|---|---|
+| `upstream --spec-type none` (MTP off) | 0/5 | — |
+| `upstream --spec-type draft-mtp` (MTP on) | 0/5 | 0.62-0.66 |
+| `kronk` (MTP auto-on) | 0/10 | 0.59-0.80 |
+
+Upstream MTP-on vs off was byte-identical on 12/18 turns, so **speculative decoding as a technique is
+not implicated**; Kronk's acceptance sits in the same band.
+
+Three Kronk replies initially scored as "forgot the standing marker" were **false positives** — each hit
+`max_tokens` exactly and ended mid-sentence. Scoring is now truncation-aware. Relevant beyond this
+harness: it is the same misreading a human makes from a transcript, and §14a means the API gives a client
+no way to tell the difference.
+
+### 13a. Two measurement traps
+
+1. Kronk's `Usage.CompletionTokens` **excludes** reasoning tokens (they are in `ReasoningTokens`);
+   llama-server's includes them — comparing raw understates Kronk ~20x on thinking turns.
+2. With thinking enabled both sides strip reasoning from replayed history, so turn count grows while used
+   context stays small — a reasoning-heavy chat never builds a long context unless the probe forces it.
+
+### 13b. Harness
+
+`sdk/kronk/tests/mtp/differential_test.go`. Opt-in: build tag `kronkdiff` **and** `KRONK_MTP_DIFF=1`.
+Launches `llama-server` for the upstream legs itself; skips cleanly if the GGUF or binary is missing.
+
+```
+KRONK_MTP_DIFF=1 go test -tags kronkdiff -timeout 3h -v -count=1 \
+  -run 'TestMTPDifferential$' ./sdk/kronk/tests/mtp/
+```
+
+Knobs: `KRONK_MTP_DIFF_CTX`, `_PROBES`, `_REPEATS`, `_OUT`, `_SERVER`, `_UPSTREAM=0`. Set
+`KRONK_MTP_DIFF_OUT` outside `/private/tmp` to keep transcripts. A `//go:build !kronkdiff` guard was
+added to `sdk/kronk/tests/mtp/main_test.go`, required because its `TestMain` force-exits on the missing
+catalog id (§10c).
+
+---
+
+## 14. A completed tool call is silently discarded at `max_tokens` — HIGH, reproduced live
+
+Measured on the 35B MTP target, n_ctx=16384, `tools=[get_weather]`,
+`enable_thinking=false`, prompt *"What is the weather in London, United Kingdom? Use celsius."*
+
+| `max_tokens` | result |
+|---|---|
+| 4, 8, 12, 16, 20, 24, 32 | `finish_reason="stop"`, `content=""`, `reasoning=""`, `tool_calls=[]`, `error=nil`, `usage.output_tokens=**39**` |
+| 48, 64 | `finish_reason="tool_calls"`, `get_weather` delivered, `usage.output_tokens=39` |
+
+Note `usage.output_tokens = 39` for **every** cap, including `max_tokens=4`. That reveals two distinct
+defects:
+
+**(a) `MaxTokens` is not enforced at all while the parser is buffering a tool call.** Every tool-body
+token classifies as `ChannelNone` and returns early at `batchgen_tokens.go:200-203`, **before** the
+MaxTokens check at `:205-210`. A cap of 4 therefore generated 39 tokens — a ~10x overrun. On a
+long tool body this is unbounded generation against an explicit caller limit.
+
+**(b) The completed call is then destroyed by its own arrival.** The whole payload arrives as a single
+`Result` at the closing tag (`parsers/qwen/state_machine.go:80-89` returns the entire buffer). At that
+token `outputTokens = 39 >= MaxTokens`, so `:205-210` calls `finishSlot` **before** the content store at
+`:213-222` — `finalTooling` stays empty and the caller gets an empty response.
+
+**The model produced a well-formed, complete tool call and Kronk discarded it.** This is §12d
+(max-tokens token's text discarded) amplified by the parser's single-shot flush: it destroys the
+*entire* call rather than one token. Confirmed: **the failure boundary is the token count, not the
+buffer state** — cap ≤ 39 loses the call, cap ≥ 40 delivers it.
+
+**Correction to the original §12a hypothesis.** The audit predicted the loss came from the parser still
+holding bytes at the cut. That route is **unreachable via `max_tokens`** — it is reached only by the EOG
+check at `batchgen_tokens.go:66-69`. Both routes are real and are pinned separately: the EOG route loses
+98 of 98 bytes, also with `toolFlag = 0`. Note `s.toolFlag` stays 0 because `ChannelNone` never
+increments it (`batchgen_tokens.go:177-180`), so `finishSlot` never even enters the tool branch at
+`batchgen_finish.go:282` — **no tool call, no log line, no error.**
+
+### 14a. Kronk has no `length` finish reason — this is what makes §14 silent — HIGH
+
+`models.go:36-38` defines only `FinishReasonStop` / `Tool` / `Error`, and `chatResponseFinal`
+(`models.go:926-929`) picks `stop` unless tool calls exist. llama.cpp does the opposite: it **starts**
+from `"length"` and downgrades only on `STOP_TYPE_WORD`/`EOS`
+(`.extras/llama.cpp/tools/server/server-task.cpp:410`, `:443`, `:492`).
+
+So a `max_tokens`-truncated turn is reported to the caller as a clean `stop`. A client has **no way to
+detect truncation** — which is exactly why §14 presents as "the model just stopped doing the task"
+rather than as an error. Fixing §14 without adding `length` would still leave callers blind.
+
+### 14b. Prompt damage on a tool loop — confirmed through the real code path
+
+Two-step tool loop, real path (`normalizeHistoryReasoning` → `applyJinjaTemplate`), IMC on (default).
+**Every in-turn assistant header degrades**, on every step:
+
+```
+template says:  <|im_start|>assistant\n<think>\nOne file. Read svc/queue.go…\n</think>\n\n
+Kronk sends:    <|im_start|>assistant\n\n\n
+```
+
+`<think>` openers 3→1, `</think>` closers 2→0, tokens 248068/248069 become newlines, and **both
+`reasoning_content` strings are deleted outright** (`reasoning.go:91-92` + `prompts.go:177-181`).
+Gated only on `IncrementalCache()`. This confirms §8a and §8c on the shape that actually triggers them,
+and it is the leading unproven mechanism for the self-contradiction symptom.
+
+### 14d. Upstream comparison — llama.cpp loses nothing, so this is Kronk's — HIGH
+
+Identical requests, same GGUF/quant/build b10211/n_ctx 16384:
+
+| | Kronk | upstream `llama-server` |
+|---|---|---|
+| silent-empty responses | **7 of 9** | **0 of 9** |
+| honours `max_tokens` | no — 39 tokens regardless of cap | yes — `completion == cap` |
+| `finish_reason` on truncation | `"stop"` (0/9 `"length"`) | `"length"` on 7/9 |
+| tool call delivered from a truncated generation | no | **yes** — parsed `get_weather` returned, with the raw partial text at cap 4 |
+
+Upstream recovers a *parsed tool call out of a generation it truncated at 4 tokens*. Kronk, given the
+same weights and the same library, returns an empty turn.
+
+Pinned by `TestToolCallCutOffAtMaxTokensIsInvisibleToTheCaller`,
+`TestMaxTokensIsCheckedAroundBufferedToolCallTokens`,
+`TestToolCallHeldByTheParserAtEOGIsUnrecoverable`, and live by `TestToolCallDifferential`:
+
+```
+KRONK_MTP_DIFF=1 KRONK_MTP_TOOL_PROBES=trunc KRONK_MTP_DIFF_CTX=16384 \
+  go test -tags kronkdiff -timeout 40m -v -run TestToolCallDifferential ./sdk/kronk/tests/mtp/
+```
+
+(12s with both legs; add `KRONK_MTP_DIFF_UPSTREAM=0` for the Kronk leg alone.)
+
+The `max_tokens` boundary was probed at caps 4, 8, 12, 16, 20, 24, 32, 36, 38, 39 (all lost) and 40, 41,
+44, 48, 64 (all delivered) — the cliff is exactly at the 39 tokens the model actually generates.
+
+### 14e. Mid-task abandonment in an agentic loop — reproduced, but UNDERPOWERED — MED confidence
+
+Separately from the `max_tokens` artefact, an 8-file agentic audit loop was run repeatedly:
+
+| | abandoned mid-task | samples |
+|---|---|---|
+| Kronk | **2** | 6 |
+| upstream | 0 | 7 |
+
+The clearest Kronk failure: it stopped at **4 of 8 files**,
+declared *"## Audit Complete"*, and then — when challenged — **agreed that it had skipped them.** That is
+"goes down a path, flips a switch, contradicts itself" in one sample.
+
+2/6 vs 0/7 is Fisher p ≈ 0.19 — **suggestive, not significant**. It is
+consistent with the §8/§14b prompt corruption causing real degradation, but it does not establish it.
+Note also that upstream had 2/7 failures of its own, in a *different* mode Kronk never showed (emitting
+`list_files` as plain text at step 0 and never entering the loop), so the two stacks fail differently
+rather than one simply being worse.
+
+Unlike §14/§14d — which is deterministic, Kronk-only, and needs no statistics — **this result needs more
+samples before anyone acts on it.** The harness supports repeats:
+`KRONK_MTP_TOOL_KRONK=0` + `KRONK_MTP_TOOL_SEED=<n>` for single-leg runs.
+
+---
+
+---
+
+## 15. Unexplained Go heap corruption — open
+
+The two libffi width defects found in yzma (see `yzma-findings.md` #3 and #5) are **not** armed by
+`Init()` — one needs a model load, the other is unreachable — so neither explains why deferring `Init()`
+worked around the crash. The `Init()`-registered `purego.NewCallback`
+log callback appears **GC-safe**: purego retains it in a package-level `cbs.funcs` array
+(`syscall_sysv.go:54-103`), and callbacks from foreign threads are handled because purego wires up
+`iscgo`/`_cgo_thread_start` via fakecgo or real `runtime/cgo`. It does leak one callback slot per
+`Init` against a hard cap of 2000.
+
+A 40s reproduction attempt (`GODEBUG=clobberfree=1,invalidptr=1 GOGC=1`, `Init()` + 4 goroutines of
+net/http+JSON + a `runtime.GC()` loop, no model) **survived 115,886 request round-trips.**
+
+So `found pointer to free object` remains **unexplained**. The yzma defects are not its resolution.
+
+**Severity caveat:** the yzma width defects are weak candidates for the reported symptom, because they
+fire at **model-load time, not per-token during generation**. The one exception worth tracking is
+`yzma-findings.md` #2 (`size_t min_keep` passed as a `uint32`), which fires per-sampler-call, is
+nondeterministic at a measured 5-14%, and silently disables top-p / min-p / XTC — that one *is* a
+plausible contributor and Kronk reaches it at `params.go:800`, `:804`, `:809`.
+
+### 15a. COVERAGE GAP — the Kronk-side pointer-lifetime audit was never completed
+
+The investigation covered yzma's binding layer. It did **not** cover the Kronk side: retained slices over
+C-owned memory (logits, embeddings, pre-norm buffers), missing `runtime.KeepAlive`, and Go pointers
+handed to C and held across calls. A subagent tasked with that call-site audit never reported back.
+
+This matters because llama.h documents that `llama_get_logits` / `get_embeddings` pointers are
+**invalidated by the next decode** — and Kronk reads those in the speculative path
+(`batchgen_speculative.go`, `logprobs.go`, `batchgen_mtp.go`). Round 1 verified that
+`captureVerifyPreNorm` copies rather than retaining, but that is one site out of many. **This is the
+most likely remaining home for the unexplained crash**, and it is the obvious next step.

--- a/sdk/kronk/model/batchseq_correctness_test.go
+++ b/sdk/kronk/model/batchseq_correctness_test.go
@@ -1,0 +1,267 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// batchseq (sequence-batch) engine regressions.
+//
+// SCOPE NOTE: the batchseq engine is reached ONLY from (*Model).Embeddings
+// (sdk/kronk/model/embed.go:91) and (*Model).Rerank (sdk/kronk/model/rerank.go:95),
+// selected at sdk/kronk/model/model.go:376 via useBatchSeq ->
+// supportsBatchSeq (sdk/kronk/model/batchseq_compat.go:7), which is true only
+// for mi.IsEmbedModel || mi.IsRerankModel. Chat / ChatStreaming never touch it.
+// Both regressions pinned below therefore affect embedding and reranking
+// quality, not text generation.
+//
+// Both live in code paths that need a loaded llama shared library plus a loaded
+// GGUF (llama.Decode / llama.GetEmbeddingsSeq / llama.Tokenize are raw FFI
+// calls), so they are pinned as AST assertions over the checked-in source in
+// the style of mtp_ctxparams_source_test.go and doc_comment_claims_test.go.
+// They locate everything by declaration name, never by line number, so they
+// survive unrelated edits. Shared helpers (kronkRepoRoot, parseKronkSource,
+// findKronkFunc, srcPos, nonTestGoFiles) come from
+// sdk/kronk/model/mtp_ctxparams_source_test.go.
+
+// batchSeqSelectorNames collects every `pkg.Name` selector name used anywhere in
+// the non-test sources of dir. Only the trailing identifier is recorded, so
+// `llama.GetEmbeddingsIth` is reported as "GetEmbeddingsIth".
+func batchSeqSelectorNames(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	root := kronkRepoRoot(t)
+	fset := token.NewFileSet()
+	found := make(map[string]string)
+
+	for _, path := range nonTestGoFiles(t, dir) {
+		f := parseKronkSource(t, fset, path)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if _, ok := sel.X.(*ast.Ident); !ok {
+				return true
+			}
+			if _, exists := found[sel.Sel.Name]; !exists {
+				found[sel.Sel.Name] = srcPos(fset, root, sel.Pos())
+			}
+
+			return true
+		})
+	}
+
+	return found
+}
+
+// batchSeqFuncSelectors collects the `pkg.Name` selector names used inside the
+// single function declaration named fn in the file at path.
+func batchSeqFuncSelectors(t *testing.T, path string, fn string) map[string]bool {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	f := parseKronkSource(t, fset, path)
+	decl := findKronkFunc(t, f, path, fn)
+
+	found := make(map[string]bool)
+	ast.Inspect(decl, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			found[sel.Sel.Name] = true
+		}
+
+		return true
+	})
+
+	return found
+}
+
+// =============================================================================
+
+// TestBatchSeqEmbeddingHandlesNonePooling pins the missing
+// LLAMA_POOLING_TYPE_NONE path in the sequence-batch embedding runtime.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchseq_engine.go:476  (*batchSeqEngine).evaluateJob
+//     unconditionally reads its per-item output with
+//     `llama.GetEmbeddingsSeq(e.lctx, entry.seqID, int32(job.outputWidth))`.
+//   - sdk/kronk/model/batchseq_engine.go:478  classifies that read failing as
+//     `fatal = true`.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/tools/server/server-context.cpp:2202-2207
+//     (send_embedding) branches on the resolved pooling type:
+//     LLAMA_POOLING_TYPE_NONE -> llama_get_embeddings_ith(ctx, i);
+//     anything else -> llama_get_embeddings_seq(ctx, seq_id).
+//     :2209-2214 then degrades a NULL result to a zero vector for that ONE
+//     request instead of tearing anything down.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:2242-2245
+//     (send_rerank) keeps the same llama_get_embeddings_ith fallback.
+//   - .extras/llama.cpp/src/llama-context.cpp:1489-1531 (encode) and
+//     :1934-1981 (decode) populate ctx->embd_seq for MEAN / CLS / LAST / RANK
+//     ONLY. Under LLAMA_POOLING_TYPE_NONE the per-token buffer embd.data is
+//     filled instead and embd_seq stays empty, so
+//     .extras/llama.cpp/src/llama-context.cpp:924-931 (get_embeddings_seq)
+//     returns nullptr for every sequence id.
+//   - .extras/llama.cpp/src/llama-context.cpp:232-236 resolves
+//     LLAMA_POOLING_TYPE_UNSPECIFIED (the llama_context_default_params value,
+//     :3491) to LLAMA_POOLING_TYPE_NONE whenever the model's own
+//     hparams.pooling_type is also UNSPECIFIED. The hparams default is
+//     LLAMA_POOLING_TYPE_NONE (.extras/llama.cpp/src/llama-hparams.h:272) and
+//     the `<arch>.pooling_type` GGUF key is only written when the source HF
+//     repo ships a sentence-transformers 1_Pooling/config.json
+//     (.extras/llama.cpp/conversion/base.py:2062-2075).
+//
+// FAILURE SCENARIO: load any embedding GGUF whose metadata lacks
+// `<arch>.pooling_type` — third-party requantizations routinely drop it, and
+// kronk never supplies a default of its own (sdk/kronk/model/config.go:844-850
+// sets ctxParams.PoolingType for rerank models only, leaving embedding models
+// at UNSPECIFIED). llama_decode succeeds and returns 0, so the status check at
+// batchseq_engine.go:467-473 is happy. Then GetEmbeddingsSeq returns a nil
+// slice (yzma .extras/yzma/pkg/llama/context.go:451-462 maps the NULL pointer
+// to `nil, nil`), the length guard at batchseq_engine.go:480 reports
+// "item[N] returned 0 outputs, expected D", and because that error is raised
+// with fatal=true the engine's processLoop terminates permanently
+// (sdk/kronk/model/batchseq_engine.go:343-347 -> terminate). m.batchSeq is
+// never rebuilt, so EVERY later Embeddings() call on that model fails with the
+// stored engine error. Upstream serves the request from embd.data instead.
+//
+// THE ASSERTION: nothing in package model references the NONE-pooling half of
+// the llama API — neither the llama.GetEmbeddingsIth fallback nor
+// llama.GetPoolingType, nor any non-RANK llama.PoolingType* constant that would
+// let kronk pin a pooling mode at context creation. Either fix satisfies this
+// test.
+func TestBatchSeqEmbeddingHandlesNonePooling(t *testing.T) {
+	root := kronkRepoRoot(t)
+	dir := filepath.Join(root, "sdk", "kronk", "model")
+
+	// Sanity: the pooled-only accessor really is what evaluateJob uses. If this
+	// fails the production code was restructured and the assertion below needs
+	// to be re-derived rather than trusted.
+	sels := batchSeqFuncSelectors(t, filepath.Join(dir, "batchseq_engine.go"), "evaluateJob")
+	if !sels["GetEmbeddingsSeq"] {
+		t.Fatal("evaluateJob no longer calls llama.GetEmbeddingsSeq; re-derive this assertion")
+	}
+
+	// Any one of these proves the NONE-pooling case is handled: the upstream
+	// per-token fallback, a runtime pooling-type query, or forcing a pooled mode
+	// on the context for embedding models.
+	remedies := []string{
+		"GetEmbeddingsIth",
+		"GetPoolingType",
+		"PoolingTypeMean",
+		"PoolingTypeCLS",
+		"PoolingTypeLast",
+		"PoolingTypeNone",
+	}
+
+	names := batchSeqSelectorNames(t, dir)
+	for _, remedy := range remedies {
+		if at, ok := names[remedy]; ok {
+			t.Logf("NONE-pooling handled via llama.%s at %s", remedy, at)
+			return
+		}
+	}
+
+	t.Fatalf("package model references none of %v: the sequence-batch embedding "+
+		"path only reads llama.GetEmbeddingsSeq, which returns NULL under "+
+		"LLAMA_POOLING_TYPE_NONE, and treats that as a fatal engine error "+
+		"(batchseq_engine.go:476-482). Upstream send_embedding falls back to "+
+		"llama_get_embeddings_ith (server-context.cpp:2202-2207).", remedies)
+}
+
+// TestFormatRerankPairSeparatesQueryFromDocument pins the malformed
+// cross-encoder input built for every reranking request.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/rerank.go:261-263  formatRerankPair returns
+//     `fmt.Sprintf("%s %s", query, document)` — a bare space join.
+//   - sdk/kronk/model/rerank.go:157-158  (processRerankBatchSeq, the batchseq
+//     feeder) tokenizes that single string with
+//     `llama.Tokenize(m.vocab, pairText, m.addBOSToken, true)`.
+//   - sdk/kronk/model/rerank.go:209-211  the context-pool fallback does the
+//     same, so both runtimes are affected.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/tools/server/server-common.h:378 states the contract
+//     verbatim: "format rerank task: [BOS]query[EOS][SEP]doc[EOS]".
+//   - .extras/llama.cpp/tools/server/server-common.cpp:1553-1594
+//     (format_prompt_rerank) implements it at the TOKEN level: it prefers the
+//     model's own "rerank" chat template (llama_model_chat_template(model,
+//     "rerank"), :1561-1568) and otherwise assembles
+//     BOS + tokenize(query) + EOS + SEP + tokenize(doc) + EOS, gated on
+//     llama_vocab_get_add_bos / _add_eos / _add_sep (:1570-1591).
+//   - .extras/llama.cpp/tools/server/server-context.cpp:5022 is the only
+//     producer of rerank prompts in the server.
+//
+// FAILURE SCENARIO: bge-reranker-v2-m3 (the reranker this repo tests with,
+// sdk/kronk/tests/testlib/testlib.go:68) is an XLM-RoBERTa cross-encoder
+// trained on `<s> query </s></s> document </s>` — the doubled separator is the
+// segment boundary the model uses to tell the two halves apart. kronk hands it
+// `<s> query document </s>` instead (llama.Tokenize's addSpecial only adds the
+// vocab's BOS/EOS, never an interior SEP), so the model scores one run-on
+// sentence. Nothing errors: LLAMA_POOLING_TYPE_RANK still emits an n_cls_out
+// score, sigmoid() still maps it into [0,1], and Rerank() still returns a
+// confident-looking ordering that is silently wrong. A model-side "rerank"
+// chat template, if the GGUF carries one, is likewise ignored.
+//
+// THE ASSERTION, part 1: formatRerankPair is a pure function, so the wrong
+// output is asserted directly. Part 2: no rerank code path consults the vocab
+// separator or the "rerank" chat template, which is why the space join cannot
+// be corrected inside formatRerankPair alone — the fix has to move the pair
+// assembly to token level.
+func TestFormatRerankPairSeparatesQueryFromDocument(t *testing.T) {
+	const query = "what is the capital of France"
+	const document = "Paris is the capital and most populous city of France."
+
+	got := formatRerankPair(query, document)
+
+	if got == query+" "+document {
+		t.Errorf("formatRerankPair joined the pair with a bare space and no segment separator:\n"+
+			"\tgot: %q\n"+
+			"\tllama.cpp emits [BOS]query[EOS][SEP]doc[EOS] "+
+			"(.extras/llama.cpp/tools/server/server-common.cpp:1570-1591)", got)
+	}
+
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "rerank.go")
+
+	fset := token.NewFileSet()
+	f := parseKronkSource(t, fset, path)
+
+	// Either the vocab separator or the model's "rerank" chat template has to
+	// show up somewhere in rerank.go for the pair to be assembled correctly.
+	// llama.VocabSEP / llama.VocabGetAddSEP / llama.ModelChatTemplate are all
+	// already bound by yzma (.extras/yzma/pkg/llama/vocab.go:281, :341 and
+	// .extras/yzma/pkg/llama/model.go), so none of these is a missing binding.
+	remedies := []string{"VocabSEP", "VocabGetAddSEP", "ModelChatTemplate"}
+
+	seen := make(map[string]bool, len(remedies))
+	ast.Inspect(f, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			seen[sel.Sel.Name] = true
+		}
+
+		return true
+	})
+
+	for _, remedy := range remedies {
+		if seen[remedy] {
+			t.Logf("rerank pair assembly consults llama.%s", remedy)
+
+			return
+		}
+	}
+
+	t.Errorf("rerank.go references none of %s: the query/document pair is built "+
+		"as a plain string join (rerank.go:261-263) and tokenized in one shot "+
+		"(rerank.go:157-158, rerank.go:209-211), so the [EOS][SEP] segment "+
+		"boundary required by llama.cpp's format_prompt_rerank "+
+		"(server-common.cpp:1553-1594, contract at server-common.h:378) is "+
+		"never emitted", strings.Join(remedies, ", "))
+}

--- a/sdk/kronk/model/caching_prefix_divergence_test.go
+++ b/sdk/kronk/model/caching_prefix_divergence_test.go
@@ -1,0 +1,424 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Finding 1: the IMC prompt-cache decode paths treat every llama_decode
+// return code as success.
+//
+// FINDING
+//
+//	Both functions that decode a cached conversation prefix into a slot's KV
+//	sequence throw away llama_decode's status code:
+//
+//	  sdk/kronk/model/caching_imc.go:118
+//	      if _, err := llama.Decode(m.lctx, batch); err != nil {
+//	  sdk/kronk/model/batchgen_mtp.go:407   (decodeTokensIntoCacheMTP, the
+//	      MTP-aware analogue used for Qwen3.6 — see the dispatch at
+//	      sdk/kronk/model/batchgen_slot_start.go:447-452)
+//	      if _, err := llama.Decode(e.model.lctx, batch); err != nil {
+//
+//	yzma's binding returns the llama_decode status as the FIRST result and
+//	only ever produces a non-nil error when the context handle is zero
+//	(.extras/yzma/pkg/llama/context.go:382-390):
+//
+//	      func Decode(ctx Context, batch Batch) (int32, error) {
+//	          if ctx == 0 { return 0, errInvalidContext }
+//	          decodeFunc.Call(...)
+//	          return int32(result), nil
+//	      }
+//
+//	So for any live context the `err != nil` guard can never fire, and both
+//	functions unconditionally return nil.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/include/llama.h:964-976 documents the contract:
+//	    0 - success
+//	    1 - could not find a KV slot for the batch
+//	    2 - aborted (processed ubatches remain in the memory state)
+//	   -1 - invalid input batch
+//	  < -1 - fatal error (processed ubatches remain in the memory state)
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:3639-3691 is the
+//	reference handling: `const int ret = llama_decode(ctx_tgt, batch_view);`
+//	followed by an explicit `if (ret != 0)` that classifies 1 / -1 / < -1,
+//	calls `slot.prompt_clear()` (i.e. throws the cached prefix away) and
+//	either errors the slot or retries with a smaller batch. Nothing in
+//	llama.cpp ever advances a slot's n_past over a batch whose decode
+//	returned non-zero.
+//
+// CONCRETE FAILURE SCENARIO
+//
+//	Multi-turn conversation, IMC "append" hit. startSlot restores the cached
+//	prefix [0, reusable), then decodes the extension tokens through one of the
+//	two functions above. The unified KV cache is under pressure from the other
+//	slots, so find_slot fails and llama_decode returns 1 — the extension cells
+//	were never written. Both functions report success, so startSlot continues:
+//
+//	  batchgen_slot_start.go:471  cacheIdx = llama.Pos(job.imcNewTotalCached)
+//	  batchgen_slot_start.go:474  imcCommitSession(..., job.imcNewTotalCached,
+//	                              ..., job.imcNewCachedTokens, ...)
+//	  batchgen_slot_start.go:603  StateSeqGetData -> snapshot of a KV that is
+//	                              missing the extension cells
+//
+//	The session now advertises N cached tokens backed by a KV holding fewer,
+//	the suffix is decoded at position N (a hole in the sequence), and every
+//	later turn of the conversation restores that same truncated snapshot while
+//	believing the full prefix is present. The model attends over a prefix from
+//	which whole messages are missing — it "contradicts what it already said"
+//	because its own earlier context really did change under it. Identically for
+//	ret == -1 on this hybrid IMROPE target (qwen35moe), where
+//	llama_batch_allocr::init rejects a batch whose positions collide with the
+//	sequence's pos_max (.extras/llama.cpp/src/llama-batch.cpp:255-270).
+//
+// This test fails while either call site discards the status code and passes
+// once both bind and check it, matching the pattern already used by the sibling
+// decoders in caching_imc_media.go.
+func TestIMCCacheDecodeChecksLlamaDecodeStatus(t *testing.T) {
+	root := kronkRepoRoot(t)
+	modelDir := filepath.Join(root, "sdk", "kronk", "model")
+
+	// Positive control: the sibling embedding decoder in the same package
+	// binds and checks the status. If this ever stops being true the test
+	// below is asserting a pattern that no longer exists in the codebase,
+	// so fail loudly rather than silently passing.
+	{
+		fset := token.NewFileSet()
+		path := filepath.Join(modelDir, "caching_imc_media.go")
+		file := parseKronkSource(t, fset, path)
+		fd := findKronkFunc(t, file, path, "decodeEmbeddingsIntoCache")
+
+		site, ok := findLlamaDecodeSite(fd)
+		if !ok {
+			t.Fatalf("precondition changed: no llama.Decode call in decodeEmbeddingsIntoCache (%s)", path)
+		}
+		if site.discarded {
+			t.Fatalf("precondition changed: decodeEmbeddingsIntoCache also discards the llama_decode status (%s)",
+				srcPos(fset, root, site.pos))
+		}
+		if !llamaDecodeStatusIsCompared(fd, site.statusName) {
+			t.Fatalf("precondition changed: decodeEmbeddingsIntoCache never compares %q (%s)",
+				site.statusName, srcPos(fset, root, site.pos))
+		}
+	}
+
+	tests := []struct {
+		file string
+		fn   string
+		note string
+	}{
+		{
+			file: "caching_imc.go",
+			fn:   "decodeTokensIntoCache",
+			note: "IMC text cache build/extend decode (called from batchgen_slot_start.go:451 and caching_imc_media.go:118)",
+		},
+		{
+			file: "batchgen_mtp.go",
+			fn:   "decodeTokensIntoCacheMTP",
+			note: "IMC cache build/extend decode used whenever an MTP drafter is loaded (batchgen_slot_start.go:449) — the live path for Qwen3.6-35B-A3B-MTP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fn, func(t *testing.T) {
+			fset := token.NewFileSet()
+			path := filepath.Join(modelDir, tt.file)
+			file := parseKronkSource(t, fset, path)
+			fd := findKronkFunc(t, file, path, tt.fn)
+
+			site, ok := findLlamaDecodeSite(fd)
+			if !ok {
+				t.Fatalf("no llama.Decode call found in %s: the test pins a call site that no longer exists; re-point it", tt.fn)
+			}
+
+			switch {
+			case site.discarded:
+				t.Errorf(`%s: %s discards llama_decode's status code.
+
+  bug:      the IMC prompt-cache decode reports success for every non-zero
+            llama_decode return. %s
+  actual:   the call is written as "_, err := llama.Decode(...)" and only err
+            is checked, but yzma's Decode returns a non-nil error solely for a
+            zero context handle
+            (.extras/yzma/pkg/llama/context.go:382-390), so the guard is dead
+            code for a live context and the function always returns nil.
+  contract: .extras/llama.cpp/include/llama.h:964-976 — 1 = "could not find a
+            KV slot for the batch", -1 = "invalid input batch",
+            < -1 = fatal error.
+  llama.cpp: tools/server/server-context.cpp:3639-3691 binds the status
+            ("const int ret = llama_decode(...)"), classifies it, and calls
+            slot.prompt_clear() instead of advancing n_past.
+  impact:   startSlot then sets cacheIdx = job.imcNewTotalCached
+            (batchgen_slot_start.go:471), commits that count to the IMC
+            session (batchgen_slot_start.go:474) and snapshots a KV that is
+            missing the just-"decoded" cells. Every later turn restores a
+            prefix shorter than the session claims, so the conversation
+            silently loses earlier context.
+  fix:      bind the status ("ret, err := llama.Decode(...)") and fail on
+            "err != nil || ret != 0" via decodeError(ret, err), exactly as
+            decodeEmbeddingsIntoCache (caching_imc_media.go:236-244),
+            decodeEmbeddingsMRoPEIntoCache (:312-323) and
+            decodeTextMRoPEIntoCache (:377-388) already do.`,
+					srcPos(fset, root, site.pos), tt.fn, tt.note)
+
+			case !llamaDecodeStatusIsCompared(fd, site.statusName):
+				t.Errorf(`%s: %s binds llama_decode's status as %q but never compares it.
+
+  bug:      the status is captured and then ignored, which is equivalent to
+            discarding it. %s
+  fix:      fail the decode on "%s != 0" (see decodeEmbeddingsIntoCache,
+            caching_imc_media.go:242-244).`,
+					srcPos(fset, root, site.pos), tt.fn, site.statusName, tt.note, site.statusName)
+			}
+		})
+	}
+}
+
+// llamaDecodeSite describes one `llama.Decode` call inside a function body.
+type llamaDecodeSite struct {
+	pos        token.Pos
+	statusName string // identifier bound to the first (status) result
+	discarded  bool   // true when the status result is assigned to "_"
+}
+
+// findLlamaDecodeSite returns the first `llama.Decode(...)` call in fd whose
+// results are assigned, together with how the status result was bound.
+func findLlamaDecodeSite(fd *ast.FuncDecl) (llamaDecodeSite, bool) {
+	var out llamaDecodeSite
+	var found bool
+
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
+			return true
+		}
+
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Decode" {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "llama" {
+			return true
+		}
+
+		out.pos = call.Pos()
+		found = true
+
+		lhs, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok {
+			out.discarded = true
+			return false
+		}
+
+		out.statusName = lhs.Name
+		out.discarded = lhs.Name == "_"
+
+		return false
+	})
+
+	return out, found
+}
+
+// llamaDecodeStatusIsCompared reports whether name appears on either side of an
+// equality/inequality comparison anywhere in fd.
+func llamaDecodeStatusIsCompared(fd *ast.FuncDecl, name string) bool {
+	if name == "" || name == "_" {
+		return false
+	}
+
+	var compared bool
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		bin, ok := n.(*ast.BinaryExpr)
+		if !ok {
+			return true
+		}
+		if bin.Op != token.EQL && bin.Op != token.NEQ {
+			return true
+		}
+		for _, side := range []ast.Expr{bin.X, bin.Y} {
+			if id, ok := side.(*ast.Ident); ok && id.Name == name {
+				compared = true
+			}
+		}
+		return true
+	})
+
+	return compared
+}
+
+// =============================================================================
+// Finding 2: the documented cachedRenderInputHash guard on the IMC pure-hit
+// snapshot-skip path does not exist.
+//
+// FINDING
+//
+//	imcSession.cachedRenderInputHash is written at three sites
+//	(sdk/kronk/model/caching_imc.go:159, :222, :262 — fed by
+//	sdk/kronk/model/batchgen_slot_start.go:340, :474, :722-724) and is never
+//	read in a comparison anywhere in sdk/kronk/model/. Three doc comments
+//	nevertheless describe it as an active guard:
+//
+//	  sdk/kronk/model/model.go:94-96
+//	      "cachedRenderInputHash guards token-v2 pure-hit snapshot reuse
+//	       against changes to template inputs that are not represented by
+//	       message tokens."
+//	  sdk/kronk/model/caching.go:203-205
+//	      "Used as the safety guard for IMCPureHitSnapshotSkip."
+//	  sdk/kronk/model/batchgen_slot_start.go:153-160
+//	      "A concurrent extend/rebuild between token-v2 planner and startSlot
+//	       would change cachedMsgsHash / cachedMsgCount / totalTokensCached /
+//	       cachedRenderInputHash"
+//
+//	The two staleness predicates the comments point at — sessionVersionOK
+//	(batchgen_slot_start.go:169-176) and the skipSnapshot versionOK
+//	(batchgen_slot_start.go:541-551) — compare cachedMsgsHash,
+//	cachedMsgCount, totalTokensCached, logicalPosition, promptPlan, reserved
+//	and kvState length. cachedRenderInputHash is absent from both. There is no
+//	IMCPureHitSnapshotSkip symbol in the package either.
+//
+//	The existing "regression guard"
+//	TestIMCCommitEmptyRenderHashDisqualifiesSkip
+//	(sdk/kronk/model/caching_imc_pure_hit_test.go:308-323) states in its own
+//	doc that "The startSlot block uses session.cachedRenderInputHash != "" as
+//	one of its required guards" and then asserts only that imcCommitSession
+//	stored the empty string — so the guard it claims to protect is never
+//	exercised.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-task.cpp:1662-1690 and
+//	tools/server/server-context.cpp:3197-3200 show the reference model for
+//	prompt-cache validity: every field that can change what a cached prefix
+//	means is folded into the comparison itself (server_tokens::get_common_prefix,
+//	.extras/llama.cpp/tools/server/server-common.cpp:471-518, plus the explicit
+//	alora_invocation_start clamp at server-context.cpp:3203-3207). llama.cpp
+//	does not carry a guard field it never evaluates.
+//
+// CONCRETE FAILURE SCENARIO
+//
+//	Not a wrong-output bug today — the token-exact prefix comparison in
+//	processIMCTokenPlan (caching_imc_tokens.go:56) and the promptPlan equality
+//	check for media sessions (caching_imc_media_tokens.go:56-62) already
+//	subsume every input the fingerprint covers. The defect is that three doc
+//	comments and one test assert a safety guard that is not in the code, so the
+//	next change to the pure-hit skip predicate (for example one that relaxes
+//	the token comparison, or adds a template input that is not rendered into
+//	tokens) will be made in the belief that the fingerprint still backstops it.
+//
+// This test fails while cachedRenderInputHash has zero comparison sites and
+// passes once the guard is implemented (or the three claims and the vacuous
+// regression guard are deleted).
+func TestIMCPureHitSkipGuardReadsCachedRenderInputHash(t *testing.T) {
+	root := kronkRepoRoot(t)
+	modelDir := filepath.Join(root, "sdk", "kronk", "model")
+
+	const field = "cachedRenderInputHash"
+
+	// Ground the claim: only assert the missing guard while the doc comments
+	// that advertise it are still present.
+	claims := []struct {
+		file string
+		want string
+	}{
+		{"model.go", "guards token-v2 pure-hit snapshot reuse"},
+		{"caching.go", "IMCPureHitSnapshotSkip"},
+		{"batchgen_slot_start.go", "cachedRenderInputHash"},
+	}
+
+	var claimed []string
+	for _, c := range claims {
+		fset := token.NewFileSet()
+		path := filepath.Join(modelDir, c.file)
+		file := parseKronkSource(t, fset, path)
+
+		for _, group := range file.Comments {
+			if strings.Contains(group.Text(), c.want) {
+				claimed = append(claimed, srcPos(fset, root, commentClaimPos(group, c.want)))
+				break
+			}
+		}
+	}
+
+	if len(claimed) == 0 {
+		t.Skipf("no doc comment advertises %s as a guard any more; nothing to pin", field)
+	}
+
+	writes := fieldWriteSites(t, root, modelDir, field)
+	reads := fieldCompareSites(t, root, modelDir, field)
+
+	if len(reads) == 0 {
+		t.Errorf(`%s is written at %d site(s) and compared at 0 site(s), but %d doc comment(s) describe it as an active guard.
+
+  bug:      the pure-hit snapshot-skip guard the comments promise does not
+            exist in the code.
+  claims:   %s
+  writes:   %s
+  actual:   neither sessionVersionOK (sdk/kronk/model/batchgen_slot_start.go:169-176)
+            nor the skipSnapshot versionOK expression
+            (sdk/kronk/model/batchgen_slot_start.go:541-551) mentions %s, and
+            there is no IMCPureHitSnapshotSkip symbol in the package.
+  also:     TestIMCCommitEmptyRenderHashDisqualifiesSkip
+            (sdk/kronk/model/caching_imc_pure_hit_test.go:308-323) documents a
+            guard ("startSlot ... uses session.cachedRenderInputHash != \"\"")
+            that it never asserts, so the "regression guard" is vacuous.
+  llama.cpp: tools/server/server-common.cpp:471-518 plus
+            tools/server/server-context.cpp:3197-3207 — every input that can
+            invalidate a cached prefix is part of the comparison itself; no
+            unread guard field is carried alongside it.
+  fix:      add session.cachedRenderInputHash == job.imcExpectedRenderHash &&
+            session.cachedRenderInputHash != "" to both staleness predicates,
+            or delete the claims above and the vacuous regression guard.`,
+			field, len(writes), len(claimed),
+			strings.Join(claimed, ", "),
+			strings.Join(writes, ", "),
+			field)
+	}
+}
+
+// fieldCompareSites returns every repo-relative "file:line" in dir's non-test
+// sources where a struct field named field appears on either side of an
+// equality/inequality comparison.
+func fieldCompareSites(t *testing.T, root string, dir string, field string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	var sites []string
+	for _, path := range nonTestGoFiles(t, dir) {
+		f := parseKronkSource(t, fset, path)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			bin, ok := n.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+			if bin.Op != token.EQL && bin.Op != token.NEQ {
+				return true
+			}
+			for _, side := range []ast.Expr{bin.X, bin.Y} {
+				if sel, ok := side.(*ast.SelectorExpr); ok && sel.Sel.Name == field {
+					sites = append(sites, srcPos(fset, root, sel.Pos()))
+				}
+			}
+			return true
+		})
+	}
+
+	return sites
+}

--- a/sdk/kronk/model/context_window_sizing_test.go
+++ b/sdk/kronk/model/context_window_sizing_test.go
@@ -1,0 +1,448 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// Context-window sizing / per-sequence division / prompt-limit regressions.
+//
+// Reference build: .extras/llama.cpp (llama.cpp b10211). Reference model:
+// unsloth/Qwen3.6-35B-A3B-MTP-GGUF (arch qwen35moe, block_count 41,
+// context_length 262144, nextn_predict_layers 1, full_attention_interval 4,
+// ssm.* present -> hybrid attention+recurrent, NO attention.sliding_window key
+// so hparams.n_swa == 0 for this target).
+//
+// RULED OUT while auditing this area (do not re-investigate):
+//
+//   - n_ctx vs n_ctx_seq. llama.cpp derives the per-sequence window as
+//     n_ctx_seq = kv_unified ? n_ctx : GGML_PAD(n_ctx / n_seq_max, 256)
+//     (.extras/llama.cpp/src/llama-context.cpp:286-298) and the server hands
+//     that to every slot (tools/server/server-context.cpp:1294, :1349).
+//     Kronk's ContextWindow is a PER-SEQUENCE quantity and modelCtxParams
+//     scales it up before handing it to libllama:
+//     sdk/kronk/model/config.go:862  ctxParams.NCtx = ContextWindow * nSeqMax
+//     sdk/kronk/model/config.go:937-939  KVUnified = 1 when nSeqMax > 1
+//     so n_ctx_seq == ContextWindow*nSeqMax (unified) or == pad(ContextWindow)
+//     (nSeqMax == 1). Either way each slot's gate of ContextWindow
+//     (batchgen_slot_start.go:839) is <= the capacity libllama allocated, and
+//     sdk/kronk/gguf/kvcache.go:74-81 sizes the VRAM estimate with the same
+//     ContextWindow*Slots convention. No halving bug.
+//   - Silent prompt truncation. The only truncation in the repo is the opt-in
+//     embeddings/rerank path (embed.go:138-150, rerank.go:160). The chat path
+//     errors the request (batchgen_slot_start.go:839-843, :1012-1016,
+//     :1112-1116), which is what llama.cpp does with ctx_shift disabled.
+//   - Context shift. Kronk implements none, and llama.cpp defaults
+//     common_params.ctx_shift = false (.extras/llama.cpp/common/common.h:569)
+//     and force-disables it for memories that cannot shift
+//     (tools/server/server-context.cpp:1268-1272), which covers this hybrid
+//     target. Nothing to diverge from.
+
+// =============================================================================
+
+// ctxSizingLlamaCppDraftMax is a VERBATIM MIRROR of llama.cpp's
+// server_slot::get_n_draft_max:
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:473
+//		int n_draft_max = n_ctx - prompt.n_tokens() - 2;
+//	.extras/llama.cpp/tools/server/server-context.cpp:475-477
+//		if (n_remaining > 0) {
+//		    n_draft_max = std::min(n_draft_max, n_remaining - 1);
+//		}
+//	.extras/llama.cpp/tools/server/server-context.cpp:2986-2988
+//		const int n_draft_max = slot.get_n_draft_max();
+//		if (n_draft_max > 0) { ... generate drafts ... }
+//
+// nPast is llama.cpp's slot.prompt.n_tokens(): the comment at
+// server-context.cpp:471-473 notes it is NOT yet expanded with the token
+// sampled this round, which is exactly Kronk's s.nPast at the point
+// batchgen_engine.go:284 pushes the spec range. nRemaining is
+// server-context.cpp:436-440 (n_predict - n_decoded); Kronk's equivalent is
+// job.params.MaxTokens - (s.reasonTokens + s.completionTokens).
+func ctxSizingLlamaCppDraftMax(nCtx int, nPast int, nRemaining int) int {
+	n := nCtx - nPast - 2
+
+	if nRemaining > 0 {
+		n = min(n, nRemaining-1)
+	}
+
+	return max(n, 0)
+}
+
+// TestChooseNDraftClampsToRemainingContext pins a missing guard: Kronk has no
+// equivalent of llama.cpp's get_n_draft_max, so the speculative/MTP draft width
+// is chosen from the acceptance EMA alone and is never clamped by the slot's
+// remaining context or its remaining token budget.
+//
+// FINDING
+//
+//	chooseNDraft (sdk/kronk/model/batchgen_speculative.go:147) branches only on
+//	s.specAccEMA and returns up to maxDraft. It cannot see s.nPast, the
+//	configured ContextWindow, or job.params.MaxTokens, and neither can its three
+//	call sites:
+//	  sdk/kronk/model/batchgen_speculative.go:181 (separate-GGUF drafter)
+//	  sdk/kronk/model/batchgen_mtp.go:258         (own-KV embedded MTP)
+//	  sdk/kronk/model/batchgen_mtp.go:671         (shared-KV MTP assistant)
+//	The returned width is then written straight into the target batch as
+//	positions s.nPast .. s.nPast+nDraft:
+//	  sdk/kronk/model/batchgen_engine.go:284-287
+//	so a speculative round needs nDraft MORE KV cells than the plain
+//	single-token round it replaces.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:473
+//	    int n_draft_max = n_ctx - prompt.n_tokens() - 2;
+//	.extras/llama.cpp/tools/server/server-context.cpp:476
+//	    n_draft_max = std::min(n_draft_max, n_remaining - 1);
+//	.extras/llama.cpp/tools/server/server-context.cpp:2988
+//	    if (n_draft_max > 0) { ... }
+//	Upstream reserves two cells of the slot's window (n_ctx here is
+//	slot.n_ctx == llama_n_ctx_seq, server-context.cpp:1294/1349) and refuses to
+//	draft at all when the reserve is gone.
+//
+// CONCRETE FAILURE SCENARIO
+//
+//	ContextWindow 8192, nseq-max 2 (KVUnified, pool = 16384 cells,
+//	config.go:862/937), MTP nDraft 2 (draft_mtp.go:22). Slot A's conversation
+//	reaches s.nPast == 8190 with acceptance high, so chooseNDraft returns 2 and
+//	batchgen_engine.go:284-287 asks libllama for positions 8190..8192 — one cell
+//	past what the slot is allowed and, with both slots near their gate, past the
+//	shared unified pool. llama_decode returns 1 and batchgen_engine.go:464-475
+//	fails EVERY active slot, so the co-resident conversation that was nowhere
+//	near its own limit dies too. llama.cpp would have returned n_draft_max <= 0
+//	and quietly decoded a single token instead. The same missing clamp makes
+//	Kronk draft a full round when only one token of MaxTokens budget is left:
+//	handleSpeculativeToken -> handleSampledToken finishes the slot mid-verify
+//	(batchgen_tokens.go:207-210), so Phase B (finalizeSpeculativeTokens) never
+//	runs and the round's draft+verify decode work is pure waste.
+//
+// The fix is to thread the slot's remaining context and remaining budget into
+// chooseNDraft and clamp exactly as get_n_draft_max does.
+func TestChooseNDraftClampsToRemainingContext(t *testing.T) {
+	const contextWindow = 8192
+
+	// maxDraft as the MTP path supplies it: mtpNDraft(cfg) with no override,
+	// i.e. defMTPNDraft (sdk/kronk/model/draft_mtp.go:22).
+	maxDraft := defMTPNDraft
+
+	tests := []struct {
+		name string
+		// nPast is the slot's KV position before this round's sampled token,
+		// i.e. what batchgen_engine.go:284 passes to e.batch.Add.
+		nPast int
+		// nRemaining is MaxTokens - (reasonTokens + completionTokens).
+		nRemaining int
+	}{
+		{
+			name:       "mid conversation, plenty of room",
+			nPast:      4000,
+			nRemaining: 4000,
+		},
+		{
+			name:       "exactly at llama.cpp's two-cell reserve",
+			nPast:      contextWindow - 2,
+			nRemaining: 1000,
+		},
+		{
+			name:       "one cell left in the window",
+			nPast:      contextWindow - 1,
+			nRemaining: 1000,
+		},
+		{
+			name:       "last token of the max-tokens budget",
+			nPast:      100,
+			nRemaining: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A slot whose acceptance is healthy, so the adaptive throttle
+			// does not mask the missing clamp. specAccEMA starts at 1.0 for
+			// every slot (newBatchEngine, batchgen_engine.go:55).
+			s := &slot{specAccEMA: 1.0}
+
+			got := chooseNDraft(s, maxDraft)
+
+			want := ctxSizingLlamaCppDraftMax(contextWindow, tt.nPast, tt.nRemaining)
+
+			if got > want {
+				// Cells the spec range writes past the slot's last legal
+				// position (contextWindow-1). Negative means the round fits in
+				// the window and it is the max-tokens budget that is violated.
+				overrun := tt.nPast + got - (contextWindow - 1)
+
+				effect := "batchgen_engine.go:284-287 pushes positions " +
+					fmt.Sprintf("%d..%d", tt.nPast, tt.nPast+got) +
+					" into the target batch — " + fmt.Sprintf("%d", overrun) +
+					" cell(s) past the slot's last legal position " +
+					fmt.Sprintf("%d", contextWindow-1) +
+					". llama_decode returns 1 and batchgen_engine.go:464-475 fails every active " +
+					"slot, including co-resident conversations that were nowhere near their own limit."
+				if overrun <= 0 {
+					effect = "the round fits the window but overshoots the remaining max-tokens " +
+						"budget: handleSpeculativeToken -> handleSampledToken finishes the slot " +
+						"mid-verify (batchgen_tokens.go:207-210), so Phase B " +
+						"(finalizeSpeculativeTokens) never runs and the whole draft+verify decode " +
+						"is wasted. llama.cpp's min(n_draft_max, n_remaining-1) prevents it."
+				}
+
+				t.Errorf("chooseNDraft = %d draft token(s), but only %d fit\n"+
+					"  slot state:    n_past = %d, context window = %d, remaining budget = %d\n"+
+					"  llama.cpp:     n_draft_max = n_ctx - prompt.n_tokens() - 2 = %d - %d - 2, "+
+					"then min(.., n_remaining-1) -> %d\n"+
+					"                 (.extras/llama.cpp/tools/server/server-context.cpp:473,476; "+
+					"gated at :2988)\n"+
+					"  kronk:         chooseNDraft (batchgen_speculative.go:147) branches only on "+
+					"s.specAccEMA and never sees n_past, ContextWindow or MaxTokens.\n"+
+					"  effect:        %s\n"+
+					"  fix:           thread the slot's remaining context and remaining token budget "+
+					"into chooseNDraft and clamp as get_n_draft_max does.",
+					got, want,
+					tt.nPast, contextWindow, tt.nRemaining,
+					contextWindow, tt.nPast, want,
+					effect)
+			}
+		})
+	}
+}
+
+// =============================================================================
+
+// ctxSizingPromptRejected is a VERBATIM MIRROR of Kronk's one and only
+// prompt-length gate, which appears three times with identical arithmetic:
+//
+//	sdk/kronk/model/batchgen_slot_start.go:839  (startSlotText)
+//		if s.nPrompt > e.model.cfg.ContextWindow() {
+//	sdk/kronk/model/batchgen_slot_start.go:1012 (startSlotTextMRoPE)
+//	sdk/kronk/model/batchgen_slot_start.go:1112 (startSlotMedia)
+//
+// The gate lives inside startSlot* which needs a live llama.Context and a
+// loaded GGUF, so this mirror isolates the comparison.
+//
+// MAINTAINER: when those three lines are fixed, update this mirror in the same
+// commit so it keeps tracking the production predicate.
+func ctxSizingPromptRejected(nPrompt int, contextWindow int) bool {
+	return nPrompt > contextWindow
+}
+
+// TestPromptAtExactContextWindowIsRejected pins an off-by-one in the prompt
+// admission gate: a prompt of EXACTLY ContextWindow tokens is admitted, leaving
+// zero cells for the very first generated token.
+//
+// FINDING
+//
+//	sdk/kronk/model/batchgen_slot_start.go:839 (and :1012, :1112) rejects only
+//	when s.nPrompt > ContextWindow. A prompt of exactly ContextWindow tokens
+//	occupies KV positions 0..ContextWindow-1, i.e. the whole per-sequence
+//	window, and then the first generation round writes position ContextWindow
+//	(batchgen_engine.go:333-334 / :284).
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:3188-3194
+//		if (slot.task->n_tokens() >= slot.n_ctx) {
+//		    send_error(slot, "request (%d tokens) exceeds the available context
+//		                      size (%d tokens), try increasing it",
+//		               ERROR_TYPE_EXCEED_CONTEXT_SIZE);
+//		    slot.release();
+//		    return;
+//		}
+//	Upstream uses >=, not >, precisely because a slot needs at least one free
+//	cell to decode anything. slot.n_ctx is the per-sequence window
+//	(llama_n_ctx_seq, server-context.cpp:1294/1349) — the same quantity Kronk
+//	compares against.
+//
+// CONCRETE FAILURE SCENARIO
+//
+//	ContextWindow 8192 and a rendered conversation that tokenizes to exactly
+//	8192 tokens. Kronk admits the slot, prefills all 8192 cells, then the first
+//	decode of the generation phase asks for position 8192. libllama's find_slot
+//	has no free cell for the sequence, llama_decode returns 1, and
+//	batchgen_engine.go:464-475 fails EVERY active slot with the generic
+//	"the context window is full" message (batchgen_errors.go:81) — after the
+//	caller has already paid for a full 8192-token prefill, and taking any
+//	co-resident conversation down with it. llama.cpp rejects the request up
+//	front with an actionable EXCEED_CONTEXT_SIZE error and never touches the
+//	other slots.
+//
+// The fix is to use >= at all three sites (or reserve at least one cell), which
+// also makes the reported limit self-consistent with MaxTokens >= 1.
+func TestPromptAtExactContextWindowIsRejected(t *testing.T) {
+	const contextWindow = 8192
+
+	tests := []struct {
+		name    string
+		nPrompt int
+		want    bool
+	}{
+		{
+			name:    "one token below the window is admissible",
+			nPrompt: contextWindow - 1,
+			want:    false,
+		},
+		{
+			name:    "exactly the window leaves no cell to generate into",
+			nPrompt: contextWindow,
+			want:    true,
+		},
+		{
+			name:    "one token above the window",
+			nPrompt: contextWindow + 1,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ctxSizingPromptRejected(tt.nPrompt, contextWindow)
+
+			if got != tt.want {
+				t.Errorf("prompt of %d token(s) against a %d-token window: rejected = %t, want %t\n"+
+					"  kronk:      batchgen_slot_start.go:839 (also :1012, :1112)\n"+
+					"                  if s.nPrompt > e.model.cfg.ContextWindow()\n"+
+					"  llama.cpp:  .extras/llama.cpp/tools/server/server-context.cpp:3188\n"+
+					"                  if (slot.task->n_tokens() >= slot.n_ctx)\n"+
+					"              -> send_error(... ERROR_TYPE_EXCEED_CONTEXT_SIZE), slot.release()\n"+
+					"  effect:     a prompt of exactly ContextWindow tokens fills KV positions\n"+
+					"              0..ContextWindow-1, so the first generation decode\n"+
+					"              (batchgen_engine.go:333-334) asks for position ContextWindow,\n"+
+					"              llama_decode returns 1, and batchgen_engine.go:464-475 fails\n"+
+					"              EVERY active slot after a full-window prefill has already been\n"+
+					"              paid for.\n"+
+					"  fix:        use >= at all three sites.",
+					tt.nPrompt, contextWindow, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+
+// ctxSizingPickedWindow is a VERBATIM MIRROR of adjustContextWindow:
+//
+//	sdk/kronk/model/config.go:804-807
+//		// User explicitly set the context window — honor it as-is.
+//		if cfg.ContextWindow() > 0 {
+//			return cfg
+//		}
+//	sdk/kronk/model/config.go:811-818  modelCW from GGUF "context_length"
+//	sdk/kronk/model/config.go:825
+//		pickedCW := min(modelCW, defContextWindow)
+//
+// adjustContextWindow takes a live llama.Model (it calls searchModelMeta), so
+// this mirror isolates the decision. defContextWindow is the real production
+// constant (sdk/kronk/model/config.go:50).
+//
+// MAINTAINER: when config.go:804-825 gains the n_ctx_train cap, update this
+// mirror in the same commit.
+func ctxSizingPickedWindow(userCW int, modelCW int) int {
+	if userCW > 0 {
+		return userCW
+	}
+
+	return min(modelCW, defContextWindow)
+}
+
+// TestPickedContextWindowNeverExceedsTrainedContext pins a missing cap: an
+// explicitly configured ContextWindow is honoured verbatim and is never bounded
+// by the model's trained context length.
+//
+// FINDING
+//
+//	sdk/kronk/model/config.go:804-807 returns immediately for any
+//	cfg.ContextWindow() > 0 without reading the GGUF's "<arch>.context_length"
+//	at all — that lookup (config.go:811-818) and the min() at config.go:825 are
+//	on the auto-pick path only. validateConfig (config.go:525) never looks at
+//	ContextWindow either. The value then becomes BOTH the per-request prompt
+//	limit (batchgen_slot_start.go:839) and the default MaxTokens
+//	(params.go:705-706), and is scaled into ctxParams.NCtx at config.go:862.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:1294-1297
+//		int n_ctx_slot = llama_n_ctx_seq(ctx_tgt);
+//		if (n_ctx_slot > n_ctx_train) {
+//		    SRV_WRN("the slot context (%d) exceeds the training context of the
+//		             model (%d) - capping\n", n_ctx_slot, n_ctx_train);
+//		    n_ctx_slot = n_ctx_train;
+//		}
+//	server-context.cpp:1349 then assigns that capped value to every slot. The
+//	C API alone only warns (.extras/llama.cpp/src/llama-context.cpp:320-322),
+//	so the cap is a deliberate server-level policy — and Kronk is a server.
+//
+// CONCRETE FAILURE SCENARIO
+//
+//	The reference MTP target advertises qwen35moe.context_length = 262144, so
+//	the auto-pick path is safe (it lands on defContextWindow = 8192). The
+//	explicit path is not: WithContextWindow(N) with N above the model's trained
+//	context makes Kronk admit prompts and grant a MaxTokens budget out to N
+//	positions the RoPE was never trained on. Generation past n_ctx_train
+//	degrades without any error, which for a long multi-turn conversation looks
+//	exactly like the model forgetting or contradicting what it asserted
+//	earlier. llama.cpp's server caps the slot instead and logs the cap.
+//
+// The fix is to clamp an explicit ContextWindow at the model's trained context
+// in adjustContextWindow (which already has the llama.Model handle and already
+// reads "context_length") and log the cap the way upstream does.
+func TestPickedContextWindowNeverExceedsTrainedContext(t *testing.T) {
+	tests := []struct {
+		name string
+		// userCW is cfg.ContextWindow() as configured (0 = auto-pick).
+		userCW int
+		// modelCW is the GGUF "<arch>.context_length" value, i.e. n_ctx_train.
+		modelCW int
+	}{
+		{
+			name:    "auto-pick on the reference qwen35moe MTP target",
+			userCW:  0,
+			modelCW: 262144,
+		},
+		{
+			name:    "explicit window equal to the trained context",
+			userCW:  262144,
+			modelCW: 262144,
+		},
+		{
+			name:    "explicit window above the trained context",
+			userCW:  524288,
+			modelCW: 262144,
+		},
+		{
+			name:    "explicit 32K window on a 4K-trained model",
+			userCW:  32768,
+			modelCW: 4096,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ctxSizingPickedWindow(tt.userCW, tt.modelCW)
+
+			if got > tt.modelCW {
+				t.Errorf("effective context window = %d, exceeds the model's trained context %d\n"+
+					"  kronk:      config.go:804-807 returns cfg unchanged for any explicit\n"+
+					"              ContextWindow; the GGUF \"context_length\" lookup at\n"+
+					"              config.go:811-818 and the min() at config.go:825 are on the\n"+
+					"              auto-pick path only, and validateConfig (config.go:525) never\n"+
+					"              inspects ContextWindow.\n"+
+					"  llama.cpp:  .extras/llama.cpp/tools/server/server-context.cpp:1294-1297\n"+
+					"                  int n_ctx_slot = llama_n_ctx_seq(ctx_tgt);\n"+
+					"                  if (n_ctx_slot > n_ctx_train) { ...capping...;\n"+
+					"                      n_ctx_slot = n_ctx_train; }\n"+
+					"              and :1349 assigns the capped value to every slot.\n"+
+					"  effect:     this value is the prompt limit (batchgen_slot_start.go:839)\n"+
+					"              AND the default MaxTokens (params.go:705-706), so Kronk\n"+
+					"              silently generates out to positions the RoPE was never\n"+
+					"              trained on — degradation with no error, which in a long\n"+
+					"              multi-turn conversation reads as the model contradicting\n"+
+					"              what it said earlier.\n"+
+					"  fix:        clamp an explicit ContextWindow at modelCW in\n"+
+					"              adjustContextWindow and log the cap.",
+					got, tt.modelCW)
+			}
+		})
+	}
+}

--- a/sdk/kronk/model/ffi_param_types_test.go
+++ b/sdk/kronk/model/ffi_param_types_test.go
@@ -1,0 +1,1111 @@
+// This file pins the FFI parameter/return TYPE defects found by a mechanical
+// sweep of every yzma binding against the llama.cpp header that matches the
+// pinned library build.
+//
+// # WHY A SWEEP WAS NEEDED
+//
+// Kronk reaches llama.cpp through yzma, a hand-written purego/libffi binding.
+// There is no cgo, so nothing checks these types at compile time. A mismatch
+// between (a) the C declaration, (b) the libffi type descriptor handed to
+// ffi.PrepCif, and (c) the Go variable whose address is handed to ffi.Fun.Call
+// is completely silent at build time and only shows up as corrupted memory or
+// corrupted values at runtime.
+//
+// THE THREE RULES CHECKED
+//
+//	RULE 1  The cif argument/return type list must match the C prototype
+//	        parameter-for-parameter in width, and in class (integer vs float
+//	        vs struct-by-value). On arm64: size_t/uint64_t/any pointer = 8,
+//	        int/int32_t/enum/float = 4, double = 8.
+//	RULE 2  The Go variable whose address is passed at each avalue slot must be
+//	        exactly as wide as the cif type claims. libffi reads exactly
+//	        ffi.Type.Size bytes from the pointer it is handed, so a 4-byte Go
+//	        variable behind a TypeUint64 slot makes libffi splice 4 bytes of
+//	        adjacent Go memory into the high half of the C argument.
+//	RULE 3  An INTEGER return buffer must be 8 bytes (ffi.Arg), because libffi
+//	        always stores a full ffi_arg. FLOAT returns are the opposite: they
+//	        must be float32, because libffi stores 4 bytes and ffi.Arg would
+//	        then be read as an integer. jupiterrider/ffi states both halves in
+//	        the Fun.Call doc comment ($GOMODCACHE/github.com/jupiterrider/
+//	        ffi@v0.7.0/fun.go:19-20): "You cannot use integer types smaller
+//	        than 8 bytes here (float32 and structs are not affected)."
+//
+// AUTHORITATIVE TREES
+//
+//	yzma that actually compiles: $GOMODCACHE/github.com/hybridgroup/yzma@v1.21.0
+//	   (resolved below with `go list -m`; the uncompiled .extras/yzma copy carries
+//	   a local patch that is NOT in the build and was deliberately not audited)
+//	header: b10211, the llama.cpp build pinned at sdk/tools/libs/libs.go:29
+//	   `git -C .extras/llama.cpp show b10211:include/llama.h`
+//	   (verified: the only include/llama.h difference between b10211 and the
+//	   checked-out b10217 is one added `bool load_mtp;` field)
+//
+// SWEEP RESULT — the numbers matter as much as the findings, because they are
+// what makes "these are the only ones" a measurement instead of an assertion.
+//
+//	847 C API declarations parsed from llama.h, ggml.h, ggml-backend.h,
+//	    ggml-cpu.h, mtmd.h and mtmd-helper.h at b10211 (0 unparsed)
+//	265 yzma ffi.Prep bindings found, 265/265 matched to a C declaration
+//	276 ffi.Fun.Call sites, 514 argument slots resolved (0 unresolvable)
+//	 23 struct-by-value slots compared by total size, all in agreement
+//
+//	RULE 1: 265 checked -> 264 clean,   1 violation
+//	RULE 2: 514 checked -> 502 clean,  12 violations
+//	RULE 3: 276 checked -> 272 clean,   4 violations
+//
+// WHERE THE 17 VIOLATIONS ARE PINNED
+//
+//	RULE 1  1  ggml_backend_cpu_buffer_type  -> this file
+//	RULE 2 12  4 sampler min_keep            -> this file
+//	           6 metadata buf_size           -> this file
+//	           1 MemorySeqDiv factor         -> this file
+//	           1 ModelDesc buf_size          -> ffi_pointer_safety_test.go (already known)
+//	RULE 3  4  2 float returns via ffi.Arg   -> this file
+//	           1 ggml_backend_cpu_buffer_type (same defect as the RULE 1 entry)
+//	           1 LoadModeFromStr return buf  -> ffi_pointer_safety_test.go (already known)
+//
+// Both already-known defects were re-derived independently by the sweep, which
+// is the correctness test for the checker. Struct FIELD layout is
+// ffi_struct_layout_test.go's subject and pointer LIFETIME is
+// ffi_pointer_safety_test.go's; this file only covers TYPES.
+//
+// Not covered by the 265: the four callback descriptors, which go through
+// ffi.PrepCif/PrepClosureLoc or purego.NewCallback rather than lib.Prep
+// (pkg/llama/model.go:887, pkg/mtmd/mtmd.go:276, pkg/llama/logs.go:56,
+// pkg/llama/context.go:800). All four were hand-checked against their C
+// typedefs and are correct.
+package model
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// =============================================================================
+// Executable evidence for the libffi behaviour the pins below rely on.
+// =============================================================================
+
+// ffiPTLibcName returns the shared library exporting the C functions the
+// runtime probes use, or "" when the platform is not one we can name.
+func ffiPTLibcName() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "libSystem.B.dylib"
+	case "linux":
+		return "libc.so.6"
+	case "freebsd", "netbsd":
+		return "libc.so.7"
+	case "windows":
+		return "msvcrt.dll"
+	default:
+		return ""
+	}
+}
+
+// TestFFIParamTypesLibffiReturnKindContract is the executable evidence for the
+// two halves of RULE 3 that the yzma pins below depend on. It goes through the
+// exact ffi.Lib/ffi.Fun machinery yzma uses and touches nothing from
+// llama.cpp, so it reproduces in milliseconds on any machine.
+//
+// Both subtests assert libffi's DOCUMENTED behaviour and are expected to PASS.
+// They exist so that TestFFIParamTypesYzmaFloatReturnsReadAsInteger and
+// TestFFIParamTypesGGMLCPUBufferTypeReturnDescriptor rest on a measurement
+// rather than on an argument from the documentation.
+func TestFFIParamTypesLibffiReturnKindContract(t *testing.T) {
+	name := ffiPTLibcName()
+	if name == "" {
+		t.Skipf("no known libc name for GOOS=%s", runtime.GOOS)
+	}
+
+	lib, err := ffi.Load(name)
+	if err != nil {
+		t.Skipf("cannot dlopen %s: %v", name, err)
+	}
+
+	// -------------------------------------------------------------------
+	// A float return is NOT an ffi_arg. libffi stores 4 bytes and leaves
+	// the rest of the buffer alone, so an ffi.Arg buffer ends up holding
+	// the IEEE-754 bit pattern in its low word. Converting that ffi.Arg
+	// with float32(...) is an integer->float numeric conversion, not a
+	// bit reinterpretation, so the result is astronomically wrong.
+	// -------------------------------------------------------------------
+	t.Run("float_return_is_not_an_ffi_arg", func(t *testing.T) {
+		fmaxf, err := lib.Prep("fmaxf", &ffi.TypeFloat, &ffi.TypeFloat, &ffi.TypeFloat)
+		if err != nil {
+			t.Skipf("prep fmaxf: %v", err)
+		}
+
+		const want = float32(1.5)
+		a, b := want, float32(0.25)
+
+		// Control: the correct buffer type round-trips exactly.
+		var correct float32
+		fmaxf.Call(unsafe.Pointer(&correct), &a, &b)
+		if correct != want {
+			t.Fatalf("control failed: fmaxf(%v, %v) into a float32 buffer = %v, want %v; "+
+				"the probe itself is wrong", a, b, correct, want)
+		}
+
+		// yzma's shape: an ffi.Arg buffer, pre-dirtied so we can see
+		// exactly how many bytes libffi replaces.
+		const dirty = uint64(0xAAAAAAAAAAAAAAAA)
+		arg := ffi.Arg(dirty)
+		fmaxf.Call(unsafe.Pointer(&arg), &a, &b)
+
+		if hi := uint32(uint64(arg) >> 32); hi != uint32(dirty>>32) {
+			t.Errorf("libffi modified the HIGH word of a float return buffer "+
+				"(0x%016X -> 0x%016X). That contradicts the premise of "+
+				"TestFFIParamTypesYzmaFloatReturnsReadAsInteger and needs "+
+				"revisiting.", dirty, uint64(arg))
+		}
+
+		if bits := math.Float32frombits(uint32(uint64(arg))); bits != want {
+			t.Errorf("low word of the float return buffer reinterpreted as "+
+				"float32 = %v, want %v (raw 0x%016X)", bits, want, uint64(arg))
+		}
+
+		// This is the number yzma actually returns.
+		if numeric := float32(arg); numeric == want {
+			t.Errorf("float32(ffi.Arg) produced the correct value %v on this "+
+				"platform. If that is genuinely true here, the "+
+				"ModelRopeFreqScaleTrain / VocabGetScore findings are harmless "+
+				"and their premise needs revisiting.", numeric)
+		} else {
+			t.Logf("confirmed: float return in an ffi.Arg buffer is raw 0x%016X; "+
+				"float32(arg) = %v but the true value is %v. yzma's "+
+				"`return float32(x)` is off by ~%.3g.",
+				uint64(arg), numeric, want, float64(numeric)/float64(want))
+		}
+	})
+
+	// -------------------------------------------------------------------
+	// A cif whose RETURN descriptor is TypeVoid makes libffi discard the
+	// return value entirely: it writes nothing at all into the buffer the
+	// caller supplied. The caller's variable therefore keeps whatever it
+	// held before the call, which for a fresh Go `var` means zero.
+	// -------------------------------------------------------------------
+	t.Run("void_return_descriptor_writes_nothing", func(t *testing.T) {
+		hay := []byte("abcdef")
+		hp := unsafe.SliceData(hay)
+		needle := int32('c')
+		n := uint64(len(hay))
+
+		// Control: declared as returning a pointer, we get one back.
+		asPtr, err := lib.Prep("memchr",
+			&ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeUint64)
+		if err != nil {
+			t.Skipf("prep memchr: %v", err)
+		}
+
+		var good uintptr
+		asPtr.Call(unsafe.Pointer(&good), unsafe.Pointer(&hp), &needle, &n)
+		if good != uintptr(unsafe.Pointer(hp))+2 {
+			t.Fatalf("control failed: memchr returned 0x%X, want base+2 (0x%X); "+
+				"the probe itself is wrong", good, uintptr(unsafe.Pointer(hp))+2)
+		}
+
+		// The defective shape: same C function, TypeVoid return descriptor.
+		asVoid, err := lib.Prep("memchr",
+			&ffi.TypeVoid, &ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeUint64)
+		if err != nil {
+			t.Skipf("prep memchr as void: %v", err)
+		}
+
+		const sentinel = uintptr(0x1234)
+		got := sentinel
+		asVoid.Call(unsafe.Pointer(&got), unsafe.Pointer(&hp), &needle, &n)
+
+		if got != sentinel {
+			t.Errorf("libffi wrote 0x%X into the return buffer of a TypeVoid cif "+
+				"(sentinel was 0x%X). If a void return descriptor really does "+
+				"deliver the value on this platform, the "+
+				"ggml_backend_cpu_buffer_type finding is harmless here and its "+
+				"premise needs revisiting.", got, sentinel)
+		} else {
+			t.Logf("confirmed: a TypeVoid return descriptor makes libffi write "+
+				"NOTHING; the caller's buffer still holds 0x%X. A Go `var x T` "+
+				"return buffer would therefore stay at its zero value forever.",
+				got)
+		}
+
+		runtime.KeepAlive(hay)
+	})
+}
+
+// =============================================================================
+// AST helpers over the COMPILED yzma.
+// =============================================================================
+
+// ffiPTYzmaDir returns the directory of a yzma package inside the module the
+// build actually uses, resolved via `go list -m` so it tracks the go.mod pin
+// rather than the uncompiled .extras/yzma copy. It skips when the toolchain or
+// the module cache is unavailable.
+func ffiPTYzmaDir(t *testing.T, pkg string) string {
+	t.Helper()
+
+	root := kronkRepoRoot(t)
+
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/hybridgroup/yzma")
+	cmd.Dir = root
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("cannot resolve the yzma module (module cache unavailable?): %v", err)
+	}
+
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		t.Skip("go list -m reported no directory for github.com/hybridgroup/yzma")
+	}
+
+	return filepath.Join(dir, pkg)
+}
+
+// ffiPTParse parses one yzma source file with positions.
+func ffiPTParse(t *testing.T, dir, base string) (*token.FileSet, *ast.File) {
+	t.Helper()
+
+	path := filepath.Join(dir, base)
+	fset := token.NewFileSet()
+
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		t.Skipf("cannot parse %s (yzma layout changed?): %v", path, err)
+	}
+
+	return fset, f
+}
+
+// ffiPTPrep locates the `<var>, err = lib.Prep("cName", &retType, &argType...)`
+// statement for a C symbol and returns the assigned Go variable name plus the
+// stringified type descriptors. retType is index 0 of types.
+func ffiPTPrep(t *testing.T, f *ast.File, cName string) (goVar string, types []string, pos token.Pos) {
+	t.Helper()
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		if goVar != "" {
+			return false
+		}
+
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Rhs) != 1 {
+			return true
+		}
+
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (sel.Sel.Name != "Prep" && sel.Sel.Name != "MustPrep") {
+			return true
+		}
+
+		if len(call.Args) < 2 || ffiPTStringLit(call.Args[0]) != cName {
+			return true
+		}
+
+		for _, l := range as.Lhs {
+			id, ok := l.(*ast.Ident)
+			if ok && id.Name != "err" && id.Name != "_" {
+				goVar = id.Name
+				break
+			}
+		}
+
+		for _, a := range call.Args[1:] {
+			types = append(types, ffiPTExprText(a))
+		}
+
+		pos = call.Lparen
+
+		return false
+	})
+
+	if goVar == "" {
+		t.Skipf("no lib.Prep(%q, ...) found; the yzma binding was renamed or removed", cName)
+	}
+
+	return goVar, types, pos
+}
+
+// ffiPTStringLit returns the value of a plain string literal, or "".
+func ffiPTStringLit(e ast.Expr) string {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return ""
+	}
+
+	return strings.Trim(bl.Value, "`\"")
+}
+
+// ffiPTExprText renders the small subset of expressions that appear in cif type
+// lists and Call argument lists.
+func ffiPTExprText(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		return ffiPTExprText(x.X) + "." + x.Sel.Name
+	case *ast.UnaryExpr:
+		return x.Op.String() + ffiPTExprText(x.X)
+	case *ast.StarExpr:
+		return "*" + ffiPTExprText(x.X)
+	case *ast.ParenExpr:
+		return "(" + ffiPTExprText(x.X) + ")"
+	case *ast.IndexExpr:
+		return ffiPTExprText(x.X) + "[" + ffiPTExprText(x.Index) + "]"
+	case *ast.BasicLit:
+		return x.Value
+	case *ast.CallExpr:
+		parts := make([]string, 0, len(x.Args))
+		for _, a := range x.Args {
+			parts = append(parts, ffiPTExprText(a))
+		}
+
+		return ffiPTExprText(x.Fun) + "(" + strings.Join(parts, ", ") + ")"
+	default:
+		return "?"
+	}
+}
+
+// ffiPTFuncDecl finds a top-level func declaration by name.
+func ffiPTFuncDecl(t *testing.T, f *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if ok && fd.Recv == nil && fd.Name.Name == name {
+			return fd
+		}
+	}
+
+	t.Skipf("func %s not found; the yzma API was renamed or removed", name)
+
+	return nil
+}
+
+// ffiPTCall finds the single `goVar.Call(...)` inside fn and returns its
+// arguments. Argument 0 is the return buffer.
+func ffiPTCall(t *testing.T, fn *ast.FuncDecl, goVar string) ([]ast.Expr, token.Pos) {
+	t.Helper()
+
+	var (
+		args []ast.Expr
+		pos  token.Pos
+		n    int
+	)
+
+	ast.Inspect(fn, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Call" {
+			return true
+		}
+
+		recv, ok := sel.X.(*ast.Ident)
+		if !ok || recv.Name != goVar {
+			return true
+		}
+
+		n++
+		args = call.Args
+		pos = call.Lparen
+
+		return true
+	})
+
+	if n != 1 {
+		t.Skipf("expected exactly one %s.Call(...) in %s, found %d; the yzma "+
+			"code shape changed", goVar, fn.Name.Name, n)
+	}
+
+	return args, pos
+}
+
+// ffiPTAddrOf unwraps `unsafe.Pointer(&x)` / `&x` down to the identifier x.
+// It returns "" for anything else (nil, a slice-data call, a bare pointer).
+func ffiPTAddrOf(e ast.Expr) string {
+	for {
+		call, ok := e.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			break
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			break
+		}
+
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "unsafe" || sel.Sel.Name != "Pointer" {
+			break
+		}
+
+		e = call.Args[0]
+	}
+
+	un, ok := e.(*ast.UnaryExpr)
+	if !ok || un.Op != token.AND {
+		return ""
+	}
+
+	id, ok := un.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return id.Name
+}
+
+// ffiPTDeclaredType returns the source-level type of a local variable or
+// parameter of fn, or "" when it cannot be determined syntactically.
+func ffiPTDeclaredType(fn *ast.FuncDecl, name string) string {
+	if fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			for _, id := range field.Names {
+				if id.Name == name {
+					return ffiPTExprText(field.Type)
+				}
+			}
+		}
+	}
+
+	found := ""
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+
+		switch x := n.(type) {
+		case *ast.DeclStmt:
+			gd, ok := x.Decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				return true
+			}
+
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || vs.Type == nil {
+					continue
+				}
+
+				for _, id := range vs.Names {
+					if id.Name == name {
+						found = ffiPTExprText(vs.Type)
+						return false
+					}
+				}
+			}
+
+		case *ast.AssignStmt:
+			if x.Tok != token.DEFINE || len(x.Lhs) != len(x.Rhs) {
+				return true
+			}
+
+			for i, l := range x.Lhs {
+				id, ok := l.(*ast.Ident)
+				if !ok || id.Name != name {
+					continue
+				}
+
+				// Only `x := T(...)` is unambiguous syntactically.
+				call, ok := x.Rhs[i].(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+
+				if conv, ok := call.Fun.(*ast.Ident); ok {
+					found = conv.Name
+					return false
+				}
+			}
+		}
+
+		return true
+	})
+
+	return found
+}
+
+// ffiPTGoWidth returns the arm64/amd64 byte width of a Go scalar type spelled
+// as it appears in yzma source, or 0 when unknown.
+func ffiPTGoWidth(name string) int {
+	switch name {
+	case "bool", "int8", "uint8", "byte":
+		return 1
+	case "int16", "uint16":
+		return 2
+	case "int32", "uint32", "float32", "rune":
+		return 4
+	case "int64", "uint64", "float64", "int", "uint", "uintptr", "ffi.Arg":
+		return 8
+	default:
+		return 0
+	}
+}
+
+// ffiPTFFIWidth returns the byte width libffi will read for a cif type
+// descriptor spelled as `&ffi.TypeX`, or 0 when unknown. -1 marks TypeVoid,
+// which is not a width at all.
+func ffiPTFFIWidth(descriptor string) int {
+	switch strings.TrimPrefix(descriptor, "&") {
+	case "ffi.TypeVoid":
+		return -1
+	case "ffi.TypeUint8", "ffi.TypeSint8":
+		return 1
+	case "ffi.TypeUint16", "ffi.TypeSint16":
+		return 2
+	case "ffi.TypeUint32", "ffi.TypeSint32", "ffi.TypeFloat":
+		return 4
+	case "ffi.TypeUint64", "ffi.TypeSint64", "ffi.TypeDouble", "ffi.TypePointer", "ffiTypeSize":
+		return 8
+	default:
+		return 0
+	}
+}
+
+// ffiPTArgWidthCase describes one RULE 2 pin: at C parameter index slot, the
+// cif claims cifWidth bytes, and the Go variable behind the address passed there
+// must be exactly that wide.
+//
+// cifWidth is compared against the RESOLVED width of whatever descriptor the
+// Prep actually names, because yzma spells the same 8-byte type three ways:
+// &ffi.TypeUint64, &ffi.TypePointer and the package-level alias &ffiTypeSize
+// (pkg/llama/model.go:14, `ffiTypeSize = ffi.TypeUint64`). Comparing widths
+// rather than spellings keeps the pin honest if the spelling changes, while
+// still turning into a skip if the binding is genuinely re-typed.
+type ffiPTArgWidthCase struct {
+	file     string // yzma file, relative to the package dir
+	goFunc   string // exported yzma wrapper
+	cName    string // C symbol, used to locate the Prep
+	slot     int    // C parameter index (0 == first C parameter)
+	cifWidth int    // bytes libffi is told to read at that slot
+	cRef     string // llama.h reference and C prototype
+}
+
+// ffiPTCheckArgWidths is the shared body of the RULE 2 pins. For each case it
+// re-derives the cif descriptor from the Prep, then measures the Go variable
+// whose address reaches that avalue slot, and reports when the two disagree.
+func ffiPTCheckArgWidths(t *testing.T, pkg string, cases []ffiPTArgWidthCase) {
+	t.Helper()
+
+	dir := ffiPTYzmaDir(t, pkg)
+
+	for _, tc := range cases {
+		t.Run(tc.goFunc, func(t *testing.T) {
+			fset, file := ffiPTParse(t, dir, tc.file)
+
+			goVar, cifTypes, prepPos := ffiPTPrep(t, file, tc.cName)
+
+			// cifTypes[0] is the return descriptor, so the argument at
+			// C parameter index slot lives at cifTypes[slot+1].
+			if len(cifTypes) < tc.slot+2 {
+				t.Skipf("%s cif has %d descriptors, need at least %d; shape changed",
+					tc.cName, len(cifTypes), tc.slot+2)
+			}
+
+			gotCif := cifTypes[tc.slot+1]
+
+			want := ffiPTFFIWidth(gotCif)
+			if want <= 0 {
+				t.Skipf("%s:%d: cif slot %d descriptor %q is not a known scalar type",
+					tc.file, fset.Position(prepPos).Line, tc.slot, gotCif)
+			}
+
+			if want != tc.cifWidth {
+				t.Skipf("%s:%d: cif slot %d is %s (%d bytes), the pin expects a "+
+					"%d-byte slot; the binding was changed and this pin needs re-deriving",
+					tc.file, fset.Position(prepPos).Line, tc.slot, gotCif, want, tc.cifWidth)
+			}
+
+			fn := ffiPTFuncDecl(t, file, tc.goFunc)
+			args, callPos := ffiPTCall(t, fn, goVar)
+
+			// args[0] is the return buffer.
+			if len(args) < tc.slot+2 {
+				t.Skipf("%s passes %d values to Call, need at least %d; shape changed",
+					tc.goFunc, len(args), tc.slot+2)
+			}
+
+			ident := ffiPTAddrOf(args[tc.slot+1])
+			if ident == "" {
+				t.Skipf("Call argument %d of %s is %q, not an &identifier; shape changed",
+					tc.slot, tc.goFunc, ffiPTExprText(args[tc.slot+1]))
+			}
+
+			goType := ffiPTDeclaredType(fn, ident)
+			if goType == "" {
+				t.Skipf("cannot determine the declared type of %s in %s", ident, tc.goFunc)
+			}
+
+			got := ffiPTGoWidth(goType)
+			if got == 0 {
+				t.Skipf("unknown Go type %q for %s in %s", goType, ident, tc.goFunc)
+			}
+
+			line := fset.Position(callPos).Line
+
+			if got == want {
+				return
+			}
+
+			verb := "reads %d byte(s) of adjacent Go memory into the high half of the C argument"
+			if got > want {
+				verb = "silently truncates the Go value, discarding %d byte(s)"
+			}
+
+			delta := want - got
+			if delta < 0 {
+				delta = -delta
+			}
+
+			t.Errorf("RULE 2 VIOLATION in yzma %s\n"+
+				"  yzma:   %s/%s:%d  %s -> %s.Call(..., &%s)\n"+
+				"  C:      %s\n"+
+				"  cif:    %s says libffi must read %d byte(s) from that address\n"+
+				"  Go:     %s is declared %s, which is %d byte(s)\n"+
+				"  effect: libffi "+verb+"\n"+
+				"  fix:    declare %s as a %d-byte type (or copy it into one before the call)",
+				tc.cName,
+				pkg, tc.file, line, tc.goFunc, goVar, ident,
+				tc.cRef,
+				gotCif, want,
+				ident, goType, got,
+				delta,
+				ident, want)
+		})
+	}
+}
+
+// =============================================================================
+// RULE 2 — size_t parameters backed by 4-byte Go variables.
+// =============================================================================
+
+// TestFFIParamTypesYzmaSamplerMinKeepWidth pins the highest-impact RULE 2
+// finding of the sweep: the four samplers whose `size_t min_keep` argument is
+// backed by a 4-byte Go uint32.
+//
+// FINDING
+//
+//	pkg/llama/sampling.go:459  SamplerInitTypical  llama.h:1354
+//	pkg/llama/sampling.go:467  SamplerInitTopP     llama.h:1348
+//	pkg/llama/sampling.go:475  SamplerInitMinP     llama.h:1351
+//	pkg/llama/sampling.go:483  SamplerInitXTC      llama.h:1363
+//
+// RULE BROKEN: 2. Each cif correctly declares the C `size_t min_keep` as an
+// 8-byte slot -- spelled &ffiTypeSize, the pkg/llama/model.go:13 alias for
+// ffi.TypeUint64 -- so RULE 1 is satisfied. But the Go wrapper passes the
+// address of its own `keep uint32` / `minKeep uint32` parameter. libffi reads 8
+// bytes from that address and splices 4 bytes of unrelated Go memory into the
+// high half of min_keep.
+//
+// # WHY THE ADJACENT BYTES ARE NOT SAFELY ZERO
+//
+// ffi.Fun.Call takes `args ...any`, so &keep is stored in an interface and
+// escapes to the heap. It lands in Go's tiny allocator, which packs several
+// 4-byte objects into one 16-byte block and does not re-zero a block it is
+// still carving up. A direct measurement of 20000 escaped 4-byte variables (in
+// a churned heap) found a non-zero adjacent high word 958-2756 times, i.e. 5-14%
+// of the time. So this fires intermittently, not never.
+//
+// # CONCRETE RUNTIME CONSEQUENCE
+//
+// When it fires, min_keep becomes >= 2^32 and llama.cpp b10211 silently turns
+// the sampler into a no-op, because every truncation guard is written as
+// "stop once we have kept at least min_keep candidates" (src/llama-sampler.cpp):
+//
+//	:1393 top_p   if (cum_sum >= p && i + 1 >= min_keep)          -> never fires
+//	:1582 min_p   if (!filtered.empty() && filtered.size() >= min_keep) -> fast path rejected
+//	:1600 min_p   if (logit < min_logit && i >= min_keep)          -> never fires (full sort, no truncation)
+//	:1754 typical if (min_keep == 0 || i >= min_keep - 1)          -> never fires
+//	:2164 xtc     if (size - pos_last >= min_keep && pos_last > 0) -> never fires
+//
+// So top-p, min-p and XTC stop filtering entirely for the lifetime of that
+// sampler, with no error and no log line. The request samples from the full
+// untruncated distribution.
+//
+// KRONK REACHES THREE OF THE FOUR, per request, in buildSampler:
+//
+//	sdk/kronk/model/params.go:800  llama.SamplerInitTopP(p.TopP, 0)
+//	sdk/kronk/model/params.go:804  llama.SamplerInitMinP(p.MinP, 0)
+//	sdk/kronk/model/params.go:809  llama.SamplerInitXTC(..., p.XtcMinKeep, ...)
+//
+// Note that Kronk passing a literal 0 does not help: the low word is 0 but the
+// high word is still garbage.
+//
+// UPSTREAM FIX (do not apply here): widen the wrapper parameters to uint64, or
+// copy into a local uint64 and pass its address.
+func TestFFIParamTypesYzmaSamplerMinKeepWidth(t *testing.T) {
+	ffiPTCheckArgWidths(t, "pkg/llama", []ffiPTArgWidthCase{
+		{
+			file: "sampling.go", goFunc: "SamplerInitTopP", cName: "llama_sampler_init_top_p",
+			slot: 1, cifWidth: 8,
+			cRef: "llama.h:1348 struct llama_sampler * llama_sampler_init_top_p(float p, size_t min_keep)",
+		},
+		{
+			file: "sampling.go", goFunc: "SamplerInitMinP", cName: "llama_sampler_init_min_p",
+			slot: 1, cifWidth: 8,
+			cRef: "llama.h:1351 struct llama_sampler * llama_sampler_init_min_p(float p, size_t min_keep)",
+		},
+		{
+			file: "sampling.go", goFunc: "SamplerInitTypical", cName: "llama_sampler_init_typical",
+			slot: 1, cifWidth: 8,
+			cRef: "llama.h:1354 struct llama_sampler * llama_sampler_init_typical(float p, size_t min_keep)",
+		},
+		{
+			file: "sampling.go", goFunc: "SamplerInitXTC", cName: "llama_sampler_init_xtc",
+			slot: 2, cifWidth: 8,
+			cRef: "llama.h:1363 struct llama_sampler * llama_sampler_init_xtc(float p, float t, size_t min_keep, uint32_t seed)",
+		},
+	})
+}
+
+// TestFFIParamTypesYzmaMetadataBufSizeWidth pins the six metadata readers that
+// repeat ModelDesc's defect: a `size_t buf_size` out-parameter length backed by
+// a 4-byte Go int32.
+//
+// FINDING
+//
+//	pkg/llama/model.go:746  ModelMetaValStr           llama.h:605
+//	pkg/llama/model.go:785  ModelMetaKeyByIndex       llama.h:614
+//	pkg/llama/model.go:813  ModelMetaValStrByIndex    llama.h:617
+//	pkg/llama/lora.go:135   AdapterMetaValStr         llama.h:677
+//	pkg/llama/lora.go:173   AdapterMetaKeyByIndex     llama.h:683
+//	pkg/llama/lora.go:200   AdapterMetaValStrByIndex  llama.h:686
+//
+// RULE BROKEN: 2. Every one of these cifs correctly models the C `size_t
+// buf_size` as an 8-byte slot (all six spell it &ffiTypeSize, the
+// pkg/llama/model.go:13 alias for ffi.TypeUint64), and every one of them then
+// passes `&bLen` where `bLen := int32(len(buf))`.
+//
+// This is exactly the ModelDesc defect (pinned separately by
+// TestFFIYzmaModelDescSizeArgWidth in ffi_pointer_safety_test.go), six more
+// times. It is NOT a yzma house style: the same file gets it right at
+// pkg/llama/model.go:979, where llama_split_path's size_t length is a uint64.
+//
+// # CONCRETE RUNTIME CONSEQUENCE
+//
+// llama.cpp receives buf_size with a garbage high word, i.e. a limit in the
+// billions of gigabytes instead of the 128 bytes yzma actually allocated. The
+// bound stops protecting the buffer, so any metadata value longer than the Go
+// buffer writes past the end of a Go heap allocation. Unlike the sampler
+// finding, the damage here is memory corruption rather than a wrong value.
+//
+// KRONK REACHES ModelMetaValStr from roughly ten call sites (model metadata
+// reads during load and capability detection), so this is on the hot path of
+// every model load, not a corner.
+//
+// UPSTREAM FIX (do not apply here): `bLen := uint64(len(buf))`, matching
+// pkg/llama/model.go:979.
+func TestFFIParamTypesYzmaMetadataBufSizeWidth(t *testing.T) {
+	ffiPTCheckArgWidths(t, "pkg/llama", []ffiPTArgWidthCase{
+		{
+			file: "model.go", goFunc: "ModelMetaValStr", cName: "llama_model_meta_val_str",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:605 int32_t llama_model_meta_val_str(const struct llama_model *, const char * key, char * buf, size_t buf_size)",
+		},
+		{
+			file: "model.go", goFunc: "ModelMetaKeyByIndex", cName: "llama_model_meta_key_by_index",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:614 int32_t llama_model_meta_key_by_index(const struct llama_model *, int32_t i, char * buf, size_t buf_size)",
+		},
+		{
+			file: "model.go", goFunc: "ModelMetaValStrByIndex", cName: "llama_model_meta_val_str_by_index",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:617 int32_t llama_model_meta_val_str_by_index(const struct llama_model *, int32_t i, char * buf, size_t buf_size)",
+		},
+		{
+			file: "lora.go", goFunc: "AdapterMetaValStr", cName: "llama_adapter_meta_val_str",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:677 int32_t llama_adapter_meta_val_str(const struct llama_adapter_lora *, const char * key, char * buf, size_t buf_size)",
+		},
+		{
+			file: "lora.go", goFunc: "AdapterMetaKeyByIndex", cName: "llama_adapter_meta_key_by_index",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:683 int32_t llama_adapter_meta_key_by_index(const struct llama_adapter_lora *, int32_t i, char * buf, size_t buf_size)",
+		},
+		{
+			file: "lora.go", goFunc: "AdapterMetaValStrByIndex", cName: "llama_adapter_meta_val_str_by_index",
+			slot: 3, cifWidth: 8,
+			cRef: "llama.h:686 int32_t llama_adapter_meta_val_str_by_index(const struct llama_adapter_lora *, int32_t i, char * buf, size_t buf_size)",
+		},
+	})
+}
+
+// TestFFIParamTypesYzmaMemorySeqDivFactorWidth pins the one RULE 2 violation
+// that runs in the opposite direction: a Go variable WIDER than its cif slot.
+//
+// FINDING: pkg/llama/memory.go:148 MemorySeqDiv, C at llama.h:768
+//
+//	void llama_memory_seq_div(llama_memory_t mem, llama_seq_id seq_id,
+//	                          llama_pos p0, llama_pos p1, int d)
+//
+// RULE BROKEN: 2. The cif is correct (ffi.TypeSint32 for the C `int d`), but
+// the Go wrapper declares its parameter `d int`, which is 8 bytes. libffi reads
+// only the low 4 bytes at &d.
+//
+// SEVERITY: LOW, and deliberately recorded as such. On little-endian arm64 and
+// amd64 the low 4 bytes ARE the correct value for any |d| < 2^31, so this
+// happens to work. It is pinned because it is a genuine contract violation that
+// silently truncates for larger d and would read the wrong half on a big-endian
+// target, and because leaving it out of the sweep's output would misrepresent
+// the count. Kronk does not call MemorySeqDiv.
+//
+// UPSTREAM FIX (do not apply here): declare the parameter `d int32`.
+func TestFFIParamTypesYzmaMemorySeqDivFactorWidth(t *testing.T) {
+	ffiPTCheckArgWidths(t, "pkg/llama", []ffiPTArgWidthCase{
+		{
+			file: "memory.go", goFunc: "MemorySeqDiv", cName: "llama_memory_seq_div",
+			slot: 4, cifWidth: 4,
+			cRef: "llama.h:768 void llama_memory_seq_div(llama_memory_t, llama_seq_id, llama_pos p0, llama_pos p1, int d)",
+		},
+	})
+}
+
+// =============================================================================
+// RULE 3 — return buffers of the wrong KIND.
+// =============================================================================
+
+// TestFFIParamTypesYzmaFloatReturnsReadAsInteger pins the two float-returning
+// bindings that read their result through ffi.Arg.
+//
+// FINDING
+//
+//	pkg/llama/model.go:646  ModelRopeFreqScaleTrain  llama.h:585
+//	                        float llama_model_rope_freq_scale_train(const struct llama_model *)
+//	pkg/llama/vocab.go:561  VocabGetScore            llama.h:1082
+//	                        float llama_vocab_get_score(const struct llama_vocab *, llama_token)
+//
+// Both are written as:
+//
+//	var x ffi.Arg
+//	someFunc.Call(unsafe.Pointer(&x), ...)
+//	return float32(x)
+//
+// RULE BROKEN: 3, in its float half. ffi.Arg is the correct return buffer for
+// INTEGER returns only; jupiterrider/ffi's own doc comment carves floats out
+// explicitly ("float32 and structs are not affected"). Two independent defects
+// stack here, and TestFFIParamTypesLibffiReturnKindContract measures both:
+//
+//  1. libffi stores only 4 bytes for a TypeFloat return and does NOT clear the
+//     rest of the buffer, so the high word of the ffi.Arg keeps whatever it
+//     held. (Measured with fmaxf: a buffer pre-set to 0xAAAAAAAAAAAAAAAA came
+//     back as 0xAAAAAAAA3FC00000.)
+//  2. `float32(x)` on an ffi.Arg is an integer-to-float NUMERIC conversion, not
+//     a bit reinterpretation. Even with a perfectly zeroed high word,
+//     float32(0x3F800000) is 1.0653532e9, not 1.0.
+//
+// CONCRETE RUNTIME CONSEQUENCE: both functions return garbage on the order of
+// 1e9 for every input, deterministically, not intermittently. VocabGetScore in
+// particular would make every token score meaningless to any caller that ranks
+// on it.
+//
+// KRONK REACHES NEITHER (no non-test references to either wrapper), so this is
+// latent for Kronk today and would bite the moment either is used.
+//
+// UPSTREAM FIX (do not apply here): use a float32 return buffer and return it
+// directly -- `var x float32; f.Call(unsafe.Pointer(&x), ...); return x`.
+func TestFFIParamTypesYzmaFloatReturnsReadAsInteger(t *testing.T) {
+	dir := ffiPTYzmaDir(t, "pkg/llama")
+
+	cases := []struct {
+		file   string
+		goFunc string
+		cName  string
+		cRef   string
+	}{
+		{
+			file: "model.go", goFunc: "ModelRopeFreqScaleTrain",
+			cName: "llama_model_rope_freq_scale_train",
+			cRef:  "llama.h:585 float llama_model_rope_freq_scale_train(const struct llama_model *)",
+		},
+		{
+			file: "vocab.go", goFunc: "VocabGetScore",
+			cName: "llama_vocab_get_score",
+			cRef:  "llama.h:1082 float llama_vocab_get_score(const struct llama_vocab *, llama_token)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.goFunc, func(t *testing.T) {
+			fset, file := ffiPTParse(t, dir, tc.file)
+
+			goVar, cifTypes, prepPos := ffiPTPrep(t, file, tc.cName)
+
+			if cifTypes[0] != "&ffi.TypeFloat" {
+				t.Skipf("%s:%d: %s return descriptor is %s, expected &ffi.TypeFloat; "+
+					"the binding changed and this pin needs re-deriving",
+					tc.file, fset.Position(prepPos).Line, tc.cName, cifTypes[0])
+			}
+
+			fn := ffiPTFuncDecl(t, file, tc.goFunc)
+			args, callPos := ffiPTCall(t, fn, goVar)
+
+			if len(args) == 0 {
+				t.Skipf("%s.Call has no return buffer argument", tc.goFunc)
+			}
+
+			ident := ffiPTAddrOf(args[0])
+			if ident == "" {
+				t.Skipf("return buffer of %s is %q, not an &identifier; shape changed",
+					tc.goFunc, ffiPTExprText(args[0]))
+			}
+
+			goType := ffiPTDeclaredType(fn, ident)
+			if goType == "" {
+				t.Skipf("cannot determine the declared type of %s in %s", ident, tc.goFunc)
+			}
+
+			if goType == "float32" {
+				return
+			}
+
+			t.Errorf("RULE 3 VIOLATION (float half) in yzma %s\n"+
+				"  yzma:   pkg/llama/%s:%d  %s -> %s.Call(unsafe.Pointer(&%s), ...)\n"+
+				"  C:      %s\n"+
+				"  cif:    return descriptor is &ffi.TypeFloat, so libffi stores 4 bytes\n"+
+				"          of IEEE-754 float and leaves the rest of the buffer untouched\n"+
+				"  Go:     %s is declared %s, and the value is then read with float32(%s)\n"+
+				"  effect: float32() on an integer buffer is a NUMERIC conversion, not a\n"+
+				"          bit reinterpretation, so %s returns ~1e9-scale garbage for\n"+
+				"          every input (see TestFFIParamTypesLibffiReturnKindContract)\n"+
+				"  fix:    var %s float32 as the return buffer, and return it directly",
+				tc.cName,
+				tc.file, fset.Position(callPos).Line, tc.goFunc, goVar, ident,
+				tc.cRef,
+				ident, goType, ident,
+				tc.goFunc,
+				ident)
+		})
+	}
+}
+
+// =============================================================================
+// RULE 1 — a cif return descriptor that does not model the C return type.
+// =============================================================================
+
+// TestFFIParamTypesGGMLCPUBufferTypeReturnDescriptor pins the single RULE 1
+// violation in the sweep, and it is the most damaging finding overall because
+// it is deterministic and Kronk reaches it without the user opting in.
+//
+// FINDING
+//
+//	cif:  pkg/llama/ggml_base.go:28
+//	      lib.Prep("ggml_backend_cpu_buffer_type", &ffi.TypeVoid)
+//	call: pkg/llama/ggml_base.go:46
+//	      var ret uintptr; ggmlBackendCpuBufferType.Call(&ret)
+//	C:    ggml/include/ggml-backend.h:431 (b10211)
+//	      GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
+//
+// RULES BROKEN: 1 (the return descriptor models a pointer return as void) and,
+// as a direct consequence, 3 (a return buffer is supplied for a cif that
+// declares no return value).
+//
+// # CONCRETE RUNTIME CONSEQUENCE
+//
+// libffi writes NOTHING into the caller's buffer when the cif's return type is
+// FFI_TYPE_VOID -- measured in TestFFIParamTypesLibffiReturnKindContract, where
+// a sentinel of 0x1234 survived the call untouched. `ret` is a fresh Go var, so
+// llama.GGMLBackendCpuBufferType() returns 0 every single time, on every
+// platform.
+//
+// That zero is not merely a wrong value; it becomes a NULL pointer inside
+// llama.cpp. yzma's NewTensorBuftOverride (pkg/llama/ggml_base.go:75) builds
+// llama.TensorBuftOverride{Pattern: ..., Type: GGMLBackendCpuBufferType()},
+// i.e. {pattern, NULL}, and nothing downstream validates it (yzma's
+// ModelParams.SetTensorBufOverrides at pkg/llama/model.go:845 only checks the
+// sentinel termination). In llama.cpp b10211's model loader:
+//
+//	src/llama-model-loader.cpp:1157  if (overrides->buft == ggml_backend_cpu_buffer_type())
+//	                                 -> false, because NULL != the real CPU buft
+//	src/llama-model-loader.cpp:1166  buft = overrides->buft;   // NULL
+//	src/llama-model-loader.cpp:1169  LLAMA_LOG_DEBUG(..., ggml_backend_buft_name(buft))
+//	ggml/src/ggml-backend.cpp:34     GGML_ASSERT(buft);        // -> abort()
+//
+// LLAMA_LOG_DEBUG is a varargs FUNCTION call (src/llama-impl.h:31), so
+// ggml_backend_buft_name(NULL) is evaluated regardless of the active log level.
+// The process aborts during model load, and the intended effect -- pinning the
+// matched tensors to the CPU buffer type -- never happens either way.
+//
+// KRONK REACHES IT, and not only through an explicit setting:
+//
+//	sdk/kronk/model/model.go:1427/1435  llama.NewTensorBuftAllFFNExprsOverride()
+//	sdk/kronk/model/model.go:1433/1441  llama.NewTensorBuftBlockOverride(idx)
+//	sdk/kronk/model/model.go:1443       llama.NewTensorBuftOverride(p)
+//	  all in parseTensorBuftOverrides, called from buildModelParams at model.go:521
+//
+// and Kronk sets cfg.TensorBuftOverrides to []string{"moe-experts"} on its own
+// at sdk/kronk/model/model.go:494 and :505 for the MoE placement modes, so an
+// MoE config reaches this with no tensor-buft-overrides in the user's YAML.
+//
+// UPSTREAM FIX (do not apply here): the return descriptor must be
+// &ffi.TypePointer. Note that the two neighbouring bindings in the same
+// loadGGMLBase get it right (ggml_backend_dev_name uses &ffi.TypePointer for
+// its `const char *` return, and ggml_backend_dev_memory is genuinely void).
+func TestFFIParamTypesGGMLCPUBufferTypeReturnDescriptor(t *testing.T) {
+	const (
+		file   = "ggml_base.go"
+		goFunc = "GGMLBackendCpuBufferType"
+		cName  = "ggml_backend_cpu_buffer_type"
+	)
+
+	dir := ffiPTYzmaDir(t, "pkg/llama")
+	fset, parsed := ffiPTParse(t, dir, file)
+
+	goVar, cifTypes, prepPos := ffiPTPrep(t, parsed, cName)
+	prepLine := fset.Position(prepPos).Line
+
+	fn := ffiPTFuncDecl(t, parsed, goFunc)
+	args, callPos := ffiPTCall(t, fn, goVar)
+	callLine := fset.Position(callPos).Line
+
+	// The wrapper must genuinely want the value back, otherwise a void
+	// descriptor would be harmless and this pin would be vacuous.
+	if len(args) == 0 || ffiPTAddrOf(args[0]) == "" {
+		t.Skipf("%s no longer passes an &identifier return buffer; shape changed", goFunc)
+	}
+
+	if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
+		t.Skipf("%s no longer returns exactly one value; shape changed", goFunc)
+	}
+
+	if got := cifTypes[0]; got != "&ffi.TypePointer" {
+		t.Errorf("RULE 1 VIOLATION in yzma %s\n"+
+			"  yzma:   pkg/llama/%s:%d  lib.Prep(%q, %s)\n"+
+			"          pkg/llama/%s:%d  %s.Call(%s)  <- a return buffer IS supplied\n"+
+			"  C:      ggml-backend.h:431 (b10211)\n"+
+			"          ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void)\n"+
+			"          -- an 8-byte POINTER return, not void\n"+
+			"  effect: libffi writes nothing at all for a TypeVoid return descriptor, so\n"+
+			"          %s() returns 0 on every call. yzma then stores that\n"+
+			"          NULL as TensorBuftOverride.Type, and llama.cpp b10211 aborts in\n"+
+			"          GGML_ASSERT(buft) at ggml-backend.cpp:34, reached unconditionally\n"+
+			"          via LLAMA_LOG_DEBUG at llama-model-loader.cpp:1169.\n"+
+			"          Kronk hits this from parseTensorBuftOverrides\n"+
+			"          (sdk/kronk/model/model.go:1427-1443), including for MoE configs\n"+
+			"          that set TensorBuftOverrides implicitly at model.go:494/:505.\n"+
+			"  fix:    the return descriptor must be &ffi.TypePointer, not %s",
+			cName,
+			file, prepLine, cName, strings.Join(cifTypes, ", "),
+			file, callLine, goVar, ffiPTExprText(args[0]),
+			goFunc,
+			got)
+	}
+}

--- a/sdk/kronk/model/ffi_pointer_safety_test.go
+++ b/sdk/kronk/model/ffi_pointer_safety_test.go
@@ -1,0 +1,709 @@
+package model
+
+// =============================================================================
+// FFI POINTER / WIDTH SAFETY AUDIT
+//
+// yzma is a hand-written purego + libffi binding, NOT cgo. None of cgo's
+// protections apply: there is no cgocheck, no automatic pinning, no compiler
+// validation of what is handed across the boundary. Every width and lifetime
+// rule is enforced only by hand, and a violation is invisible until it
+// corrupts the heap.
+//
+// This file audits ONE rule family: the width contract on values whose
+// ADDRESS is handed to libffi. libffi does not know the size of the Go
+// variable behind a pointer; it uses only the ffi.Type recorded in the cif at
+// Lib.Prep time.
+//
+//   RULE 1 (arguments). libffi reads exactly ffi.Type.Size bytes from each
+//   avalue pointer. If the declared ffi type is WIDER than the Go variable,
+//   libffi reads past the end of that Go object and the argument C receives
+//   has adjacent Go heap memory in its high bytes.
+//
+//   RULE 2 (return values). For integer return types narrower than a register,
+//   libffi stores a full ffi_arg (8 bytes on 64-bit) into the return buffer.
+//   The binding documents this prohibition itself, at
+//   $GOMODCACHE/github.com/jupiterrider/ffi@v0.7.0/fun.go:19-20:
+//
+//       "ret is a pointer to a variable that will hold the result of the
+//        function call. [...] You cannot use integer types smaller than 8
+//        bytes here (float32 and structs are not affected). Use [Arg] instead
+//        and typecast afterwards."
+//
+//   Violating RULE 2 writes 4 bytes past the end of a Go variable.
+//
+// TestFFILibffiWidthContract proves both rules empirically against libc, with
+// no llama.cpp library, no kronk.Init and no model load, so the mechanism is
+// established independently of any model. The two Test...Yzma... functions then
+// pin the two places in the COMPILED yzma where the rules are broken.
+//
+// WHICH yzma IS AUDITED. go.mod pins github.com/hybridgroup/yzma v1.21.0 and
+// there is no replace directive and no go.work, so the code that actually
+// compiles lives in the module cache, NOT in .extras/yzma. The .extras copy is
+// a reference checkout and currently carries an uncommitted local patch (an
+// added pMin parameter in pkg/llama/draft.go) that is not built. These tests
+// therefore resolve the module directory with `go list -m` and assert over
+// that, never over .extras.
+//
+// SCOPE. Struct LAYOUT (Go mirrors vs include/llama.h) is covered by
+// ffi_struct_layout_test.go. This file is about the width of individual scalar
+// values crossing the boundary, which layout equality does not catch.
+// =============================================================================
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// ffiPtrLibcName returns the shared library that exports the C89 functions the
+// width proofs use (abs, memchr), or "" when the platform is not one we know
+// how to name.
+func ffiPtrLibcName() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "libSystem.B.dylib"
+	case "linux":
+		return "libc.so.6"
+	case "freebsd", "netbsd":
+		return "libc.so.7"
+	case "windows":
+		return "msvcrt.dll"
+	default:
+		return ""
+	}
+}
+
+// TestFFILibffiWidthContract is the executable evidence for RULE 1 and RULE 2
+// described in the file header. It calls two libc functions through the exact
+// same ffi.Lib/ffi.Fun machinery yzma uses, so whatever it shows about libffi
+// is true of every yzma binding.
+//
+// It deliberately depends on NOTHING from llama.cpp: no library load, no
+// kronk.Init, no GGUF. That matters because it makes the mechanism behind the
+// two yzma defects reproducible on any machine in milliseconds.
+//
+// Both subtests assert libffi's DOCUMENTED behaviour, so they are expected to
+// PASS. They exist to prove the rule is real, which is what makes the two
+// pinning tests below more than an argument from the documentation.
+func TestFFILibffiWidthContract(t *testing.T) {
+	name := ffiPtrLibcName()
+	if name == "" {
+		t.Skipf("no known libc name for GOOS=%s", runtime.GOOS)
+	}
+
+	lib, err := ffi.Load(name)
+	if err != nil {
+		t.Skipf("cannot dlopen %s: %v", name, err)
+	}
+
+	// -------------------------------------------------------------------
+	// RULE 2: a narrow integer return buffer is overwritten to 8 bytes.
+	//
+	// int abs(int) returns int32. We hand libffi an 8-byte return buffer
+	// pre-filled with a recognisable pattern and check how much of it
+	// libffi replaces. A correct 4-byte store would leave the high half
+	// intact; an ffi_arg-sized store clears it.
+	//
+	// An 8-byte buffer is used (rather than a real int32 next to a
+	// sentinel) so the observation does not depend on Go's field packing
+	// or on unaligned-store behaviour.
+	// -------------------------------------------------------------------
+	t.Run("narrow_integer_return_writes_eight_bytes", func(t *testing.T) {
+		absFn, err := lib.Prep("abs", &ffi.TypeSint32, &ffi.TypeSint32)
+		if err != nil {
+			t.Skipf("prep abs: %v", err)
+		}
+
+		const pattern = uint64(0xDEADBEEF00000000)
+
+		box := pattern
+		in := int32(-5)
+		absFn.Call(unsafe.Pointer(&box), &in)
+
+		if got := uint32(box); got != 5 {
+			t.Fatalf("abs(-5) low word = %d, want 5 (the call itself did not work)", got)
+		}
+
+		high := uint32(box >> 32)
+		switch high {
+		case 0:
+			t.Logf("confirmed RULE 2: libffi cleared the high 4 bytes "+
+				"(buffer 0x%016X -> 0x%016X), i.e. it stored a full 8-byte "+
+				"ffi_arg into what a caller may believe is a 4-byte slot", pattern, box)
+		case uint32(pattern >> 32):
+			t.Errorf("RULE 2 did NOT reproduce: libffi left the high 4 bytes "+
+				"untouched (0x%016X). If this platform really only writes 4 "+
+				"bytes for a Sint32 return, the LoadModeFromStr finding pinned "+
+				"by TestFFIYzmaLoadModeFromStrReturnBufferWidth is harmless "+
+				"here and that test's premise needs revisiting.", box)
+		default:
+			t.Errorf("unexpected return buffer 0x%016X after abs(-5)", box)
+		}
+	})
+
+	// -------------------------------------------------------------------
+	// RULE 1: a size_t argument backed by a 4-byte Go variable.
+	//
+	// void *memchr(const void *s, int c, size_t n) is the cleanest probe
+	// available: it makes the value of n directly observable through the
+	// return value, because it stops at the first match. We place the
+	// needle beyond the intended limit, so "found" can only mean C
+	// received an n larger than we intended to pass.
+	//
+	// This is precisely the shape of yzma's ModelDesc (see
+	// TestFFIYzmaModelDescSizeArgWidth): a size_t parameter declared to
+	// libffi as TypeUint64 but passed the address of an int32.
+	// -------------------------------------------------------------------
+	t.Run("narrow_size_arg_reads_adjacent_go_memory", func(t *testing.T) {
+		memchr, err := lib.Prep("memchr",
+			&ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeUint64)
+		if err != nil {
+			t.Skipf("prep memchr: %v", err)
+		}
+
+		// 64-byte haystack; the needle sits at 40, far beyond the limit
+		// of 8 we intend to pass, but still inside the allocation, so C
+		// always stops before leaving the buffer.
+		const (
+			hayLen    = 64
+			needleAt  = 40
+			intendedN = 8
+		)
+		hay := make([]byte, hayLen)
+		hay[needleAt] = 0xAA
+		hayPtr := unsafe.SliceData(hay)
+		needle := int32(0xAA)
+
+		// Control: an honest 8-byte length. C must not see the needle.
+		var wide uint64 = intendedN
+		var got *byte
+		memchr.Call(unsafe.Pointer(&got), unsafe.Pointer(&hayPtr), &needle, &wide)
+		if got != nil {
+			t.Fatalf("control failed: memchr with a real uint64 n=%d found the "+
+				"needle at %d; the probe itself is wrong", intendedN, needleAt)
+		}
+
+		// yzma's shape: the length variable is only 4 bytes wide, and the
+		// 4 bytes of Go memory that follow it are non-zero.
+		narrow := [2]uint32{intendedN, 0x11111111}
+		got = nil
+		memchr.Call(unsafe.Pointer(&got), unsafe.Pointer(&hayPtr), &needle, &narrow[0])
+
+		if got == nil {
+			t.Errorf("RULE 1 did NOT reproduce: memchr honoured n=%d even though "+
+				"only a 4-byte Go variable was supplied for a TypeUint64 "+
+				"parameter. If that is genuinely true on this platform, the "+
+				"ModelDesc finding pinned by TestFFIYzmaModelDescSizeArgWidth "+
+				"is harmless here and its premise needs revisiting.", intendedN)
+			return
+		}
+
+		t.Logf("confirmed RULE 1: memchr found the needle at offset %d despite "+
+			"an intended n=%d, because libffi read 8 bytes from a 4-byte Go "+
+			"variable and C therefore saw n=0x%08X%08X",
+			needleAt, intendedN, narrow[1], narrow[0])
+
+		runtime.KeepAlive(hay)
+	})
+}
+
+// =============================================================================
+// Source assertions over the COMPILED yzma.
+// =============================================================================
+
+// ffiPtrYzmaLlamaDir returns the directory of the yzma pkg/llama package that
+// this module actually compiles against, resolved through `go list -m` so it
+// tracks the go.mod pin rather than the uncompiled .extras/yzma copy. It skips
+// the test when the toolchain or the module cache is unavailable.
+func ffiPtrYzmaLlamaDir(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("cannot determine this test file's location")
+	}
+
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/hybridgroup/yzma")
+	cmd.Dir = filepath.Dir(thisFile)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("go list -m github.com/hybridgroup/yzma: %v", err)
+	}
+
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		t.Skip("go list -m returned no directory for github.com/hybridgroup/yzma")
+	}
+
+	llamaDir := filepath.Join(dir, "pkg", "llama")
+	if _, err := os.Stat(llamaDir); err != nil {
+		t.Skipf("yzma pkg/llama not readable at %s: %v", llamaDir, err)
+	}
+
+	return llamaDir
+}
+
+// ffiPtrParseFile parses one yzma source file.
+func ffiPtrParseFile(t *testing.T, dir, base string) (*token.FileSet, *ast.File) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	path := filepath.Join(dir, base)
+
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Skipf("parse %s: %v", path, err)
+	}
+
+	return fset, f
+}
+
+// ffiPtrPrepArgTypes finds a `lib.Prep("cName", ...)` call anywhere in f and
+// returns the ffi type names it declares. Index 0 is the return type, so
+// index i+1 is C parameter i. Names are returned bare, e.g. "TypeUint64" for
+// &ffi.TypeUint64 and "ffiTypeBatch" for &ffiTypeBatch.
+//
+// Returns nil when the symbol is not registered in this file.
+func ffiPtrPrepArgTypes(f *ast.File, cName string) []string {
+	var types []string
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		if types != nil {
+			return false
+		}
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (sel.Sel.Name != "Prep" && sel.Sel.Name != "PrepVar") {
+			return true
+		}
+		if len(call.Args) == 0 {
+			return true
+		}
+
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		if s, err := strconv.Unquote(lit.Value); err != nil || s != cName {
+			return true
+		}
+
+		found := make([]string, 0, len(call.Args)-1)
+		for _, a := range call.Args[1:] {
+			// PrepVar has an integer nFixedArgs before the return type.
+			if bl, ok := a.(*ast.BasicLit); ok && bl.Kind == token.INT {
+				continue
+			}
+			un, ok := a.(*ast.UnaryExpr)
+			if !ok || un.Op != token.AND {
+				found = append(found, "?")
+				continue
+			}
+			switch x := un.X.(type) {
+			case *ast.SelectorExpr:
+				found = append(found, x.Sel.Name)
+			case *ast.Ident:
+				found = append(found, x.Name)
+			default:
+				found = append(found, "?")
+			}
+		}
+		types = found
+
+		return false
+	})
+
+	return types
+}
+
+// ffiPtrFuncDecl returns the top-level function named name.
+func ffiPtrFuncDecl(f *ast.File, name string) *ast.FuncDecl {
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv == nil && fd.Name.Name == name {
+			return fd
+		}
+	}
+
+	return nil
+}
+
+// ffiPtrCallArgs returns the argument expressions of the first `X.Call(...)`
+// inside fn. Index 0 is the return buffer; index i+1 is C parameter i.
+func ffiPtrCallArgs(fn *ast.FuncDecl) []ast.Expr {
+	var args []ast.Expr
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if args != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Call" {
+			args = call.Args
+			return false
+		}
+
+		return true
+	})
+
+	return args
+}
+
+// ffiPtrAddrOfIdent unwraps `&x` and `unsafe.Pointer(&x)` to "x".
+func ffiPtrAddrOfIdent(e ast.Expr) string {
+	if call, ok := e.(*ast.CallExpr); ok && len(call.Args) == 1 {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Pointer" {
+			e = call.Args[0]
+		}
+	}
+
+	un, ok := e.(*ast.UnaryExpr)
+	if !ok || un.Op != token.AND {
+		return ""
+	}
+
+	id, ok := un.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return id.Name
+}
+
+// ffiPtrLocalType reports the Go type name of local variable name inside fn,
+// recognising the two forms yzma uses: `var name T` and `name := T(...)`.
+func ffiPtrLocalType(fn *ast.FuncDecl, name string) string {
+	var found string
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+
+		switch s := n.(type) {
+		case *ast.ValueSpec:
+			for _, id := range s.Names {
+				if id.Name != name {
+					continue
+				}
+				if t, ok := s.Type.(*ast.Ident); ok {
+					found = t.Name
+					return false
+				}
+			}
+
+		case *ast.AssignStmt:
+			for i, lhs := range s.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok || id.Name != name || i >= len(s.Rhs) {
+					continue
+				}
+				if call, ok := s.Rhs[i].(*ast.CallExpr); ok {
+					if t, ok := call.Fun.(*ast.Ident); ok {
+						found = t.Name
+						return false
+					}
+				}
+			}
+		}
+
+		return true
+	})
+
+	return found
+}
+
+// ffiPtrGoWidth maps a Go type name to its size in bytes, resolving yzma's
+// named scalar types (e.g. `type LoadMode int32`) through decls found in the
+// package. Returns 0 when unknown.
+func ffiPtrGoWidth(name string, named map[string]string) int {
+	builtin := map[string]int{
+		"int8": 1, "uint8": 1, "bool": 1, "byte": 1,
+		"int16": 2, "uint16": 2,
+		"int32": 4, "uint32": 4, "float32": 4, "rune": 4,
+		"int64": 8, "uint64": 8, "float64": 8,
+		"int": 8, "uint": 8, "uintptr": 8,
+	}
+
+	for range 8 { // follow a short alias chain
+		if w, ok := builtin[name]; ok {
+			return w
+		}
+		next, ok := named[name]
+		if !ok {
+			return 0
+		}
+		name = next
+	}
+
+	return 0
+}
+
+// ffiPtrNamedScalars collects `type X <ident>` declarations across the package
+// so named types such as LoadMode, Token and Pos can be sized.
+func ffiPtrNamedScalars(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("read %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+
+		f, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, parser.SkipObjectResolution)
+		if err != nil {
+			continue
+		}
+
+		for _, d := range f.Decls {
+			gd, ok := d.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if id, ok := ts.Type.(*ast.Ident); ok {
+					out[ts.Name.Name] = id.Name
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+// ffiPtrFFIWidth maps an ffi.TypeXxx name to its size in bytes. Returns 0 for
+// struct types and anything unrecognised.
+func ffiPtrFFIWidth(name string) int {
+	return map[string]int{
+		"TypeVoid":  0,
+		"TypeUint8": 1, "TypeSint8": 1,
+		"TypeUint16": 2, "TypeSint16": 2,
+		"TypeUint32": 4, "TypeSint32": 4, "TypeFloat": 4,
+		"TypeUint64": 8, "TypeSint64": 8, "TypePointer": 8, "TypeDouble": 8,
+	}[name]
+}
+
+// TestFFIYzmaModelDescSizeArgWidth pins FINDING 1, the one of the two width
+// defects that Kronk actually reaches at runtime.
+//
+// FINDING. yzma's ModelDesc hands libffi the address of a 4-byte int32 for a
+// parameter it has correctly declared as 8-byte TypeUint64:
+//
+//	$GOMODCACHE/github.com/hybridgroup/yzma@v1.21.0/pkg/llama/model.go:249
+//	  lib.Prep("llama_model_desc", &ffi.TypeSint32,
+//	           &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint64)
+//
+//	.../pkg/llama/model.go:571-580  (func ModelDesc)
+//	  buf  := make([]byte, 128)
+//	  b    := unsafe.SliceData(buf)
+//	  bLen := int32(len(buf))                       // <-- 4 bytes
+//	  modelDescFunc.Call(unsafe.Pointer(&result),
+//	      unsafe.Pointer(&model), unsafe.Pointer(&b), &bLen)
+//
+// C SIDE. .extras/llama.cpp/include/llama.h:621 declares
+//
+//	LLAMA_API int32_t llama_model_desc(const struct llama_model * model,
+//	                                  char * buf, size_t buf_size);
+//
+// and .extras/llama.cpp/src/llama-model.cpp:2711 implements it as
+//
+//	return snprintf(buf, buf_size, "%s", model->desc().c_str());
+//
+// RULE. libffi reads exactly ffi.Type.Size bytes from each avalue pointer, so
+// it reads 8 bytes from &bLen. TestFFILibffiWidthContract proves this against
+// libc. The low half is 128; the high half is whatever Go heap memory follows
+// bLen. buf_size therefore becomes 0xXXXXXXXX_00000080 — never smaller than
+// 128, so snprintf's bound is effectively lost rather than tightened.
+//
+// FAILURE SCENARIO. Kronk calls this on every model load, from
+// sdk/kronk/model/models.go:120 (`desc := llama.ModelDesc(model)` in
+// toModelInfo). snprintf will then write the whole of model->desc() into a
+// 128-byte GO HEAP allocation. For any model whose description exceeds 127
+// bytes, C writes past the end of that Go object and corrupts whatever the
+// allocator placed next — which is exactly how a later GC cycle comes to scan
+// a clobbered pointer field and abort with "found pointer to free object" in
+// runtime.bgsweep. Today the only thing preventing it is that descriptions
+// happen to be short; nothing in the code enforces that. Secondarily,
+// ModelDesc's own `string(buf[:int32(result)])` would panic with a slice
+// bounds error once snprintf reports more than 128 bytes.
+//
+// This test FAILS while the defect is present and passes once yzma widens
+// bLen to uint64 (or declares the parameter TypeUint32, which would not match
+// the header).
+func TestFFIYzmaModelDescSizeArgWidth(t *testing.T) {
+	dir := ffiPtrYzmaLlamaDir(t)
+	_, f := ffiPtrParseFile(t, dir, "model.go")
+
+	const cName = "llama_model_desc"
+
+	prep := ffiPtrPrepArgTypes(f, cName)
+	if len(prep) < 4 {
+		t.Skipf("%s: cannot locate the Prep registration for %s (found %v); "+
+			"yzma's structure changed, re-audit by hand", dir, cName, prep)
+	}
+
+	// prep[0] is the return type; C parameter 2 (buf_size) is prep[3].
+	sizeParamFFI := prep[3]
+	wantWidth := ffiPtrFFIWidth(sizeParamFFI)
+	if wantWidth == 0 {
+		t.Skipf("unrecognised ffi type %q for %s parameter 2", sizeParamFFI, cName)
+	}
+
+	fn := ffiPtrFuncDecl(f, "ModelDesc")
+	if fn == nil {
+		t.Skip("func ModelDesc not found; yzma's structure changed, re-audit by hand")
+	}
+
+	args := ffiPtrCallArgs(fn)
+	if len(args) < 4 {
+		t.Skipf("ModelDesc: expected at least 4 Call arguments, got %d", len(args))
+	}
+
+	// args[0] is the return buffer, so C parameter 2 is args[3].
+	ident := ffiPtrAddrOfIdent(args[3])
+	if ident == "" {
+		t.Skipf("ModelDesc: Call argument 3 is not a plain &variable; re-audit by hand")
+	}
+
+	goType := ffiPtrLocalType(fn, ident)
+	if goType == "" {
+		t.Skipf("ModelDesc: cannot resolve the Go type of %q; re-audit by hand", ident)
+	}
+
+	gotWidth := ffiPtrGoWidth(goType, ffiPtrNamedScalars(t, dir))
+	if gotWidth == 0 {
+		t.Skipf("ModelDesc: unknown Go type %q for %q", goType, ident)
+	}
+
+	if gotWidth < wantWidth {
+		t.Errorf("yzma ModelDesc passes &%s (Go %s, %d bytes) for %s parameter "+
+			"buf_size, which the cif declares as ffi.%s (%d bytes).\n"+
+			"libffi reads %d bytes from a %d-byte Go variable, so C receives "+
+			"buf_size = <adjacent Go heap>|%d instead of %d.\n"+
+			"llama_model_desc then snprintf()s into yzma's 128-byte Go []byte "+
+			"with no effective bound. Reached from Kronk on every model load at "+
+			"sdk/kronk/model/models.go:120.\n"+
+			"FIX (in yzma, not Kronk): declare the length as uint64, e.g.\n"+
+			"    bLen := uint64(len(buf))",
+			ident, goType, gotWidth, cName, sizeParamFFI, wantWidth,
+			wantWidth, gotWidth, 128, 128)
+	}
+}
+
+// TestFFIYzmaLoadModeFromStrReturnBufferWidth pins FINDING 2.
+//
+// FINDING. yzma's LoadModeFromStr uses a 4-byte variable as the libffi return
+// buffer for an integer-returning C function:
+//
+//	$GOMODCACHE/github.com/hybridgroup/yzma@v1.21.0/pkg/llama/backend.go:120
+//	  lib.Prep("llama_load_mode_from_str", &ffi.TypeSint32, &ffi.TypePointer)
+//
+//	.../pkg/llama/backend.go:211-216
+//	  func LoadModeFromStr(str string) LoadMode {
+//	      var result LoadMode          // type LoadMode int32 -> 4 bytes
+//	      s, _ := utils.BytePtrFromString(str)
+//	      loadModeFromStrFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&s))
+//	      return result
+//	  }
+//
+// RULE. jupiterrider/ffi states the prohibition outright, in the doc comment
+// on the very method being called here
+// ($GOMODCACHE/github.com/jupiterrider/ffi@v0.7.0/fun.go:19-20): "You cannot
+// use integer types smaller than 8 bytes here (float32 and structs are not
+// affected). Use [Arg] instead and typecast afterwards." libffi stores a full
+// ffi_arg — 8 bytes on a 64-bit target — for narrow integer returns.
+// TestFFILibffiWidthContract proves this against libc.
+//
+// FAILURE SCENARIO. The call writes 4 bytes past the end of a Go variable. If
+// `result` is heap-allocated (it escapes, because its address is boxed into
+// ffi.Fun.Call's `ret any` parameter), those 4 bytes land in whatever the
+// allocator placed after it, silently corrupting an unrelated Go object.
+//
+// Every other integer-returning binding in yzma routes through ffi.Arg
+// correctly; this is the lone exception, which is why it reads as an oversight
+// rather than a deliberate choice. No Kronk code path reaches
+// LoadModeFromStr today (Kronk converts its own config enum via
+// Config.LoadMode.ToYZMAType instead), so this is latent, not active — but it
+// is one call away from becoming active and the fix is trivial.
+//
+// This test FAILS while the defect is present and passes once yzma uses
+// ffi.Arg for the return buffer.
+func TestFFIYzmaLoadModeFromStrReturnBufferWidth(t *testing.T) {
+	dir := ffiPtrYzmaLlamaDir(t)
+	_, f := ffiPtrParseFile(t, dir, "backend.go")
+
+	fn := ffiPtrFuncDecl(f, "LoadModeFromStr")
+	if fn == nil {
+		t.Skip("func LoadModeFromStr not found; yzma's structure changed, re-audit by hand")
+	}
+
+	args := ffiPtrCallArgs(fn)
+	if len(args) == 0 {
+		t.Skip("LoadModeFromStr: no .Call found; re-audit by hand")
+	}
+
+	ident := ffiPtrAddrOfIdent(args[0])
+	if ident == "" {
+		t.Skip("LoadModeFromStr: return buffer is not a plain &variable; re-audit by hand")
+	}
+
+	goType := ffiPtrLocalType(fn, ident)
+	if goType == "" {
+		t.Skipf("LoadModeFromStr: cannot resolve the Go type of %q", ident)
+	}
+
+	// ffi.Arg is the sanctioned 8-byte carrier; anything else must be at
+	// least register-wide.
+	if goType == "Arg" {
+		return
+	}
+
+	width := ffiPtrGoWidth(goType, ffiPtrNamedScalars(t, dir))
+	if width == 0 {
+		t.Skipf("LoadModeFromStr: unknown Go type %q for return buffer %q", goType, ident)
+	}
+
+	const registerWidth = 8
+	if width < registerWidth {
+		t.Errorf("yzma LoadModeFromStr uses &%s (Go %s, %d bytes) as the libffi "+
+			"return buffer for the int-returning llama_load_mode_from_str.\n"+
+			"libffi stores a full %d-byte ffi_arg there, writing %d bytes past "+
+			"the end of that Go variable.\n"+
+			"jupiterrider/ffi forbids this explicitly in the doc comment on "+
+			"Fun.Call (ffi@v0.7.0/fun.go:19-20): integer return buffers narrower "+
+			"than 8 bytes must use ffi.Arg.\n"+
+			"FIX (in yzma, not Kronk): mirror every other integer binding, e.g.\n"+
+			"    var result ffi.Arg\n"+
+			"    loadModeFromStrFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&s))\n"+
+			"    return LoadMode(int32(result))",
+			ident, goType, width, registerWidth, registerWidth-width)
+	}
+}

--- a/sdk/kronk/model/ffi_struct_layout_test.go
+++ b/sdk/kronk/model/ffi_struct_layout_test.go
@@ -1,0 +1,371 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// =============================================================================
+// FFI struct-layout audit: yzma's hand-written Go mirrors vs llama.cpp's
+// include/llama.h at the vendored reference build.
+//
+// yzma is a purego/libffi binding, NOT cgo. Nothing checks its Go structs
+// against the C ones: `llama_model_params` and `llama_context_params` are both
+// passed BY VALUE through libffi (see .extras/yzma/pkg/llama/model.go:16-20
+// `ffiTypeModelParams` and .extras/yzma/pkg/llama/context.go:12-31
+// `ffiTypeContextParams`, which are the hand-maintained libffi element lists
+// used for llama_model_load_from_file and llama_init_from_model). A field
+// inserted upstream shifts every following field and silently scrambles the
+// call, with no error message.
+//
+// The C layout used by these tests was verified empirically, not only read out
+// of the header: a throwaway C probe compiled against
+// .extras/llama.cpp/include/llama.h and linked against the shipped
+// libllama.0.0.10211.dylib printed
+//
+//	sizeof(llama_model_params)   = 72   // vocab_only@64 check_tensors@65
+//	                                   // use_extra_bufts@66 no_host@67
+//	                                   // no_alloc@68 load_mtp@69
+//	sizeof(llama_context_params) = 160  // n_ctx@0 ... ctx_other@152
+//
+// and llama_model_default_params() returned load_mtp = false, matching
+// .extras/llama.cpp/src/llama-model.cpp:2393.
+//
+// VERIFIED CORRECT (checked field by field, so the negative result is on
+// record and a future upstream insert is caught):
+//
+//   - llama_context_params (llama.h:350-409) vs llama.ContextParams
+//     (.extras/yzma/pkg/llama/llama.go:335-378): all 36 fields, same order,
+//     same widths, same padding (defrag_thold@80 + 4 pad bytes before
+//     cb_eval@88; six bools at 128-133 + 6 pad bytes before samplers@136);
+//     total 160 bytes on both sides. Pinned by
+//     TestYzmaParamsStructsMirrorLlamaHeader/context_params.
+//   - llama_batch (llama.h:255-264) = 56 bytes vs llama.Batch
+//     (llama.go:286-294); llama_token_data_array (llama.h:228-235) = 32 bytes,
+//     selected@16 sorted@24, vs llama.TokenDataArray (llama.go:278-283);
+//     llama_sampler_chain_params (llama.h:445-447) = 1 byte vs
+//     llama.SamplerChainParams (llama.go:405-407);
+//     llama_model_quantize_params (llama.h:423-438) = 56 bytes / 14 members vs
+//     llama.ModelQuantizeParams (llama.go:381-396) / ffiTypeModelQuantizeParams
+//     (model.go:23-25); llama_logit_bias, llama_chat_message,
+//     llama_sampler_seq_config: all match.
+//   - Enums: llama_rope_scaling_type, llama_pooling_type,
+//     llama_attention_type, llama_flash_attn_type (AUTO=-1/DISABLED=0/
+//     ENABLED=1, llama.h:190-194), llama_load_mode, llama_context_type,
+//     llama_ftype, ggml_type (0..30, 34, 35, 39) — numeric values all match.
+//   - LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY == 1 (llama.h:898); the three
+//     llama_state_seq_*_ext signatures (llama.h:906-923) are registered with
+//     the correct arity and a uint32 flags argument in
+//     .extras/yzma/pkg/llama/state.go:165-175.
+//   - Kronk builds both params structs from the llama.cpp getters, never from a
+//     zero Go struct: modelCtxParams starts at llama.ContextDefaultParams()
+//     (sdk/kronk/model/config.go:842) and buildModelParams at
+//     llama.ModelDefaultParams() (sdk/kronk/model/model.go:429), and every
+//     subsequent write is gated on an explicit config value.
+// =============================================================================
+
+// llamaHeaderPath returns the vendored llama.h, skipping the test when the
+// .extras reference tree is not checked out (it is optional, so these tests
+// must stay portable).
+func llamaHeaderPath(t *testing.T, root string) string {
+	t.Helper()
+
+	path := filepath.Join(root, ".extras", "llama.cpp", "include", "llama.h")
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("vendored llama.cpp reference not present at %s: %v", path, err)
+	}
+
+	return path
+}
+
+// cStructFieldNames returns the member names of the C struct named name, in
+// declaration order, as written in the header at path.
+//
+// The grammar it needs to handle is small and fixed: one member per line,
+// terminated by ';', with '//' comments and comment-only continuation lines
+// interleaved. Every member name is the last identifier before the ';'.
+func cStructFieldNames(t *testing.T, path string, name string) []string {
+	t.Helper()
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	open := regexp.MustCompile(`(?m)^\s*(?:typedef\s+)?struct\s+` + regexp.QuoteMeta(name) + `\s*\{\s*$`)
+	loc := open.FindIndex(src)
+	if loc == nil {
+		t.Fatalf("%s: cannot find the opening line of struct %s", path, name)
+	}
+
+	body := string(src[loc[1]:])
+	ident := regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]*`)
+
+	var fields []string
+
+	for line := range strings.SplitSeq(body, "\n") {
+		code := strings.TrimSpace(line)
+		if i := strings.Index(code, "//"); i >= 0 {
+			code = strings.TrimSpace(code[:i])
+		}
+
+		switch {
+		case code == "":
+			continue
+
+		case strings.HasPrefix(code, "}"):
+			if len(fields) == 0 {
+				t.Fatalf("%s: struct %s parsed as empty", path, name)
+			}
+
+			return fields
+		}
+
+		if !strings.HasSuffix(code, ";") {
+			t.Fatalf("%s: struct %s has a member line this parser cannot handle: %q", path, name, code)
+		}
+
+		names := ident.FindAllString(strings.TrimSuffix(code, ";"), -1)
+		if len(names) == 0 {
+			t.Fatalf("%s: struct %s member line has no identifier: %q", path, name, code)
+		}
+
+		fields = append(fields, names[len(names)-1])
+	}
+
+	t.Fatalf("%s: struct %s is never closed", path, name)
+
+	return nil
+}
+
+// normalizeFieldName folds a C snake_case member name and a Go exported field
+// name onto the same key, so NGpuLayers matches n_gpu_layers and KVUnified
+// matches kv_unified.
+func normalizeFieldName(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", ""))
+}
+
+// TestYzmaParamsStructsMirrorLlamaHeader pins the by-value params structs that
+// yzma hands to llama_model_load_from_file and llama_init_from_model against
+// the C declarations in the vendored llama.h, field for field and in order.
+//
+// FINDING (subtest "model_params"): llama.cpp added a sixth boolean,
+// `bool load_mtp`, to `llama_model_params` — .extras/llama.cpp/include/llama.h:340,
+// introduced by llama.cpp commit 82dbc4f01 ("llama : load MTP tensors only if
+// they are really used", first tagged b10212). yzma mirrors only the five
+// older booleans: .extras/yzma/pkg/llama/llama.go:309-325 (struct ModelParams,
+// last field NoAlloc) and .extras/yzma/pkg/llama/model.go:16-20
+// (ffiTypeModelParams, fifteen libffi elements where C now has sixteen).
+// There is therefore no Go field that can carry load_mtp, and
+// sdk/kronk/model/model.go:428-534 (buildModelParams) has nothing to set —
+// grep confirms `load_mtp` appears nowhere in Kronk outside a JSON tag.
+//
+// CONCRETE FAILURE SCENARIO. Both layouts are 72 bytes (five bools end at
+// offset 68 and tail-pad to 72; six bools end at 69 and tail-pad to 72), so
+// nothing errors and no size assertion catches it — the C byte at offset 69 is
+// simply unreachable Go padding, permanently zero. Against a llama.cpp >= b10212
+// that means load_mtp = false on every llama_model_load_from_file. For the
+// architecture of the user's model (general.architecture = qwen35moe, with
+// qwen35moe.nextn_predict_layers = 1 and blk.40.nextn.* tensors present in the
+// GGUF), .extras/llama.cpp/src/models/qwen35moe.cpp:45 then computes
+// `mtp_flags = TENSOR_SKIP`, and .extras/llama.cpp/src/llama-model-loader.cpp:1100
+// drops every blk.40.nextn.* tensor with "model has unused tensor ... ignoring".
+// layer.nextn.eh_proj / enorm / hnorm stay nullptr, and the first MTP graph
+// build — which Kronk requests by setting CtxType = llama.ContextTypeMTP at
+// sdk/kronk/model/draft_mtp.go:87 and :316 — hits
+// .extras/llama.cpp/src/models/qwen35moe.cpp:565-567
+// `GGML_ASSERT(layer.nextn.eh_proj && "MTP block missing nextn.eh_proj")` and
+// aborts the process.
+//
+// Today Kronk pins defaultVersion = "b10211" (sdk/tools/libs/libs.go:29), the
+// last build before load_mtp existed, which is the only reason this is latent
+// rather than a hard crash; see
+// TestVendoredLlamaCppMatchesPinnedLibraryBuild for that gap.
+//
+// The subtest "context_params" asserts the same correspondence for
+// llama_context_params (llama.h:350-409) vs llama.ContextParams
+// (.extras/yzma/pkg/llama/llama.go:335-378). It passes today and exists so an
+// upstream insert into the struct that carries rope scaling, KV cache types,
+// n_ubatch, n_seq_max and the flash-attention mode cannot land unnoticed.
+func TestYzmaParamsStructsMirrorLlamaHeader(t *testing.T) {
+	root := kronkRepoRoot(t)
+	header := llamaHeaderPath(t, root)
+
+	tests := []struct {
+		name   string
+		cName  string
+		goType reflect.Type
+
+		// aliases maps a C member name to the Go field name when yzma chose a
+		// spelling that does not fold onto the C one. Layout-neutral.
+		aliases map[string]string
+	}{
+		{
+			name:   "model_params",
+			cName:  "llama_model_params",
+			goType: reflect.TypeOf(llama.ModelParams{}),
+		},
+		{
+			name:   "context_params",
+			cName:  "llama_context_params",
+			goType: reflect.TypeOf(llama.ContextParams{}),
+			aliases: map[string]string{
+				"flash_attn_type": "FlashAttentionType",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cFields := cStructFieldNames(t, header, tt.cName)
+
+			goFields := make([]string, 0, tt.goType.NumField())
+			for i := range tt.goType.NumField() {
+				goFields = append(goFields, tt.goType.Field(i).Name)
+			}
+
+			for i, cField := range cFields {
+				want := normalizeFieldName(cField)
+				if alias, ok := tt.aliases[cField]; ok {
+					want = normalizeFieldName(alias)
+				}
+
+				if i >= len(goFields) {
+					t.Errorf("%s member %d %q (llama.h) has NO counterpart in %s: the Go mirror stops after %d fields, so the C bytes for %q are unreachable padding and can never be set",
+						tt.cName, i, cField, tt.goType, len(goFields), cField)
+
+					continue
+				}
+
+				if got := normalizeFieldName(goFields[i]); got != want {
+					t.Errorf("%s member %d: llama.h says %q, %s field %d is %q — the by-value struct is shifted from here on",
+						tt.cName, i, cField, tt.goType, i, goFields[i])
+				}
+			}
+
+			if len(goFields) > len(cFields) {
+				t.Errorf("%s: %s has %d fields but llama.h declares %d; the extra Go fields are written past the C struct",
+					tt.cName, tt.goType, len(goFields), len(cFields))
+			}
+		})
+	}
+}
+
+// TestVendoredLlamaCppMatchesPinnedLibraryBuild pins the reference-vs-runtime
+// build gap that lets an ABI change like `load_mtp` slip in unseen.
+//
+// FINDING. sdk/tools/libs/libs.go:29 pins the shared library Kronk downloads
+// and dlopens to `defaultVersion = "b10211"`, and the installed library really
+// is that build (~/.kronk/libraries/.../libllama.0.0.10211.dylib). The
+// vendored reference tree that every layout audit reads —
+// .extras/llama.cpp, whose include/llama.h is the authority for yzma's
+// hand-mirrored structs — is checked out at b10217+1 commit
+// (`git describe --tags` reports b10217-1-gde699957b), seven builds ahead.
+//
+// CONCRETE FAILURE SCENARIO. The two builds are not ABI-identical. `git diff
+// b10211..HEAD -- include/llama.h` in the vendored tree is exactly one hunk:
+// `+ bool load_mtp;` appended to llama_model_params (llama.h:340). So
+// llama_model_params is 15 members in the library that actually runs and 16 in
+// the header used to review yzma — which is why yzma's 15-member mirror both
+// looks correct against the running library and is silently wrong for the
+// header in the repo. Reviewing against the wrong header cuts both ways: a
+// field added between the pinned build and the vendored tip reads as "yzma is
+// missing a field" (harmless until the pin moves, then a hard abort — see
+// TestYzmaParamsStructsMirrorLlamaHeader), and a field REMOVED or reordered
+// upstream would read as "yzma is fine" while every argument after it is
+// scrambled at runtime.
+//
+// The invariant is that the vendored reference is checked out at exactly the
+// pinned build, so header-based audits describe the library that runs.
+func TestVendoredLlamaCppMatchesPinnedLibraryBuild(t *testing.T) {
+	root := kronkRepoRoot(t)
+
+	tree := filepath.Join(root, ".extras", "llama.cpp")
+	if _, err := os.Stat(filepath.Join(tree, ".git")); err != nil {
+		t.Skipf("vendored llama.cpp git checkout not present at %s: %v", tree, err)
+	}
+
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	out, err := exec.Command(git, "-C", tree, "describe", "--tags").Output()
+	if err != nil {
+		t.Skipf("git describe in %s failed: %v", tree, err)
+	}
+
+	described := strings.TrimSpace(string(out))
+	pinned := pinnedLibsDefaultVersion(t, root)
+
+	build := regexp.MustCompile(`^b[0-9]+`).FindString(described)
+	if build == "" {
+		t.Fatalf("cannot read a llama.cpp build tag out of %q", described)
+	}
+
+	if build != pinned {
+		t.Errorf("vendored .extras/llama.cpp is at build %s (git describe %q) but sdk/tools/libs/libs.go pins defaultVersion = %q: include/llama.h does not describe the libllama Kronk loads",
+			build, described, pinned)
+	}
+
+	if described != build {
+		t.Errorf("vendored .extras/llama.cpp is %s, i.e. ahead of tag %s: commits past the pinned build can add, remove or reorder struct members (b10212 appended llama_model_params.load_mtp) with nothing to catch it",
+			described, build)
+	}
+}
+
+// pinnedLibsDefaultVersion reads the unexported defaultVersion constant out of
+// sdk/tools/libs/libs.go, so the assertion tracks the real pin instead of a
+// copy of it.
+func pinnedLibsDefaultVersion(t *testing.T, root string) string {
+	t.Helper()
+
+	path := filepath.Join(root, "sdk", "tools", "libs", "libs.go")
+	file := parseKronkSource(t, token.NewFileSet(), path)
+
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for i, name := range vs.Names {
+				if name.Name != "defaultVersion" || i >= len(vs.Values) {
+					continue
+				}
+
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					t.Fatalf("%s: defaultVersion is not a string literal", path)
+				}
+
+				v, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("%s: unquote defaultVersion: %v", path, err)
+				}
+
+				return v
+			}
+		}
+	}
+
+	t.Fatalf("%s: cannot find the defaultVersion constant", path)
+
+	return ""
+}

--- a/sdk/kronk/model/flash_attention_resolve_test.go
+++ b/sdk/kronk/model/flash_attention_resolve_test.go
@@ -1,0 +1,264 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// =============================================================================
+// Flash Attention configuration path: Kronk config -> llama.ContextParams ->
+// llama_context_params.flash_attn_type.
+//
+// GROUND TRUTH (.extras/llama.cpp @ b10211)
+//
+//	include/llama.h:190-194
+//	    enum llama_flash_attn_type {
+//	        LLAMA_FLASH_ATTN_TYPE_AUTO     = -1,
+//	        LLAMA_FLASH_ATTN_TYPE_DISABLED =  0,
+//	        LLAMA_FLASH_ATTN_TYPE_ENABLED  =  1,
+//	    };
+//
+//	include/llama.h:364                   llama_context_params.flash_attn_type
+//	src/llama-context.cpp:3493            default = LLAMA_FLASH_ATTN_TYPE_AUTO
+//	common/common.h:496                   CLI default = LLAMA_FLASH_ATTN_TYPE_AUTO
+//	common/arg.cpp:1666-1680              -fa on|off|auto
+//
+// yzma mirrors the C values exactly (.extras/yzma/pkg/llama/llama.go:163-165)
+// and its ContextParams field order matches llama_context_params field for
+// field, so nothing is lost in the FFI hand-off. Kronk, however, declares its
+// OWN int32 enum with DIFFERENT numbers (config.go:1183-1185):
+//
+//	FlashAttentionEnabled  = 0   // == LLAMA_FLASH_ATTN_TYPE_DISABLED
+//	FlashAttentionDisabled = 1   // == LLAMA_FLASH_ATTN_TYPE_ENABLED
+//	FlashAttentionAuto     = 2   // not a valid llama_flash_attn_type at all
+//
+// Every value therefore MUST pass through the translation switch at
+// config.go:873-882. Today exactly one call site writes
+// ctxParams.FlashAttentionType and it does go through that switch, so there is
+// no live mistranslation to pin here — the two enums are audited as equivalent
+// only through that switch, which is what the mirror below reproduces.
+// =============================================================================
+
+// resolveFlashAttentionType is a VERBATIM MIRROR of the translation switch that
+// turns Kronk's FlashAttentionType into the llama.cpp enum value handed to
+// llama_init_from_model:
+//
+//	sdk/kronk/model/config.go:873-882
+//		switch cfg.FlashAttention() {
+//		case FlashAttentionDisabled:
+//			ctxParams.FlashAttentionType = llama.FlashAttentionTypeDisabled
+//
+//		case FlashAttentionAuto:
+//			ctxParams.FlashAttentionType = llama.FlashAttentionTypeAuto
+//
+//		default:
+//			ctxParams.FlashAttentionType = llama.FlashAttentionTypeEnabled
+//		}
+//
+// The switch lives inside modelCtxParams (sdk/kronk/model/config.go:842), which
+// opens with llama.ContextDefaultParams() — a raw FFI call with no nil-handle
+// guard (.extras/yzma/pkg/llama/context.go) that panics without a prior dlopen
+// of the llama shared library. That is why the switch is mirrored instead of
+// called; see the same reasoning in mtp_ctxparams_source_test.go.
+//
+// MAINTAINER: when config.go:873-882 changes, update this mirror in the same
+// commit so it keeps tracking the production mapping.
+func resolveFlashAttentionType(cfg Config) llama.FlashAttentionType {
+	switch cfg.FlashAttention() {
+	case FlashAttentionDisabled:
+		return llama.FlashAttentionTypeDisabled
+
+	case FlashAttentionAuto:
+		return llama.FlashAttentionTypeAuto
+
+	default:
+		return llama.FlashAttentionTypeEnabled
+	}
+}
+
+// TestFlashAttentionUnsetResolvesToLlamaAuto pins the Flash Attention default
+// divergence between Kronk and llama.cpp.
+//
+// FINDING
+// An unset PtrFlashAttention resolves to FlashAttentionEnabled, so Kronk hands
+// llama.cpp a FORCED LLAMA_FLASH_ATTN_TYPE_ENABLED (1) on every load that does
+// not name a mode explicitly. llama.cpp's own default — for the library, for
+// common/, and for llama-server — is LLAMA_FLASH_ATTN_TYPE_AUTO (-1).
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/config.go:1255-1259  DerefFlashAttention returns
+//     FlashAttentionEnabled for a nil pointer.
+//   - sdk/kronk/model/config.go:441-443    Config.FlashAttention() delegates to it.
+//   - sdk/kronk/model/config.go:880-881    the switch's default arm turns that
+//     into llama.FlashAttentionTypeEnabled.
+//   - sdk/kronk/model/config.go:183-187    the doc comment that documents the
+//     divergence as intentional ("When nil, FlashAttentionEnabled is used").
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/src/llama-context.cpp:3493 — llama_context_default_params()
+//     sets flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO.
+//   - .extras/llama.cpp/common/common.h:496 — the CLI/server default is AUTO too.
+//   - .extras/llama.cpp/src/llama-context.cpp:246-247
+//     cparams.flash_attn = params.flash_attn_type != DISABLED;
+//     cparams.auto_fa    = params.flash_attn_type == AUTO;
+//   - .extras/llama.cpp/src/llama-context.cpp:549-552 — the Flash Attention
+//     capability probe runs ONLY under `if (cparams.auto_fa)`.
+//
+// FAILURE SCENARIO
+// AUTO makes llama.cpp reserve a probe graph and compare the device the fused
+// FLASH_ATTN node landed on against the device that owns the layer
+// (llama-context.cpp:520-547). On a mismatch — "usually due to missing support"
+// — it logs "Flash Attention not supported, set to disabled" and rebuilds
+// without FA. A forced ENABLED sets auto_fa = false, so that probe never runs:
+// cparams.flash_attn stays true unconditionally and the graph keeps its
+// ggml_flash_attn_ext node (llama-graph.cpp:2418-2441). On a backend/head-dim
+// combination the device cannot honour there is no fallback — the node is
+// scheduled onto whichever backend accepts it (typically CPU) while the layer's
+// K/V live on the accelerator, silently adding a per-layer, per-token
+// device round trip, with no error and no log line from either side. The
+// forced value also suppresses the AUTO-only promotions and rejections that
+// llama.cpp performs at llama-context.cpp:3546-3569.
+//
+// The fix is for DerefFlashAttention(nil) to return FlashAttentionAuto, so an
+// unconfigured Kronk behaves like an unconfigured llama.cpp. Note that
+// config_test.go:104 ("unset" -> FlashAttentionEnabled) pins the current wrong
+// default and must be updated in the same commit.
+func TestFlashAttentionUnsetResolvesToLlamaAuto(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want llama.FlashAttentionType
+	}{
+		{"unset must match the llama.cpp default", NewConfig(), llama.FlashAttentionTypeAuto},
+		{"explicit auto", NewConfig(WithFlashAttention(FlashAttentionAuto)), llama.FlashAttentionTypeAuto},
+		{"explicit enabled", NewConfig(WithFlashAttention(FlashAttentionEnabled)), llama.FlashAttentionTypeEnabled},
+		{"explicit disabled", NewConfig(WithFlashAttention(FlashAttentionDisabled)), llama.FlashAttentionTypeDisabled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveFlashAttentionType(tt.cfg); got != tt.want {
+				t.Errorf("flash_attn_type handed to llama_init_from_model: got %d, want %d", got, tt.want)
+			}
+		})
+	}
+
+	// The numeric values are load bearing: Kronk's own enum reuses 0 and 1 with
+	// the opposite meaning, so any future assignment that skips the switch at
+	// config.go:873-882 would be a silent inversion (both types are int32).
+	if llama.FlashAttentionTypeAuto != -1 || llama.FlashAttentionTypeDisabled != 0 || llama.FlashAttentionTypeEnabled != 1 {
+		t.Fatalf("yzma no longer mirrors llama.h:190-194: auto=%d disabled=%d enabled=%d",
+			llama.FlashAttentionTypeAuto, llama.FlashAttentionTypeDisabled, llama.FlashAttentionTypeEnabled)
+	}
+}
+
+// TestValidateConfigRejectsQuantizedVCacheWithFlashAttentionDisabled pins the
+// missing pre-flight guard for the one KV-cache/Flash-Attention combination
+// llama.cpp refuses outright.
+//
+// FINDING
+// llama.cpp hard-rejects a quantized V cache when Flash Attention is explicitly
+// DISABLED. Kronk lets that Config through validateConfig untouched, and the
+// AutoTune/analyze path can even PRODUCE it: on a host without a usable GPU,
+// buildProfile hardcodes flash_attention = "disabled"
+// (sdk/tools/models/analyze.go:374-381) while the cache selector independently
+// falls back from f16 to q8_0 for both K and V when f16 does not fit
+// (sdk/tools/models/analyze.go:439, 462-464 via cacheRecommendations at :622-650).
+// applyRecommendation then writes both into the model.Config
+// (sdk/tools/models/kronkresolve.go:229-237, :306-315). Nothing in between
+// notices the conflict.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/config.go:525-674 — validateConfig has no
+//     CacheTypeK/CacheTypeV vs FlashAttention rule at all.
+//   - sdk/kronk/model/config.go:865-871 — CacheTypeV is copied into
+//     ctxParams.TypeV whenever it is not GGMLTypeAuto.
+//   - sdk/kronk/model/config.go:874-876 — FlashAttentionDisabled is copied into
+//     ctxParams.FlashAttentionType.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/src/llama-context.cpp:3561-3569
+//     if (ggml_is_quantized(params.type_v) && flash_attn_type != ENABLED) {
+//     AUTO     -> promoted to ENABLED ("required for quantized V cache");
+//     DISABLED -> LLAMA_LOG_ERROR "quantized V cache requires flash_attn to be
+//     enabled" and llama_init_from_model returns nullptr.
+//   - .extras/llama.cpp/src/llama-context.cpp:458-461 — the same invariant is
+//     re-checked inside the constructor and throws
+//     "quantized V cache was requested, but this requires Flash Attention".
+//
+// FAILURE SCENARIO
+// A default-config load is safe (CacheTypeV stays GGMLTypeAuto, so TypeV keeps
+// llama.cpp's F16), but any config that pairs cache-type-v: q8_0 with
+// flash-attention: disabled — including one AutoTune wrote itself on a
+// CPU-only, RAM-tight host — reaches llama_init_from_model and comes back as a
+// nil context. Kronk surfaces that as a generic "unable to init context" with
+// llama.cpp's explanatory line only in the C log, instead of failing in
+// validateConfig with the actual conflict. The three control rows below are the
+// combinations llama.cpp accepts (AUTO is promoted, ENABLED is honoured, F16
+// needs nothing) and must keep passing after the guard is added.
+func TestValidateConfigRejectsQuantizedVCacheWithFlashAttentionDisabled(t *testing.T) {
+	discard := func(ctx context.Context, msg string, args ...any) {}
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			"quantized V cache with flash attention disabled is rejected by llama.cpp",
+			NewConfig(
+				WithModelFiles([]string{"dummy.gguf"}),
+				WithCacheTypeV(GGMLTypeQ8_0),
+				WithFlashAttention(FlashAttentionDisabled),
+			),
+			true,
+		},
+		{
+			"quantized V cache with flash attention auto is promoted by llama.cpp",
+			NewConfig(
+				WithModelFiles([]string{"dummy.gguf"}),
+				WithCacheTypeV(GGMLTypeQ8_0),
+				WithFlashAttention(FlashAttentionAuto),
+			),
+			false,
+		},
+		{
+			"quantized V cache with flash attention enabled is honoured",
+			NewConfig(
+				WithModelFiles([]string{"dummy.gguf"}),
+				WithCacheTypeV(GGMLTypeQ8_0),
+				WithFlashAttention(FlashAttentionEnabled),
+			),
+			false,
+		},
+		{
+			"f16 V cache with flash attention disabled is fine",
+			NewConfig(
+				WithModelFiles([]string{"dummy.gguf"}),
+				WithCacheTypeV(GGMLTypeF16),
+				WithFlashAttention(FlashAttentionDisabled),
+			),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(context.Background(), tt.cfg, discard)
+
+			switch {
+			case tt.wantErr && err == nil:
+				t.Error("validateConfig: got nil, want an error naming the quantized V cache / flash attention conflict")
+
+			case tt.wantErr && !strings.Contains(strings.ToLower(err.Error()), "flash"):
+				t.Errorf("validateConfig: got %v, want an error naming the flash attention conflict", err)
+
+			case !tt.wantErr && err != nil:
+				t.Errorf("validateConfig: got %v, want nil", err)
+			}
+		})
+	}
+}

--- a/sdk/kronk/model/mtp_disable_test.go
+++ b/sdk/kronk/model/mtp_disable_test.go
@@ -1,0 +1,172 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v2"
+)
+
+// =============================================================================
+// Silent test-coverage holes in the MTP integration suites.
+//
+// Two suites under sdk/kronk/tests/ resolve a model id that is absent from the
+// catalog. resolveModel discards the error, TestMain reads the zero Path as
+// "model not downloaded", and the suite exits 0 — green, silent, zero tests run.
+// =============================================================================
+
+// =============================================================================
+// Silently skipping MTP test suites.
+
+// mtpCatalogModelIDs returns the set of model ids declared in the shipped
+// catalog, keyed both by the full "provider/name" form and by the bare name,
+// which is what testlib passes to Models.FullPath (see fullPathLookupKeys /
+// sdk/tools/models/retrieve.go:198).
+func mtpCatalogModelIDs(t *testing.T) (full map[string]map[string]any, bare map[string]string) {
+	t.Helper()
+
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "tools", "defaults", "yaml", "catalog.yaml")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+
+	var catalog struct {
+		Models map[string]map[string]any `yaml:"models"`
+	}
+
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("parse catalog %s: %v", path, err)
+	}
+
+	if len(catalog.Models) == 0 {
+		t.Fatalf("catalog %s declares no models", path)
+	}
+
+	bare = make(map[string]string, len(catalog.Models))
+	for id := range catalog.Models {
+		if idx := strings.LastIndex(id, "/"); idx >= 0 {
+			bare[id[idx+1:]] = id
+			continue
+		}
+		bare[id] = id
+	}
+
+	return catalog.Models, bare
+}
+
+// resolveModelCallRE matches testlib.Setup's catalog lookups, e.g.
+//
+//	resolveModel(mdls, "mtp-Qwen3.6-35B-A3B-UD-Q2_K_XL", &MPMTP)
+var resolveModelCallRE = regexp.MustCompile(`resolveModel\(mdls,\s*"([^"]+)",\s*&(\w+)\)`)
+
+// TestTestlibResolvesOnlyCatalogModelIDs pins a silent test-coverage hole: the
+// integration suites resolve model ids that the shipped catalog does not
+// contain, and the resolution failure is swallowed.
+//
+// FINDING
+// sdk/kronk/tests/testlib/testlib.go:96-106 resolves every suite's model, and
+// sdk/kronk/tests/testlib/testlib.go:110-116 (resolveModel) DISCARDS the error:
+//
+//	func resolveModel(mdls *models.Models, name string, mp *models.Path) {
+//	    if dp, err := mdls.FullPath(name); err == nil {   // err dropped
+//	        *mp = dp
+//	    }
+//	}
+//
+// A bad id therefore leaves the models.Path zero-valued, and each suite's
+// TestMain reads that as "model not downloaded" and calls os.Exit(0) — a green,
+// silent, zero-test run. sdk/kronk/tests/testlib/testlib.go:97 asks for
+// "mtp-Qwen3.6-35B-A3B-UD-Q2_K_XL", which is not in
+// sdk/tools/defaults/yaml/catalog.yaml; the only MTP-capable entry is
+// unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL (catalog.yaml:321). An id absent from
+// the catalog can never enter the on-disk download index that
+// Models.FullPath consults (sdk/tools/models/retrieve.go:198-207), so
+// testlib.MPMTP is permanently empty and sdk/kronk/tests/mtp/main_test.go:20
+// exits 0 every time.
+//
+// LLAMA.CPP REFERENCE
+// Not a llama.cpp divergence — this is what let the MTP divergences from
+// llama.cpp's reference speculative path (.extras/llama.cpp/common/speculative.cpp,
+// .extras/llama.cpp/tools/server/server-context.cpp) ship unnoticed: the suite
+// that was supposed to catch them has never executed a single test.
+//
+// FAILURE SCENARIO
+// CI reports the mtp package as passing. It printed
+// "model mtp-Qwen3.6-35B-A3B-UD-Q2_K_XL not downloaded, skipping mtp tests"
+// and ran nothing, so every MTP regression — including the ones behind the
+// user's contradictions and abandoned tasks — is unguarded.
+func TestTestlibResolvesOnlyCatalogModelIDs(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "tests", "testlib", "testlib.go")
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	matches := resolveModelCallRE.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no resolveModel(mdls, ...) calls found in %s; update this assertion", path)
+	}
+
+	_, bare := mtpCatalogModelIDs(t)
+
+	for _, m := range matches {
+		id, target := m[1], m[2]
+
+		if _, ok := bare[id]; !ok {
+			t.Errorf("testlib.go resolves model id %q into %s, but it is not in sdk/tools/defaults/yaml/catalog.yaml: it can never be downloaded, resolveModel swallows the error (testlib.go:110-116), and the suite gated on %s silently exits 0",
+				id, target, target)
+		}
+	}
+}
+
+// TestGemma4MTPSuiteTargetShipsMTPSidecar pins the same silent-skip defect in
+// the second MTP suite, which fails for a different reason: the id resolves,
+// but the catalog entry carries no MTP companion file.
+//
+// FINDING
+// sdk/kronk/tests/gemma4mtp/main_test.go:19-22 exits 0 unless
+// testlib.MPMoEVision.MTPFile is non-empty. MPMoEVision is
+// gemma-4-26B-A4B-it-UD-Q4_K_M (sdk/kronk/tests/testlib/testlib.go:89), and
+// models.Path.MTPFile is populated only from the catalog entry's `mtp:` key
+// (sdk/tools/models/catalog.go:787-789, sdk/tools/models/download.go:520).
+// catalog.yaml declares `mtp:` only on unsloth/gemma-4-26B-A4B-it-UD-Q8_K_XL
+// (catalog.yaml:352); the Q4_K_M entry (catalog.yaml:127-145) has none. So
+// MTPFile is always "" and the whole gemma4mtp suite — the only coverage for
+// the shared-KV MTP drafter path that Config.MTPDrafterFile selects
+// (sdk/kronk/model/draft_mtp.go:438-458) — has never run.
+//
+// LLAMA.CPP REFERENCE
+// The shared-KV drafter mirrors upstream's ctx_dft-shares-target-memory MTP
+// implementation (.extras/llama.cpp/common/speculative.cpp:1286,
+// COMMON_SPECULATIVE_TYPE_DRAFT_MTP). Upstream downloads that sidecar only on
+// explicit request (.extras/llama.cpp/common/arg.cpp:388), which is why the
+// catalog has to declare it per quant — and why the missing declaration on the
+// Q4_K_M quant silently disables the suite instead of failing it.
+//
+// FAILURE SCENARIO
+// A change to loadDraftModelMTPShared or to the Pass 2A/2B split lands with a
+// green gemma4mtp package that executed zero tests. Either point the suite at
+// the Q8_K_XL quant that actually ships the sidecar, or add the `mtp:` entry to
+// the Q4_K_M catalog record.
+func TestGemma4MTPSuiteTargetShipsMTPSidecar(t *testing.T) {
+	models, bare := mtpCatalogModelIDs(t)
+
+	const target = "gemma-4-26B-A4B-it-UD-Q4_K_M"
+
+	full, ok := bare[target]
+	if !ok {
+		t.Fatalf("catalog has no entry for %q; testlib.go:89 resolves it for MPMoEVision", target)
+	}
+
+	if _, ok := models[full]["mtp"]; !ok {
+		t.Errorf("catalog entry %q declares no mtp: sidecar, so testlib.MPMoEVision.MTPFile is always empty and sdk/kronk/tests/gemma4mtp/main_test.go:19 exits 0 without running a single test", full)
+	}
+}

--- a/sdk/kronk/model/nonspeculative_decode_test.go
+++ b/sdk/kronk/model/nonspeculative_decode_test.go
@@ -1,0 +1,898 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// PLAIN (NON-SPECULATIVE) DECODE PATH REGRESSIONS
+//
+// Every finding pinned in this file is reachable with NO drafter configured
+// (e.model.draft == nil), i.e. it survives "disable MTP" as a workaround.
+//
+// A plain Chat() always lands in the generation batch engine: batchseq_engine.go
+// is a separate runtime used only by embed.go:33 and rerank.go:35, and it never
+// samples. So batchgen_*.go is the only generation path.
+//
+// Most of these live inside functions that need a live llama.Context and a
+// loaded GGUF (llama.SamplerSample, llama.Decode, llama.GetLogitsIth), so where
+// a direct call is impossible the test is either a VERBATIM MIRROR of the
+// production arithmetic/ordering (with the mirrored file.go:LINE cited on the
+// mirror itself, per rollback_draft_test.go's convention) or an AST assertion
+// over the checked-in source.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Finding 1: every sampled token is accepted TWICE into the sampler chain.
+
+// penaltyRingMirror is a VERBATIM MIRROR of llama.cpp's
+// `ring_buffer<llama_token> prev` as the penalties sampler uses it:
+//
+//	.extras/llama.cpp/src/llama-sampler.cpp:25-26   ring_buffer(size_t cap) : capacity(cap), data(cap) {}
+//	.extras/llama.cpp/src/llama-sampler.cpp:55-68   push_back: when sz == capacity, advance `first` (evict oldest)
+//	.extras/llama.cpp/src/llama-sampler.cpp:2782    prev = ring_buffer<llama_token>(penalty_last_n)
+//
+// The capacity is penalty_last_n, so the buffer holds at most penalty_last_n
+// ACCEPTED tokens — not at most penalty_last_n *generated* tokens.
+type penaltyRingMirror struct {
+	capacity int
+	items    []int
+}
+
+func (r *penaltyRingMirror) size() int { return len(r.items) }
+
+func (r *penaltyRingMirror) front() int { return r.items[0] }
+
+func (r *penaltyRingMirror) pushBack(tok int) {
+	if r.capacity == 0 {
+		return
+	}
+	if len(r.items) == r.capacity {
+		r.items = r.items[1:]
+	}
+	r.items = append(r.items, tok)
+}
+
+// penaltiesMirror is a VERBATIM MIRROR of llama_sampler_penalties' state and of
+// llama_sampler_penalties_accept:
+//
+//	.extras/llama.cpp/src/llama-sampler.cpp:2657-2685
+//	    ctx->token_count[token]++;
+//	    if (ctx->prev.size() >= (size_t) ctx->penalty_last_n) {
+//	        const auto old = ctx->prev.front();
+//	        ctx->token_count[old]--;
+//	        if (ctx->token_count[old] == 0) { ctx->token_count.erase(old); }
+//	    }
+//	    ctx->prev.push_back(token);
+//
+// llama_sampler_penalties_apply (:2687-2718) reads token_count: the repeat
+// penalty is applied once per PRESENT token (membership only), the presence
+// penalty is `float(count > 0) * penalty_present` (membership only), but the
+// frequency penalty is `float(count) * penalty_freq` — proportional to the
+// stored count.
+type penaltiesMirror struct {
+	penaltyLastN int
+	prev         penaltyRingMirror
+	tokenCount   map[int]int
+}
+
+func newPenaltiesMirror(penaltyLastN int) *penaltiesMirror {
+	return &penaltiesMirror{
+		penaltyLastN: penaltyLastN,
+		prev:         penaltyRingMirror{capacity: penaltyLastN},
+		tokenCount:   make(map[int]int),
+	}
+}
+
+func (p *penaltiesMirror) accept(tok int) {
+	if p.penaltyLastN == 0 {
+		return
+	}
+
+	p.tokenCount[tok]++
+
+	if p.prev.size() >= p.penaltyLastN {
+		old := p.prev.front()
+		p.tokenCount[old]--
+		if p.tokenCount[old] == 0 {
+			delete(p.tokenCount, old)
+		}
+	}
+
+	p.prev.pushBack(tok)
+}
+
+// distinctWindow reports how many DISTINCT emitted tokens the penalty window
+// still covers, which is the property `penalty_last_n = 64` is supposed to
+// guarantee.
+func (p *penaltiesMirror) distinctWindow() int {
+	return len(p.tokenCount)
+}
+
+// TestSamplerAcceptedTwicePerTokenCorruptsPenaltyWindow pins the double-accept
+// on the PLAIN, non-speculative decode path.
+//
+// FINDING
+// llama_sampler_sample() itself ends with llama_sampler_accept(smpl, token)
+// (.extras/llama.cpp/src/llama-sampler.cpp:873, inside the function that starts
+// at :810). Kronk calls it through yzma's thin wrapper llama.SamplerSample
+// (.extras/yzma/pkg/llama/sampling.go:574-584) and then calls
+// llama.SamplerAccept on the SAME chain again, so the chain's accept() runs
+// twice for every emitted token.
+//
+// PRODUCTION LINES PINNED (all non-speculative)
+//   - sdk/kronk/model/batchgen_tokens.go:25  processSlotToken   -> :63 accept
+//   - sdk/kronk/model/batchgen_tokens.go:265 sampleFirstToken   -> :63 accept
+//   - sdk/kronk/model/batchgen_engine.go:259 M-RoPE generation  -> :261 -> :63
+//
+// The single accept is at sdk/kronk/model/batchgen_tokens.go:63
+// (`llama.SamplerAccept(s.sampler, token)`), which is the ONLY SamplerAccept
+// call on the request sampler in the whole package.
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+//   - .extras/llama.cpp/common/sampling.cpp:646-676
+//     common_sampler_sample_and_accept_n uses common_sampler_sample (which
+//     calls llama_sampler_apply, NOT llama_sampler_sample — see
+//     common/sampling.cpp:630-643) plus exactly ONE common_sampler_accept per
+//     emitted token.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:3801 + :3806
+//     the plain server path: common_sampler_sample() then exactly one
+//     common_sampler_accept().
+//
+// FAILURE SCENARIO
+// With Params.RepeatLastN = 64 (DefRepeatLastN, sdk/kronk/model/params.go:80)
+// and any repeat/frequency/presence penalty set, the penalties sampler is added
+// to the chain (sdk/kronk/model/params.go:785-788). Its ring buffer capacity is
+// penalty_last_n, so two accepts per token mean the window covers only 32 real
+// output tokens instead of 64, and token_count reaches 2 for every token in the
+// window, doubling the frequency-penalty weight `float(count) * penalty_freq`
+// (.extras/llama.cpp/src/llama-sampler.cpp:2715). The repeat and presence
+// penalties are membership-only and keep their nominal weight.
+//
+// The same double-accept halves the DRY sampler's last_tokens window
+// (.extras/llama.cpp/src/llama-sampler.cpp:3245, accept at :2937-2944) and
+// additionally poisons its content: DRY's suffix-repetition search runs over
+// "a a b b c c" instead of "a b c", so it detects repetitions the model never
+// produced.
+//
+// The default chain does NOT contain penalties or DRY (DefRepeatPenalty = 1.0,
+// DefFrequencyPenalty = 0, DefPresencePenalty = 0, DefDryMultiplier = 0 at
+// sdk/kronk/model/params.go:34/47/72/88, gated at params.go:785 and :792), and
+// the remaining default samplers (suppress-bias, top-k, top-p, min-p, temp-ext,
+// dist) all have `.accept = nullptr`. So this is latent under default params
+// and bites any caller that enables a penalty.
+//
+// FIX: use llama.SamplerApply on a locally built candidate array (as
+// common_sampler_sample does) and keep the single explicit
+// llama.SamplerAccept, or drop the explicit accept at batchgen_tokens.go:63.
+func TestSamplerAcceptedTwicePerTokenCorruptsPenaltyWindow(t *testing.T) {
+	const (
+		penaltyLastN = 64 // DefRepeatLastN, sdk/kronk/model/params.go:80
+		nEmitted     = 64
+	)
+
+	// One distinct token per emitted position, so the window content is
+	// unambiguous.
+	emitted := make([]int, nEmitted)
+	for i := range emitted {
+		emitted[i] = 1000 + i
+	}
+
+	// Upstream: common_sampler_sample (apply only) + one accept per token.
+	upstream := newPenaltiesMirror(penaltyLastN)
+	for _, tok := range emitted {
+		upstream.accept(tok)
+	}
+
+	// Kronk: llama.SamplerSample accepts internally
+	// (llama-sampler.cpp:873), then batchgen_tokens.go:63 accepts again.
+	kronk := newPenaltiesMirror(penaltyLastN)
+	for _, tok := range emitted {
+		kronk.accept(tok) // implicit, inside llama_sampler_sample
+		kronk.accept(tok) // explicit, batchgen_tokens.go:63
+	}
+
+	if upstream.distinctWindow() != nEmitted {
+		t.Fatalf("mirror is wrong: upstream window covers %d of %d emitted tokens",
+			upstream.distinctWindow(), nEmitted)
+	}
+
+	if got := kronk.distinctWindow(); got != upstream.distinctWindow() {
+		t.Errorf("penalty window after %d emitted tokens with penalty_last_n=%d: kronk covers %d distinct tokens, upstream covers %d\n"+
+			"llama.SamplerSample already runs llama_sampler_accept (llama-sampler.cpp:873); "+
+			"batchgen_tokens.go:63 accepts the same token a second time, so the "+
+			"ring_buffer of capacity penalty_last_n (llama-sampler.cpp:2782) holds two "+
+			"entries per output token and the effective repetition window is halved.",
+			nEmitted, penaltyLastN, got, upstream.distinctWindow())
+	}
+
+	// Weight: token_count is what the frequency penalty is multiplied by
+	// (llama-sampler.cpp:2715).
+	{
+		tok := emitted[nEmitted-1]
+		want := upstream.tokenCount[tok]
+		if got := kronk.tokenCount[tok]; got != want {
+			t.Errorf("token_count[%d] = %d, want %d\n"+
+				"the doubled accept double-counts each token, so the frequency penalty "+
+				"`float(count) * penalty_freq` (llama-sampler.cpp:2715) is applied at twice "+
+				"the configured strength.", tok, got, want)
+		}
+	}
+}
+
+// TestPromptTokensArePrimedIntoTheSamplerChain pins the second half of the
+// sampler-state divergence: Kronk never seeds the sampler chain with the prompt.
+//
+// FINDING
+// llama.cpp's server primes the request's sampler with every prompt token
+// before generation starts:
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:375-397  server_slot::init_sampler()
+//	    common_sampler_reset(smpl.get());
+//	    for (int i = 0; i < (int) prompt.tokens.size(); i++) {
+//	        const llama_token id = prompt.tokens[i];
+//	        if (id != LLAMA_TOKEN_NULL) { common_sampler_accept(smpl.get(), id, false); }
+//	    }
+//
+// so penalties / DRY see the last penalty_last_n tokens of the
+// prompt-plus-generation stream, exactly as the sampler's own documentation
+// assumes.
+//
+// PRODUCTION LINE PINNED: sdk/kronk/model/batchgen_tokens.go:63 is the only
+// llama.SamplerAccept call on a request sampler anywhere in the package (the
+// other two are grammar.go:436, a different sampler object, and
+// batchgen_speculative.go:198, a SamplerReset on the draft sampler). Neither
+// startSlotText (sdk/kronk/model/batchgen_slot_start.go:791) nor
+// addPrefillChunk (sdk/kronk/model/batchgen_prefill_text.go:14) primes the
+// chain.
+//
+// FAILURE SCENARIO
+// In a long multi-turn conversation the entire history is prompt, not
+// generation. With RepeatPenalty/FrequencyPenalty/DRY enabled the penalty
+// window starts EMPTY at the first output token, so nothing discourages the
+// model from re-deriving or restating text that is already in the transcript —
+// and on a fresh turn it has no memory at all of what it said in the previous
+// turn. Combined with the doubled accept above, the window that does build up
+// is half the configured length.
+//
+// FIX: after building s.sampler in startSlot, accept the full generation-ready
+// token sequence (job.actualTokens, or the cached prefix plus job.tailTokens)
+// into the chain, mirroring init_sampler().
+func TestPromptTokensArePrimedIntoTheSamplerChain(t *testing.T) {
+	fset, files := parseModelPackage(t)
+
+	// enclosing function name -> "file:line" of each llama.SamplerAccept call
+	// made on a slot's request sampler (s.sampler).
+	sites := make(map[string][]string)
+
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok || !isLlamaCall(call, "SamplerAccept") || len(call.Args) == 0 {
+					return true
+				}
+
+				sel, ok := call.Args[0].(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "sampler" {
+					return true
+				}
+
+				sites[fd.Name.Name] = append(sites[fd.Name.Name], posOf(fset, call))
+
+				return true
+			})
+		}
+	}
+
+	if len(sites) == 0 {
+		t.Fatal("no llama.SamplerAccept(x.sampler, ...) call found at all; " +
+			"this assertion has drifted from the source")
+	}
+
+	// A prompt-priming site must exist somewhere on the slot-start / prefill
+	// path, before the first token is generated.
+	priming := []string{"startSlot", "startSlotText", "primeSampler", "addPrefillChunk", "toSampler"}
+
+	for _, name := range priming {
+		if _, ok := sites[name]; ok {
+			return
+		}
+	}
+
+	var found []string
+	for name, at := range sites {
+		found = append(found, name+" ("+strings.Join(at, ", ")+")")
+	}
+
+	t.Errorf("no prompt-token priming of the request sampler chain; llama.SamplerAccept(*.sampler, ...) only appears in: %s\n"+
+		"llama.cpp primes the chain with every prompt token in server_slot::init_sampler "+
+		"(.extras/llama.cpp/tools/server/server-context.cpp:375-397) so the penalties and "+
+		"DRY windows cover prompt+generation. Kronk only accepts tokens it generated itself "+
+		"(sdk/kronk/model/batchgen_tokens.go:63), so in a multi-turn conversation the entire "+
+		"transcript is invisible to the repetition machinery.",
+		strings.Join(found, "; "))
+}
+
+// -----------------------------------------------------------------------------
+// Finding 2: a slot released mid-batch-assembly leaves its rows in the pending
+// batch, and fillSlots can hand the same KV sequence to a new request before
+// the decode runs.
+
+// mirrorBatchRow is one row of the shared llama_batch: token, position, and the
+// single sequence id batch.Add writes (sdk/kronk/model/batchgen_prefill_text.go:63,
+// via slot.seqIDs, sdk/kronk/model/batchgen_engine.go:54). `req` is test-only
+// bookkeeping identifying which request produced the row.
+type mirrorBatchRow struct {
+	pos int
+	seq int
+	req string
+}
+
+// mirrorGenSlot mirrors the subset of `slot` the batch-assembly ordering
+// touches (sdk/kronk/model/batchgen_slot.go:84-298).
+type mirrorGenSlot struct {
+	seq        int
+	active     bool
+	req        string
+	nPast      int
+	prefill    int // len(s.prefillTokens)
+	nPrefilled int
+	cancelled  bool // s.job.ctx.Err() != nil
+}
+
+// mirrorAssembleBatch is a VERBATIM MIRROR of the batch-assembly ordering in
+// (*batchEngine).processBatch, for a text-only, non-speculative, non-media
+// configuration (e.model.draft == nil, no M-RoPE slots):
+//
+//	sdk/kronk/model/batchgen_engine.go:201       e.batch.Clear()
+//	sdk/kronk/model/batchgen_engine.go:366-396   round-robin prefill loop
+//	sdk/kronk/model/batchgen_engine.go:373-376     cancel check -> e.finishSlot(s, ...)
+//	sdk/kronk/model/batchgen_prefill_text.go:60-66 add chunk rows, s.nPast++
+//	sdk/kronk/model/batchgen_engine.go:418       e.fillSlots(buf)
+//	sdk/kronk/model/batchgen_schedule.go:51-58     first inactive slot wins
+//	sdk/kronk/model/batchgen_slot_start.go:493-498 clear the seq, s.nPast = cacheIdx
+//	sdk/kronk/model/batchgen_slot_start.go:945-949 addPrefillChunk for the new job
+//	sdk/kronk/model/batchgen_engine.go:458       llama.Decode(e.model.lctx, e.batch)
+//
+// finishSlot's KV teardown is sdk/kronk/model/batchgen_finish.go:176-182
+// (MemorySeqRm(seqID, -1, -1)) followed by s.reset()
+// (sdk/kronk/model/batchgen_slot.go:300-321, which clears nPast and active).
+// Neither touches e.batch.
+//
+// MAINTAINER: when processBatch is fixed, update this mirror in the same commit.
+func mirrorAssembleBatch(slots []*mirrorGenSlot, chunkLimit int, nBatch int, pending []string, cancelAfterPass int) []mirrorBatchRow {
+	var batch []mirrorBatchRow
+
+	// batchgen_prefill_text.go:14-86.
+	addPrefillChunk := func(s *mirrorGenSlot) {
+		if s.prefill == 0 || s.nPrefilled >= s.prefill {
+			return
+		}
+
+		available := nBatch - len(batch)
+		if available <= 0 {
+			return
+		}
+
+		chunk := min(s.prefill-s.nPrefilled, available, chunkLimit)
+		for range chunk {
+			batch = append(batch, mirrorBatchRow{pos: s.nPast, seq: s.seq, req: s.req})
+			s.nPast++
+		}
+		s.nPrefilled += chunk
+	}
+
+	// batchgen_finish.go:176-182 + batchgen_slot.go:300-321. The already-added
+	// rows in `batch` are deliberately left untouched: that is the bug.
+	finishSlot := func(s *mirrorGenSlot) {
+		s.active = false
+		s.nPast = 0
+		s.prefill = 0
+		s.nPrefilled = 0
+		s.req = ""
+	}
+
+	// batchgen_engine.go:366-396.
+	pass := 0
+	for {
+		before := len(batch)
+		pass++
+
+		for _, s := range slots {
+			if !s.active || s.prefill == 0 {
+				continue
+			}
+
+			// batchgen_engine.go:373-377.
+			if s.cancelled && pass > cancelAfterPass {
+				finishSlot(s)
+				continue
+			}
+
+			addPrefillChunk(s)
+		}
+
+		if len(batch) == before {
+			break
+		}
+	}
+
+	// batchgen_engine.go:418 -> batchgen_schedule.go:43-63.
+	for _, job := range pending {
+		for _, s := range slots {
+			if s.active {
+				continue
+			}
+
+			// batchgen_slot_start.go:493-498: clear the seq, nPast = cacheIdx
+			// (0 for a non-IMC request), then add the first chunk (:945-949).
+			s.active = true
+			s.req = job
+			s.nPast = 0
+			s.prefill = chunkLimit
+			s.nPrefilled = 0
+			s.cancelled = false
+			addPrefillChunk(s)
+
+			break
+		}
+	}
+
+	return batch
+}
+
+// TestReleasedSlotRowsAreRemovedFromPendingBatch pins the cross-request KV
+// contamination window in the plain decode path.
+//
+// FINDING
+// (*batchEngine).processBatch assembles the shared batch, releases slots in the
+// middle of that assembly, and then calls fillSlots — which can immediately
+// re-assign the released slot (and therefore its KV sequence id) to a queued
+// request — all BEFORE the single llama.Decode. The released request's rows are
+// never removed from e.batch, so one llama_decode writes two different
+// requests' tokens into the same KV sequence.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_engine.go:373-383  finishSlot inside the
+//     round-robin prefill loop, after earlier passes already pushed rows for
+//     that slot's seqID into e.batch (batchgen_prefill_text.go:63).
+//   - sdk/kronk/model/batchgen_finish.go:176-182  clears the KV sequence but
+//     leaves e.batch alone; s.reset() (batchgen_slot.go:300-321) drops nPast.
+//   - sdk/kronk/model/batchgen_engine.go:418      fillSlots runs BEFORE the
+//     decode and takes the first inactive slot (batchgen_schedule.go:51-58).
+//   - sdk/kronk/model/batchgen_engine.go:458      the decode that commits both
+//     requests' rows to the same sequence.
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+//   - .extras/llama.cpp/tools/server/server-queue.cpp:139-163
+//     start_loop() drains every queued task (which is where
+//     launch_slot_with_task assigns slots) and only THEN calls
+//     callback_update_slots(); the comment on :159 is literally "all tasks in
+//     the current loop is processed, slots data is now ready". Slot assignment
+//     can therefore never interleave with batch assembly.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:137 and :161
+//     update_slots() starts from common_batch_clear(batch) and only adds rows
+//     for slots that are processing at that moment.
+//
+// FAILURE SCENARIO
+// A client cancels (or disconnects) while a long prompt is being prefilled in
+// round-robin chunks — NUBatch tokens per pass, so an NBatch-sized tray needs
+// several passes and the ctx.Err() check at batchgen_engine.go:374 is evaluated
+// between them. Pass 1 pushes rows for seq N; the cancel lands; pass 2 releases
+// the slot and clears seq N; fillSlots assigns a queued request to the same slot
+// and pushes ITS rows for seq N; the decode commits both. The new request's
+// sequence now contains cells from a different conversation at positions beyond
+// its own prompt, and the model attends to them — which is exactly the
+// "asserts something then contradicts what it already said" symptom. On an IMC
+// hit the restored prefix is polluted the same way, because the restore also
+// runs inside startSlot, before the decode.
+//
+// FIX: either compact the released slot's rows out of e.batch in finishSlot, or
+// move fillSlots after the decode so a freed sequence can never be reused
+// within the same batch.
+func TestReleasedSlotRowsAreRemovedFromPendingBatch(t *testing.T) {
+	const (
+		chunkLimit = 4  // e.model.cfg.NUBatch(), batchgen_engine.go:352
+		nBatch     = 64 // e.model.cfg.NBatch()
+	)
+
+	slots := []*mirrorGenSlot{
+		{seq: 0, active: true, req: "reqA", prefill: 3 * chunkLimit, cancelled: true},
+	}
+
+	rows := mirrorAssembleBatch(slots, chunkLimit, nBatch, []string{"reqB"}, 1)
+
+	if len(rows) == 0 {
+		t.Fatal("mirror produced an empty batch; the assertion has drifted")
+	}
+
+	// Invariant: one llama_decode must never carry rows for the same KV
+	// sequence on behalf of two different requests.
+	perSeq := make(map[int]map[string][]int)
+	for _, r := range rows {
+		if perSeq[r.seq] == nil {
+			perSeq[r.seq] = make(map[string][]int)
+		}
+		perSeq[r.seq][r.req] = append(perSeq[r.seq][r.req], r.pos)
+	}
+
+	for seq, byReq := range perSeq {
+		if len(byReq) <= 1 {
+			continue
+		}
+
+		var detail []string
+		for req, positions := range byReq {
+			detail = append(detail, req+" at positions "+fmtInts(positions))
+		}
+		slices.Sort(detail)
+
+		t.Errorf("KV sequence %d carries rows for %d different requests in one llama.Decode: %s\n"+
+			"batchgen_engine.go:373-383 releases a slot mid-assembly, batchgen_finish.go:176-182 "+
+			"clears its KV sequence without removing its rows from e.batch, and "+
+			"batchgen_engine.go:418 (fillSlots) hands the same slot/seqID to a queued request "+
+			"before the decode at batchgen_engine.go:458. llama.cpp cannot do this: "+
+			"server-queue.cpp:139-163 assigns every slot before update_slots() builds the batch.",
+			seq, len(byReq), strings.Join(detail, "; "))
+	}
+}
+
+// fmtInts renders a position list without pulling fmt into the hot assertion.
+func fmtInts(xs []int) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, x := range xs {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(itoa(x))
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+func itoa(x int) string {
+	if x == 0 {
+		return "0"
+	}
+
+	neg := x < 0
+	if neg {
+		x = -x
+	}
+
+	var buf [20]byte
+	i := len(buf)
+	for x > 0 {
+		i--
+		buf[i] = byte('0' + x%10)
+		x /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+
+	return string(buf[i:])
+}
+
+// -----------------------------------------------------------------------------
+// Finding 3: the token that reaches MaxTokens has its text thrown away.
+
+// mirrorEmitTokenTail is a VERBATIM MIRROR of the tail of
+// (*batchEngine).handleSampledToken, from the token counter to the content
+// store:
+//
+//	sdk/kronk/model/batchgen_tokens.go:188-193   count the token
+//	sdk/kronk/model/batchgen_tokens.go:205       outputTokens := s.reasonTokens + s.completionTokens
+//	sdk/kronk/model/batchgen_tokens.go:207-210   if outputTokens >= MaxTokens { e.finishSlot(s, nil); return }
+//	sdk/kronk/model/batchgen_tokens.go:213-222   store content in the final accumulator
+//	sdk/kronk/model/batchgen_tokens.go:233       stream the delta
+//
+// The same ordering appears in the partial-UTF-8 branch at
+// sdk/kronk/model/batchgen_tokens.go:135-155, which returns before the parser
+// ever sees the bytes.
+//
+// Returns true when the slot was finished by this token.
+//
+// MAINTAINER: when batchgen_tokens.go:205-222 is reordered, update this mirror
+// in the same commit.
+func mirrorEmitTokenTail(completionTokens *int, maxTokens int, content string, final *strings.Builder) bool {
+	*completionTokens++ // batchgen_tokens.go:192
+
+	outputTokens := *completionTokens // batchgen_tokens.go:205
+
+	if outputTokens >= maxTokens { // batchgen_tokens.go:207
+		return true // e.finishSlot(s, nil); return
+	}
+
+	final.WriteString(content) // batchgen_tokens.go:221
+
+	return false
+}
+
+// TestMaxTokensKeepsTheLimitReachingTokensText pins the one-token content loss
+// at the max-tokens boundary on the plain path.
+//
+// FINDING
+// handleSampledToken counts the token, then compares the running total against
+// Params.MaxTokens and calls finishSlot BEFORE the token's text is written to
+// finalContent/finalReasoning/finalTooling and before the streaming delta is
+// sent. The token that trips the limit is counted in Usage but its text is
+// never delivered to the caller by either transport.
+//
+// PRODUCTION LINE PINNED: sdk/kronk/model/batchgen_tokens.go:205-210 (and the
+// identical partial-UTF-8 variant at :146-151).
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/tools/server/server-context.cpp:1895-1899 —
+// process_token() does slot.add_token(result) and send_partial_response() for
+// the token FIRST, and only afterwards, at :1913-1918, evaluates
+// `!slot.has_budget(params_base)` and sets STOP_TYPE_LIMIT. The limit-reaching
+// token's text is always part of the response.
+//
+// FAILURE SCENARIO
+// A request capped at N tokens returns the text of tokens 1..N-1 while
+// reporting OutputTokens = N. Since Params.MaxTokens defaults to the whole
+// context window, in practice this bites callers who set an explicit cap: the
+// answer is silently truncated one token earlier than requested, and for a
+// single-token final piece (a closing brace, a digit) the visible output is
+// wrong rather than merely short.
+//
+// FIX: store and stream the content, then evaluate the budget — i.e. move the
+// MaxTokens check below batchgen_tokens.go:238.
+func TestMaxTokensKeepsTheLimitReachingTokensText(t *testing.T) {
+	const maxTokens = 3
+
+	pieces := []string{"alpha", "beta", "gamma"}
+
+	var final strings.Builder
+	completionTokens := 0
+	emitted := 0
+
+	for _, piece := range pieces {
+		if mirrorEmitTokenTail(&completionTokens, maxTokens, piece, &final) {
+			break
+		}
+		emitted++
+	}
+
+	want := strings.Join(pieces, "")
+
+	if got := final.String(); got != want {
+		t.Errorf("content after generating %d tokens with MaxTokens=%d = %q, want %q (%d of %d token texts delivered)\n"+
+			"batchgen_tokens.go:207-210 evaluates `outputTokens >= s.job.params.MaxTokens` "+
+			"and calls finishSlot BEFORE the content store at :213-222 and the delta at :233, "+
+			"so the token that reaches the limit is counted in Usage but its text is dropped "+
+			"from both the streamed deltas and the final response.\n"+
+			"llama.cpp emits the token first (server-context.cpp:1895-1899) and only then "+
+			"applies the budget check (server-context.cpp:1913-1918).",
+			completionTokens, maxTokens, got, want, emitted, len(pieces))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Finding 4: nothing drains the parser state machine at end of generation.
+
+// TestGenerationEndDrainsParserHeldBackContent pins the missing
+// end-of-generation flush for content the parser state machine is holding.
+//
+// FINDING
+// handleSampledToken routes every token's text through
+// s.stateMachine.Classify (sdk/kronk/model/batchgen_tokens.go:158). Parser
+// state machines legitimately withhold text across tokens while they wait for a
+// closing marker — e.g. sdk/kronk/parsers/standard/state_machine.go:51-55
+// buffers tool-call bytes into toolCallBuf until "</tool_call>" arrives, and
+// sdk/kronk/parsers/qwen/state_machine.go:88-89 plus its pendingTagBuf
+// lookahead (:47-68) do the same for Qwen, the lineage the reported failures
+// were seen on.
+//
+// The model.StateMachine contract (sdk/kronk/model/parser.go:73-80) exposes only
+// Classify and Reset. finishSlot flushes s.utf8Buf
+// (sdk/kronk/model/batchgen_finish.go:261-278) but never asks the state machine
+// for what it is still holding, and the deferred s.reset()
+// (sdk/kronk/model/batchgen_finish.go:62 -> batchgen_slot.go:379-381) calls
+// stateMachine.Reset(), which discards it.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/parser.go:73-80        StateMachine has no drain/flush
+//   - sdk/kronk/model/batchgen_finish.go:261-278  only utf8Buf is flushed
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/tools/server/server-context.cpp:1868-1898 —
+// slot.generated_text is the single source of truth. Text withheld from the
+// stream by find_partial_stop_string is not deleted; it stays in
+// generated_text, and send_final_response ships whatever is left. Nothing the
+// model produced can be lost by a stop-sequence lookahead that never resolves.
+//
+// FAILURE SCENARIO
+// The model emits "<tool_call>" and the JSON body, then hits EOG or MaxTokens
+// before "</tool_call>" (a routine outcome once a reasoning model has burned
+// its budget). s.toolFlag > 0, so finishSlot takes the tool-call branch
+// (sdk/kronk/model/batchgen_finish.go:282) — over an EMPTY s.finalTooling,
+// because every buffered byte is still inside the state machine. The caller
+// gets no tool call, no content, and no error: the task is started and then
+// silently dropped. The Qwen pendingTagBuf path loses the trailing "<" the same
+// way.
+//
+// FIX: add a drain step to the StateMachine contract (returning the held-back
+// content and its channel) and call it from finishSlot before s.reset(), or
+// mirror llama.cpp and keep the raw generated text on the slot as the
+// authority.
+func TestGenerationEndDrainsParserHeldBackContent(t *testing.T) {
+	// (a) Does the contract let the engine ask for held-back content?
+	iface := reflect.TypeOf((*StateMachine)(nil)).Elem()
+
+	var methods []string
+	drainable := false
+	for i := range iface.NumMethod() {
+		name := iface.Method(i).Name
+		methods = append(methods, name)
+
+		switch name {
+		case "Drain", "Flush", "Finish", "Pending", "Remaining", "Close":
+			drainable = true
+		}
+	}
+
+	// (b) Or does finishSlot reach into the state machine itself?
+	fset, files := parseModelPackage(t)
+
+	finishSlotReadsStateMachine := false
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil || fd.Name.Name != "finishSlot" {
+				continue
+			}
+
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if ok && sel.Sel.Name == "stateMachine" {
+					finishSlotReadsStateMachine = true
+					t.Logf("finishSlot touches stateMachine at %s", posOf(fset, sel))
+				}
+
+				return true
+			})
+		}
+	}
+
+	if drainable || finishSlotReadsStateMachine {
+		return
+	}
+
+	t.Errorf("nothing drains the parser state machine at end of generation: StateMachine exposes only %s and finishSlot never touches s.stateMachine\n"+
+		"Parser state machines withhold text across tokens while they wait for a closing "+
+		"marker (sdk/kronk/parsers/standard/state_machine.go:51-55, "+
+		"sdk/kronk/parsers/qwen/state_machine.go:47-68 and :88-89). finishSlot flushes only "+
+		"s.utf8Buf (sdk/kronk/model/batchgen_finish.go:261-278) and its deferred s.reset() "+
+		"calls stateMachine.Reset() (sdk/kronk/model/batchgen_slot.go:379-381), so an "+
+		"unterminated <tool_call> at EOG or MaxTokens is discarded whole: the tool-call "+
+		"branch at batchgen_finish.go:282 runs over an empty s.finalTooling and the caller "+
+		"gets an empty response with no error.\n"+
+		"llama.cpp cannot lose it — slot.generated_text keeps every byte and "+
+		"send_final_response ships the remainder (.extras/llama.cpp/tools/server/"+
+		"server-context.cpp:1868-1898).",
+		strings.Join(methods, ", "))
+}
+
+// -----------------------------------------------------------------------------
+// Finding 5: the M-RoPE generation step applies grammar during reasoning but
+// never accepts it.
+
+// TestMRoPEGenerationGrammarIsGatedOnReasonFlag pins the grammar-gating
+// asymmetry on the plain M-RoPE generation step.
+//
+// FINDING
+// Kronk applies grammar constraints only outside the reasoning phase, because
+// masking thinking tokens "would corrupt the thinking tokens and prevent the
+// model from closing the think block"
+// (sdk/kronk/model/batchgen_tokens.go:15-18). Two of the three plain-path
+// sampling sites honour that:
+//
+//	sdk/kronk/model/batchgen_tokens.go:21   case s.grammarSampler != nil && s.reasonFlag == 0:
+//	sdk/kronk/model/batchgen_tokens.go:261  case s.grammarSampler != nil && s.reasonFlag == 0:
+//
+// and the matching grammar Accept is gated identically at
+// sdk/kronk/model/batchgen_tokens.go:59. The M-RoPE generation step is not:
+//
+//	sdk/kronk/model/batchgen_engine.go:256  case s.grammarSampler != nil:
+//
+// PRODUCTION LINE PINNED: sdk/kronk/model/batchgen_engine.go:255-260, inside
+// the `if s.useMRoPE` generation branch of processBatch.
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/common/sampling.cpp:630-643 — common_sampler_sample applies
+// the grammar only when grammar_should_apply(gsmpl) is true, and
+// common_sampler_accept advances the grammar under the SAME predicate. Apply and
+// accept are never allowed to disagree about whether the grammar is live.
+//
+// FAILURE SCENARIO
+// A vision/M-RoPE request with a JSON schema on a reasoning model: every
+// reasoning token is sampled from grammar-masked logits (grammar.go:419-425
+// writes the -inf mask straight back into the context's logit row), so the
+// thinking text degenerates into schema-shaped fragments and the model may
+// never be able to emit "</think>" — it starts the task and never finishes it.
+// Meanwhile batchgen_tokens.go:59 skips the Accept, so the grammar stack never
+// advances: once reasoning ends, the answer is constrained from a stale root
+// state that does not match the tokens already sampled.
+//
+// FIX: add `&& s.reasonFlag == 0` at batchgen_engine.go:256 so the M-RoPE
+// generation step matches processSlotToken and sampleFirstToken.
+func TestMRoPEGenerationGrammarIsGatedOnReasonFlag(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := root + "/sdk/kronk/model/batchgen_engine.go"
+
+	fset := token.NewFileSet()
+	f := parseKronkSource(t, fset, path)
+	fd := findKronkFunc(t, f, path, "processBatch")
+
+	mentions := func(n ast.Node, name string) bool {
+		found := false
+		ast.Inspect(n, func(x ast.Node) bool {
+			if id, ok := x.(*ast.Ident); ok && id.Name == name {
+				found = true
+			}
+			return true
+		})
+
+		return found
+	}
+
+	checked := 0
+
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok || ifStmt.Cond == nil || !mentions(ifStmt.Cond, "useMRoPE") {
+			return true
+		}
+
+		ast.Inspect(ifStmt.Body, func(x ast.Node) bool {
+			clause, ok := x.(*ast.CaseClause)
+			if !ok || len(clause.List) == 0 {
+				return true
+			}
+
+			for _, cond := range clause.List {
+				if !mentions(cond, "grammarSampler") {
+					continue
+				}
+
+				checked++
+
+				if !mentions(cond, "reasonFlag") {
+					t.Errorf("%s: M-RoPE generation grammar case does not test s.reasonFlag\n"+
+						"batchgen_tokens.go:21 and :261 both use `s.grammarSampler != nil && s.reasonFlag == 0`, "+
+						"and the grammar Accept at batchgen_tokens.go:59 is gated the same way. This site "+
+						"applies the grammar mask to reasoning tokens and then never accepts them, so the "+
+						"grammar stack desynchronises from the sampled tokens.\n"+
+						"llama.cpp keeps apply and accept under one predicate "+
+						"(grammar_should_apply, .extras/llama.cpp/common/sampling.cpp:630-643).",
+						posOf(fset, cond))
+				}
+			}
+
+			return true
+		})
+
+		return true
+	})
+
+	if checked == 0 {
+		t.Fatalf("%s: no grammarSampler case found inside the `if s.useMRoPE` generation "+
+			"branch of processBatch; this assertion has drifted from the source", path)
+	}
+}

--- a/sdk/kronk/model/prompt_tokenize_special_test.go
+++ b/sdk/kronk/model/prompt_tokenize_special_test.go
@@ -1,0 +1,664 @@
+package model
+
+import (
+	"context"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ardanlabs/kronk/sdk/kronk/applog"
+)
+
+// =============================================================================
+// Prompt assembly / tokenization audit for Qwen3.6-35B-A3B-MTP.
+//
+// Everything in this file is anchored on the real target GGUF:
+//
+//	/Users/florin/.kronk/models/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/
+//	    mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf
+//
+// Facts read straight out of its metadata (GGUF v3, 55 KV entries):
+//
+//	tokenizer.ggml.model          = "gpt2"          -> LLAMA_VOCAB_TYPE_BPE
+//	tokenizer.ggml.pre            = "qwen35"
+//	tokenizer.ggml.add_bos_token  = false           (GGUF_TYPE_BOOL)
+//	tokenizer.ggml.add_eos_token  = <absent>
+//	tokenizer.ggml.bos_token_id   = 248044          "<|endoftext|>"
+//	tokenizer.ggml.eos_token_id   = 248046          "<|im_end|>"
+//	token 248045 "<|im_start|>"   token_type 3      (CONTROL)
+//	token 248046 "<|im_end|>"     token_type 3      (CONTROL)
+//	token 248068 "<think>"        token_type 4      (USER_DEFINED)
+//	token 248069 "</think>"       token_type 4      (USER_DEFINED)
+//	token 248058 "<tool_call>"    token_type 4      (USER_DEFINED)
+//
+// Two of the five audit questions came back clean and are recorded here so
+// nobody re-opens them:
+//
+//   - BOS duplication: add_bos_token=false in the GGUF, so
+//     model.go:299-302 resolves addBOSToken=false and llama.cpp's
+//     llama_vocab::add_bos is false too (llama-vocab.cpp:1813 default, the
+//     LLAMA_VOCAB_TYPE_BPE branch never assigns it, and the GGUF override at
+//     llama-vocab.cpp:2547-2556 sets it to false). No BOS is prepended by
+//     either implementation and the ChatML template emits no bos_token, so
+//     there is no double BOS on this model. Continuation prefills are also
+//     safe: batchgen_slot_start.go:794 gates addBOS on cacheIdx==0, and the
+//     IMC token-plan tail (caching_imc_tokens.go:24-26) is carved out of a
+//     single tokenization of the complete render.
+//
+//   - parse_special: every production tokenize call site passes
+//     parseSpecial=true (prompt_plan.go:38, chat.go:306-307, tokenize.go:55,
+//     batchgen_slot_start.go:813 and :992), which matches what llama.cpp's
+//     server passes for a templated chat prompt —
+//     server-context.cpp:4132 and :2273 both call
+//     tokenize_input_prompts(vocab, mctx, prompt, /*add_special*/ true,
+//     /*parse_special*/ true). <|im_start|>/<|im_end|> therefore land as
+//     CONTROL tokens 248045/248046 rather than literal text.
+//
+// What follows are the divergences that did NOT come back clean.
+// =============================================================================
+
+// qwen36GGUFChatTemplate is the VERBATIM tokenizer.chat_template value embedded
+// in mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf (8057 bytes,
+// sha256 55d4931433fe502b794226ee7f4d206a6bdd436ac9f80eb7d8ebb4c639f9ea0c).
+//
+// This is the template Kronk actually runs for this model: retrieveTemplate
+// (model.go:1032) only reaches the GGUF fallback at model.go:1053 because
+// cfg.JinjaFile is unset for the catalog entry and no
+// <base>/jinja/Qwen3.6-35B-A3B*.jinja override exists.
+//
+// It is embedded rather than read from disk because the model file is not part
+// of the repository and .extras/ is gitignored.
+const qwen36GGUFChatTemplate = `{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set num_sys = 0 %}
+{%- set merged_system = '' %}
+{%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+    {%- set first = render_content(messages[0].content, false, true)|trim %}
+    {%- if messages|length > 1 and (messages[1].role == 'system' or messages[1].role == 'developer') %}
+        {%- set second = render_content(messages[1].content, false, true)|trim %}
+        {%- set merged_system = first + '\n' + second %}
+        {%- set num_sys = 2 %}
+    {%- else %}
+        {%- set merged_system = first %}
+        {%- set num_sys = 1 %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if merged_system %}
+        {{- '\n\n' + merged_system }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if merged_system %}
+        {{- '<|im_start|>system\n' + merged_system + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if loop.index0 >= num_sys and message.role != "system" and message.role != "developer" %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is mapping %}
+                    {%- for args_name in tool_call.arguments %}
+                        {%- set args_value = tool_call.arguments[args_name] %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+{#- Unsloth fixes - developer role, tool calling #}`
+
+// -----------------------------------------------------------------------------
+// Verbatim mirror of the Qwen reasoning normalizer.
+//
+// prompts.go:178 type-asserts m.parser to ReasoningNormalizer and calls
+// StripEmptyReasoning on the fully rendered prompt. The real implementation for
+// this model is sdk/kronk/parsers/qwen/reasoning.go:20 delegating to
+// sdk/kronk/parsers/standard/reasoning.go:34 -> :43. Those packages import
+// sdk/kronk/model, so a test inside package model cannot import them without an
+// import cycle. The two regexes and StripExceptTrailing below are copied
+// verbatim from:
+//
+//	sdk/kronk/parsers/standard/reasoning.go:15  closedThink
+//	sdk/kronk/parsers/standard/reasoning.go:18  emptyThink
+//	sdk/kronk/parsers/standard/reasoning.go:24  StripThinkContent
+//	sdk/kronk/parsers/standard/reasoning.go:43  StripExceptTrailing
+//
+// MAINTAINER: if standard/reasoning.go changes, update this mirror in the same
+// commit so the pin keeps tracking production behaviour.
+// -----------------------------------------------------------------------------
+
+var (
+	mirrorClosedThink = regexp.MustCompile(`(?s)<think>.*?</think>`)
+	mirrorEmptyThink  = regexp.MustCompile(`(?s)<think>\s*</think>`)
+)
+
+// qwenThinkNormalizer is the Parser + ReasoningNormalizer pair Kronk selects for
+// this model (parser "qwen").
+type qwenThinkNormalizer struct{}
+
+func (qwenThinkNormalizer) Name() string                  { return "qwen" }
+func (qwenThinkNormalizer) NewStateMachine() StateMachine { return nil }
+func (qwenThinkNormalizer) ToolCall(_ context.Context, _ applog.Logger, _ string) []ResponseToolCall {
+	return nil
+}
+
+func (qwenThinkNormalizer) StripReasoningContent(content string) string {
+	if !strings.Contains(content, "<think>") {
+		return content
+	}
+	return mirrorClosedThink.ReplaceAllString(content, "")
+}
+
+func (qwenThinkNormalizer) StripEmptyReasoning(rendered string) string {
+	locs := mirrorEmptyThink.FindAllStringIndex(rendered, -1)
+	if len(locs) == 0 {
+		return rendered
+	}
+
+	var b strings.Builder
+	prev := 0
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+		if strings.TrimSpace(rendered[end:]) == "" {
+			continue
+		}
+		b.WriteString(rendered[prev:start])
+		prev = end
+	}
+	b.WriteString(rendered[prev:])
+
+	return b.String()
+}
+
+// newQwen36PromptModel builds the minimum *Model that Model.applyJinjaTemplate
+// (prompts.go:111) touches: the compiled template, the parser, the logger and
+// cfg.IncrementalCache (read by stripReasoning at reasoning.go:37).
+//
+// applyJinjaTemplate only reaches m.vocab when bos_token / eos_token are absent
+// from the render context (prompts.go:155-164), so every case below supplies
+// both and no llama vocab handle is required.
+func newQwen36PromptModel(imc bool) *Model {
+	return &Model{
+		cfg:      Config{PtrIncrementalCache: &imc},
+		log:      noopLog,
+		template: Template{FileName: "tokenizer.chat_template", Script: qwen36GGUFChatTemplate},
+		parser:   qwenThinkNormalizer{},
+	}
+}
+
+// renderQwen36Prompt renders msgs through the real production entry point,
+// Model.applyJinjaTemplate (prompts.go:111) — the same call
+// Model.createPrompt -> applyRequestJinjaTemplate makes for a text-only model
+// (prompts.go:23).
+func renderQwen36Prompt(t *testing.T, imc bool, msgs []D, extra D) string {
+	t.Helper()
+
+	d := D{
+		"messages": msgs,
+		// Supplied by parseParams (params.go:675) on every real request.
+		"enable_thinking": true,
+		// llama.cpp seeds these from the vocab in
+		// common_chat_template_direct_apply_impl (chat.cpp:897-898). This
+		// template never reads them; they are here only to keep
+		// applyJinjaTemplate away from m.vocab.
+		"bos_token": "<|endoftext|>",
+		"eos_token": "<|im_end|>",
+	}
+	for k, v := range extra {
+		d[k] = v
+	}
+
+	got, err := newQwen36PromptModel(imc).applyJinjaTemplate(context.Background(), d)
+	if err != nil {
+		t.Fatalf("applyJinjaTemplate: %v", err)
+	}
+
+	return got
+}
+
+// TestQwen36PostRenderReasoningStripBreaksAssistantTurns pins the post-render
+// reasoning strip that Kronk runs over the finished prompt.
+//
+// FINDING
+// Kronk mutates the rendered chat prompt after the template has produced it.
+// prompts.go:177-181 calls ReasoningNormalizer.StripEmptyReasoning on the whole
+// string, which deletes every empty "<think>...</think>" span except a trailing
+// one (sdk/kronk/parsers/standard/reasoning.go:34 -> :43). The Qwen3.6 template
+// emits that span as an inseparable unit with its own trailing blank line —
+// template line 104 writes
+//
+//	'<|im_start|>' + role + '\n<think>\n' + reasoning + '\n</think>\n\n' + content
+//
+// so removing only the "<think>...</think>" bytes leaves the "\n\n" behind and
+// the assistant turn header becomes "<|im_start|>assistant\n\n\n". That is a
+// role header the model never saw in training: Qwen3.6 assistant turns open
+// either with "<|im_start|>assistant\n<think>...</think>\n\n" or with
+// "<|im_start|>assistant\n" and nothing else. The reasoning-channel delimiters
+// that told the model which of its own earlier bytes were thinking versus answer
+// are gone at the same time.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/prompts.go:177-181   (the post-render pass)
+//   - sdk/kronk/model/prompts.go:147-149   (preserve_thinking forced to false)
+//   - sdk/kronk/parsers/standard/reasoning.go:34,43 (the strip itself)
+//
+// LLAMA.CPP REFERENCE
+// .extras/llama.cpp/common/chat.cpp:926-940. llama.cpp renders the template and
+// performs exactly one post-render edit — trimming a leading BOS / trailing EOS
+// when the tokenizer is going to add them (chat.cpp:934-939). It never rewrites
+// reasoning markup in the prompt. tools/server/server-context.cpp:4132 then
+// tokenizes that string as-is with add_special=true, parse_special=true.
+//
+// FAILURE SCENARIO
+// The strip only fires when template line 103's
+// "loop.index0 > ns.last_query_index" is true, i.e. on assistant turns that sit
+// AFTER the last real user query. That is precisely the agentic tool-calling
+// loop the user is running: system, user, assistant(tool_call), tool,
+// assistant(tool_call), tool, ... Every assistant turn already in the history
+// arrives at the model as "<|im_start|>assistant\n\n\n<tool_call>" instead of
+// "<|im_start|>assistant\n<think>\n\n</think>\n\n<tool_call>". The damage
+// accumulates with conversation length and shows up as the model losing track of
+// what it previously concluded — asserting something and then contradicting it —
+// which is exactly the reported symptom and is invisible to a smoke test that
+// only greps the answer for a keyword.
+//
+// The pass is gated on cfg.IncrementalCache() (reasoning.go:37), documented as
+// default-true in sdk/tools/defaults/yaml/model_config.yaml:20 and set to true
+// by sdk/kronk/tests/testlib/testlib.go:276. Each case re-renders with IMC off
+// to prove the template output itself is byte-correct and localize the corruption
+// to prompts.go:177-181.
+//
+// Expected values were produced by rendering the embedded GGUF template with
+// Jinja2 3.1.6 under trim_blocks=True, lstrip_blocks=True — the same lexer
+// options llama.cpp's own engine defaults to
+// (.extras/llama.cpp/common/jinja/lexer.cpp:115,118).
+func TestQwen36PostRenderReasoningStripBreaksAssistantTurns(t *testing.T) {
+	toolCalls := []D{
+		{"function": D{"name": "get_weather", "arguments": D{"city": "Paris"}}},
+	}
+
+	tests := []struct {
+		name  string
+		msgs  []D
+		extra D
+		want  string
+	}{
+		{
+			// Control: a plain multi-turn chat emits no empty reasoning span
+			// at all, so the strip is a no-op and Kronk matches llama.cpp
+			// byte for byte. This case passing is what makes the failures
+			// below attributable to the strip and not to the Jinja engine.
+			name: "control: plain 3-turn chat is byte-exact",
+			msgs: []D{
+				{"role": "system", "content": "You are helpful."},
+				{"role": "user", "content": "u1"},
+				{"role": "assistant", "content": "a1"},
+				{"role": "user", "content": "u2"},
+				{"role": "assistant", "content": "a2"},
+				{"role": "user", "content": "u3"},
+			},
+			want: "<|im_start|>system\nYou are helpful.<|im_end|>\n" +
+				"<|im_start|>user\nu1<|im_end|>\n" +
+				"<|im_start|>assistant\na1<|im_end|>\n" +
+				"<|im_start|>user\nu2<|im_end|>\n" +
+				"<|im_start|>assistant\na2<|im_end|>\n" +
+				"<|im_start|>user\nu3<|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n",
+		},
+		{
+			name: "agentic: assistant tool-call turn followed by a tool result",
+			msgs: []D{
+				{"role": "system", "content": "sys"},
+				{"role": "user", "content": "weather?"},
+				{"role": "assistant", "content": "", "tool_calls": toolCalls},
+				{"role": "tool", "content": "sunny"},
+			},
+			want: "<|im_start|>system\nsys<|im_end|>\n" +
+				"<|im_start|>user\nweather?<|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n\n</think>\n\n" +
+				"<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call><|im_end|>\n" +
+				"<|im_start|>user\n<tool_response>\nsunny\n</tool_response><|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n",
+		},
+		{
+			name: "agentic: assistant turn with prose and a tool call",
+			msgs: []D{
+				{"role": "system", "content": "sys"},
+				{"role": "user", "content": "weather?"},
+				{"role": "assistant", "content": "Let me check.", "tool_calls": toolCalls},
+				{"role": "tool", "content": "sunny"},
+			},
+			want: "<|im_start|>system\nsys<|im_end|>\n" +
+				"<|im_start|>user\nweather?<|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n\n</think>\n\nLet me check.\n\n" +
+				"<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call><|im_end|>\n" +
+				"<|im_start|>user\n<tool_response>\nsunny\n</tool_response><|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n",
+		},
+		{
+			// This is the render chat.go:298 asks for when IMC is on: the
+			// same messages with add_generation_prompt=false, used as the
+			// cacheable prefix. The corrupted assistant header therefore also
+			// ends up in the KV cache and is reused by every later turn.
+			name: "imc stable render of a trailing assistant turn",
+			msgs: []D{
+				{"role": "user", "content": "Hi"},
+				{"role": "assistant", "content": "Hello!"},
+			},
+			extra: D{"add_generation_prompt": false},
+			want: "<|im_start|>user\nHi<|im_end|>\n" +
+				"<|im_start|>assistant\n<think>\n\n</think>\n\nHello!<|im_end|>\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderQwen36Prompt(t, true, tt.msgs, tt.extra)
+			if got == tt.want {
+				return
+			}
+
+			unstripped := renderQwen36Prompt(t, false, tt.msgs, tt.extra)
+
+			t.Errorf("rendered prompt does not match the llama.cpp reference render\n"+
+				"got  (IncrementalCache on):  %q\n"+
+				"want (llama.cpp / Jinja2):   %q\n"+
+				"same render, IncrementalCache off: %q\n\n"+
+				"The template output is correct; prompts.go:177-181 rewrites it afterwards.\n"+
+				"StripEmptyReasoning (sdk/kronk/parsers/standard/reasoning.go:34,43) deletes the\n"+
+				"empty <think></think> span but not the '\\n\\n' the template emits as part of the\n"+
+				"same literal (template line 104), so the assistant header degrades to\n"+
+				"\"<|im_start|>assistant\\n\\n\\n\" and the reasoning-channel delimiters vanish.\n"+
+				"llama.cpp never edits the rendered prompt except to de-duplicate BOS/EOS\n"+
+				"(.extras/llama.cpp/common/chat.cpp:934-939) and tokenizes it verbatim\n"+
+				"(tools/server/server-context.cpp:4132).\n"+
+				"Fix: drop the post-render pass and let the template's own\n"+
+				"preserve_thinking / last_query_index logic decide, as llama.cpp does.",
+				got, tt.want, unstripped)
+		})
+	}
+}
+
+// TestQwen36PostRenderReasoningStripDeletesUserContent pins the same
+// post-render pass deleting bytes out of a USER message.
+//
+// FINDING
+// StripEmptyReasoning is applied to the entire rendered prompt
+// (prompts.go:179), not to assistant turns. Its regex
+// `(?s)<think>\s*</think>` (sdk/kronk/parsers/standard/reasoning.go:18) has no
+// idea which role block it is inside, so a user who writes an empty
+// "<think></think>" pair — asking about the markup, pasting a template, quoting
+// a transcript — has those bytes silently removed from the prompt the model
+// sees. Nothing in the request path escapes or protects user content before the
+// pass runs.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/prompts.go:177-181
+//   - sdk/kronk/parsers/standard/reasoning.go:18,43
+//
+// LLAMA.CPP REFERENCE
+// .extras/llama.cpp/common/chat.cpp:926-940 — the rendered prompt is handed to
+// the tokenizer unchanged apart from BOS/EOS de-duplication; user content is
+// never rewritten. The templated string is then tokenized with parse_special =
+// true (tools/server/server-context.cpp:4132), which is also what Kronk does,
+// so the control tokens are not the issue here — the deletion is.
+//
+// FAILURE SCENARIO
+// A coding agent asks "why is <think>\n</think> showing up in my output?" and
+// the model receives "why is  showing up in my output?". The question is
+// mutilated, the answer is nonsense, and no log records the edit.
+func TestQwen36PostRenderReasoningStripDeletesUserContent(t *testing.T) {
+	msgs := []D{
+		{"role": "user", "content": "explain <think>\n</think> markers"},
+	}
+
+	const want = "<|im_start|>user\nexplain <think>\n</think> markers<|im_end|>\n" +
+		"<|im_start|>assistant\n<think>\n"
+
+	got := renderQwen36Prompt(t, true, msgs, nil)
+	if got == want {
+		return
+	}
+
+	t.Errorf("user message content was rewritten by the post-render reasoning strip\n"+
+		"got:  %q\n"+
+		"want: %q\n"+
+		"same render, IncrementalCache off: %q\n\n"+
+		"prompts.go:179 runs StripEmptyReasoning over the WHOLE prompt, so the\n"+
+		"`(?s)<think>\\s*</think>` regex at sdk/kronk/parsers/standard/reasoning.go:18\n"+
+		"matches inside a user turn and deletes it. llama.cpp hands the rendered\n"+
+		"prompt to the tokenizer untouched (.extras/llama.cpp/common/chat.cpp:926-940).\n"+
+		"Fix: drop the post-render pass; if empty reasoning spans must be removed,\n"+
+		"do it on assistant message content before the render, where\n"+
+		"normalizeHistoryReasoning (reasoning.go:46) already operates.",
+		got, want, renderQwen36Prompt(t, false, msgs, nil))
+}
+
+// TestAddBOSTokenUsesTheVocabFlag pins Kronk's BOS decision being re-derived
+// from a GGUF metadata STRING instead of being read from the vocab.
+//
+// FINDING
+// NewModel decides whether to prepend BOS like this (model.go:297-302):
+//
+//	addBOSToken := true
+//	if v, ok := modelInfo.Metadata["tokenizer.ggml.add_bos_token"]; ok && v == "false" {
+//	    addBOSToken = false
+//	}
+//
+// That is a re-implementation of a decision llama.cpp already made and exposes,
+// and it differs from it in both directions:
+//
+//   - Key absent. Kronk defaults to true. llama.cpp's llama_vocab::add_bos
+//     starts false (llama-vocab.cpp:1813) and only the SPM and WPM branches
+//     raise it (llama-vocab.cpp:2374-2384); the LLAMA_VOCAB_TYPE_BPE branch
+//     never touches it. A gpt2/BPE GGUF that omits the key — which the Qwen and
+//     Llama families are — gets a spurious BOS at position 0 from Kronk and none
+//     from llama.cpp.
+//
+//   - Key present and false. Kronk always honours it. llama.cpp overrides it
+//     back to true for Gemma 4 (llama-vocab.cpp:2563-2568, "workaround for
+//     Gemma 4"), so on those models Kronk omits a BOS llama.cpp requires.
+//     .extras/templates/gemma4.jinja shows Kronk targets that family.
+//
+// Kronk already has the correct accessor wired up and uses it elsewhere:
+// prompt_plan.go:35 passes llama.VocabGetAddBOS(vocab) (yzma
+// .extras/yzma/pkg/llama/vocab.go:321 -> llama_vocab_get_add_bos) into the
+// media prompt plan, while the text path uses m.addBOSToken. When the two
+// disagree the media and text IMC identities for one model disagree too.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/model.go:297-302  (the metadata-string derivation)
+//   - sdk/kronk/model/model.go:336      (stored as Model.addBOSToken)
+//   - consumers: tokenize.go:55, chat.go:306-307, embed.go:136,193,
+//     rerank.go:158,211, batchgen_slot_start.go:794,987
+//   - sdk/kronk/model/prompt_plan.go:35 (the path that does ask the vocab)
+//
+// LLAMA.CPP REFERENCE
+// .extras/llama.cpp/src/llama-vocab.cpp:1813 (default false),
+// :2374-2394 (per-tokenizer-type defaults), :2547-2556 (GGUF override),
+// :2563-2568 (Gemma 4 force-on), :4203-4205 (llama_vocab_get_add_bos).
+// The server never re-derives the flag: it calls common_tokenize with
+// add_special = true (tools/server/server-context.cpp:4132) and lets
+// llama_vocab::add_bos decide (common/common.cpp:1731 ->
+// llama-vocab.cpp:3455).
+//
+// FAILURE SCENARIO
+// A spurious BOS at position 0 of every prompt on a BPE GGUF that omits the
+// key, or a missing BOS on Gemma 4. Either one is a malformed prompt for the
+// whole conversation and degrades coherence diffusely rather than visibly.
+//
+// This is verified against the source rather than at runtime because the
+// derivation is inline in NewModel, which needs a dlopen'd libllama and a
+// loaded GGUF. NOTE: it is latent on the reported model —
+// mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf does carry
+// tokenizer.ggml.add_bos_token=false, so both implementations agree there.
+func TestAddBOSTokenUsesTheVocabFlag(t *testing.T) {
+	path := filepath.Join(kronkRepoRoot(t), "sdk", "kronk", "model", "model.go")
+
+	fset := token.NewFileSet()
+	f := parseKronkSource(t, fset, path)
+	fn := findKronkFunc(t, f, path, "NewModel")
+
+	var readsMetadataKey bool
+	var readsVocabFlag bool
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.BasicLit:
+			if node.Kind == token.STRING && strings.Contains(node.Value, "tokenizer.ggml.add_bos_token") {
+				readsMetadataKey = true
+			}
+
+		case *ast.SelectorExpr:
+			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "llama" && node.Sel.Name == "VocabGetAddBOS" {
+				readsVocabFlag = true
+			}
+		}
+
+		return true
+	})
+
+	if readsVocabFlag {
+		return
+	}
+
+	t.Errorf("NewModel derives addBOSToken without consulting llama_vocab_get_add_bos "+
+		"(reads the %q metadata string: %v)\n\n"+
+		"model.go:299 starts from `addBOSToken := true` and only lowers it when the GGUF\n"+
+		"string is exactly \"false\". llama.cpp's llama_vocab::add_bos starts FALSE\n"+
+		"(.extras/llama.cpp/src/llama-vocab.cpp:1813) and is raised only for SPM/WPM\n"+
+		"(:2374-2384), so a gpt2/BPE GGUF with no add_bos_token key gets a BOS from Kronk\n"+
+		"and none from llama.cpp. In the other direction llama.cpp forces add_bos back on\n"+
+		"for Gemma 4 (:2563-2568), which Kronk's string check cannot see.\n"+
+		"llama.cpp's server never re-derives this: it passes add_special=true\n"+
+		"(tools/server/server-context.cpp:4132) and lets the vocab decide\n"+
+		"(common/common.cpp:1731 -> llama-vocab.cpp:3455, llama-vocab.cpp:4203).\n"+
+		"Kronk already calls the right accessor on the media path (prompt_plan.go:35),\n"+
+		"so the two paths can disagree for the same model.\n"+
+		"Fix: set Model.addBOSToken from llama.VocabGetAddBOS(vocab) "+
+		"(.extras/yzma/pkg/llama/vocab.go:321).",
+		"tokenizer.ggml.add_bos_token", readsMetadataKey)
+}

--- a/sdk/kronk/model/reasoning_history_roundtrip_test.go
+++ b/sdk/kronk/model/reasoning_history_roundtrip_test.go
@@ -1,0 +1,616 @@
+package model
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ardanlabs/kronk/sdk/kronk/applog"
+)
+
+// =============================================================================
+// Reasoning history round-trip: Qwen3.6-35B-A3B (MTP)
+//
+// GROUND TRUTH used by every test in this file is the chat template embedded in
+// the model itself:
+//
+//	~/.kronk/models/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf
+//	  general.architecture      = "qwen35moe"   -> parsers/qwen claims it (qwen.go:35)
+//	  tokenizer.chat_template   = qwen36ChatTemplate below (8057 bytes, verbatim)
+//	  "<think>"  = token 248068  (single special token)
+//	  "</think>" = token 248069  (single special token)
+//
+// The template is reproduced verbatim below; the line numbers cited in the test
+// doc comments are its own 1-based line numbers. The two rules that matter:
+//
+//	L92-107   assistant-turn rendering. L103-104 emit
+//	          "<think>\n" + reasoning_content + "\n</think>\n\n" + content
+//	          whenever preserve_thinking is true OR the assistant turn sits
+//	          AFTER the last real user query (loop.index0 > ns.last_query_index,
+//	          i.e. every turn of a tool-call loop and any trailing assistant
+//	          turn). Otherwise (plain prior turns) reasoning is dropped.
+//	L150-157  generation prompt: "<|im_start|>assistant\n" followed by
+//	          "<think>\n\n</think>\n\n" when enable_thinking is false, else a
+//	          FORCE-OPENED "<think>\n".
+//
+// llama.cpp is the reference implementation for the surrounding behaviour:
+//
+//	common/chat.cpp:895-900   the template receives inputs.messages VERBATIM.
+//	                          Nothing in common/chat.cpp removes reasoning_content
+//	                          from history; the template alone decides.
+//	common/chat.cpp:949-971   generation_prompt = the suffix diff between the
+//	                          renders with and without add_generation_prompt,
+//	                          i.e. "<|im_start|>assistant\n<think>\n" here.
+//	common/chat.cpp:3252-3254 that generation prompt is PREPENDED to the model
+//	                          output before parsing, which is how llama.cpp
+//	                          copes with a force-opened <think>. Kronk does the
+//	                          equivalent at batchgen_slot_start.go:37-53.
+// =============================================================================
+
+const qwen36ChatTemplate = `{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set num_sys = 0 %}
+{%- set merged_system = '' %}
+{%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+    {%- set first = render_content(messages[0].content, false, true)|trim %}
+    {%- if messages|length > 1 and (messages[1].role == 'system' or messages[1].role == 'developer') %}
+        {%- set second = render_content(messages[1].content, false, true)|trim %}
+        {%- set merged_system = first + '\n' + second %}
+        {%- set num_sys = 2 %}
+    {%- else %}
+        {%- set merged_system = first %}
+        {%- set num_sys = 1 %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if merged_system %}
+        {{- '\n\n' + merged_system }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if merged_system %}
+        {{- '<|im_start|>system\n' + merged_system + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if loop.index0 >= num_sys and message.role != "system" and message.role != "developer" %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is mapping %}
+                    {%- for args_name in tool_call.arguments %}
+                        {%- set args_value = tool_call.arguments[args_name] %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+{#- Unsloth fixes - developer role, tool calling #}`
+
+// qwen36Normalizer is a VERBATIM MIRROR of the ReasoningNormalizer that
+// parsers/qwen installs on this model. parsers/qwen imports sdk/kronk/model, so
+// an in-package (package model) test cannot import it without an import cycle.
+//
+//	sdk/kronk/parsers/qwen/reasoning.go:14-22   delegates both methods to
+//	sdk/kronk/parsers/standard/reasoning.go:15-18  (closedThink / emptyThink)
+//	sdk/kronk/parsers/standard/reasoning.go:24-29  StripThinkContent
+//	sdk/kronk/parsers/standard/reasoning.go:34-36  StripEmptyThink
+//	sdk/kronk/parsers/standard/reasoning.go:43-62  StripExceptTrailing
+//
+// MAINTAINER: keep this mirror in sync with those two files.
+type qwen36Normalizer struct{}
+
+var (
+	qwen36ClosedThink = regexp.MustCompile(`(?s)<think>.*?</think>`)
+	qwen36EmptyThink  = regexp.MustCompile(`(?s)<think>\s*</think>`)
+)
+
+func (qwen36Normalizer) Name() string                  { return "qwen" }
+func (qwen36Normalizer) NewStateMachine() StateMachine { return nil }
+
+func (qwen36Normalizer) ToolCall(_ context.Context, _ applog.Logger, _ string) []ResponseToolCall {
+	return nil
+}
+
+// StripReasoningContent mirrors standard.StripThinkContent.
+func (qwen36Normalizer) StripReasoningContent(content string) string {
+	if !strings.Contains(content, "<think>") {
+		return content
+	}
+	return qwen36ClosedThink.ReplaceAllString(content, "")
+}
+
+// StripEmptyReasoning mirrors standard.StripEmptyThink -> StripExceptTrailing.
+func (qwen36Normalizer) StripEmptyReasoning(rendered string) string {
+	locs := qwen36EmptyThink.FindAllStringIndex(rendered, -1)
+	if len(locs) == 0 {
+		return rendered
+	}
+
+	var b strings.Builder
+	prev := 0
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+		if strings.TrimSpace(rendered[end:]) == "" {
+			continue
+		}
+		b.WriteString(rendered[prev:start])
+		prev = end
+	}
+	b.WriteString(rendered[prev:])
+
+	return b.String()
+}
+
+// newQwen36Model builds a *Model wired to the real embedded Qwen3.6 template and
+// the qwen reasoning normalizer. bos_token/eos_token are supplied by the caller
+// so applyJinjaTemplate (prompts.go:155-164) never reaches into a nil vocab.
+func newQwen36Model(imc bool) *Model {
+	return &Model{
+		cfg:      Config{PtrIncrementalCache: new(imc)},
+		template: Template{FileName: "tokenizer.chat_template", Script: qwen36ChatTemplate},
+		parser:   qwen36Normalizer{},
+		log:      noopLog,
+	}
+}
+
+// renderQwen36 runs the production request path that shapes reasoning in the
+// prompt: normalizeHistoryReasoning (reasoning.go:46, called from chat.go:254)
+// followed by applyJinjaTemplate (prompts.go:111, which applies the
+// StripEmptyReasoning post-pass at prompts.go:177-181).
+func renderQwen36(t *testing.T, m *Model, d D) string {
+	t.Helper()
+
+	d["bos_token"] = ""
+	d["eos_token"] = "<|im_end|>"
+
+	d = m.normalizeHistoryReasoning(d)
+
+	out, err := m.applyJinjaTemplate(context.Background(), d)
+	if err != nil {
+		t.Fatalf("applyJinjaTemplate: %v", err)
+	}
+
+	return out
+}
+
+// TestQwen36EmptyThinkScaffoldStrippedFromInTurnAssistant pins the following
+// finding: on every request where an assistant message sits after the last real
+// user query — i.e. every turn of a tool-call loop, and every request whose last
+// message is an assistant turn — Kronk rewrites that turn's
+// "<think>\n\n</think>\n\n" header into two bare newlines, so the model is fed
+// "<|im_start|>assistant\n\n\n..." instead of the shape it was trained on.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/prompts.go:177-181     post-render StripEmptyReasoning pass
+//   - sdk/kronk/parsers/standard/reasoning.go:34-36 / :43-62 (mirrored above)
+//
+// # REFERENCE
+//
+// The model's own embedded chat template, qwen36ChatTemplate L103-104, emits
+//
+//	'<|im_start|>' + role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content
+//
+// for any assistant turn with loop.index0 > ns.last_query_index. "<think>" and
+// "</think>" are single special tokens in this model's vocabulary (248068 /
+// 248069), so this header is a fixed two-token frame, not decorative text.
+// llama.cpp renders the template output unmodified (common/chat.cpp:887-941 has
+// no post-render rewriting of any kind), so llama.cpp feeds the frame through.
+//
+// # FAILURE SCENARIO
+//
+// Agentic turn: [user, assistant(tool_calls), tool]. ns.last_query_index is 0
+// (the tool result renders as a <tool_response> user turn, which the L79-84 scan
+// skips), so the assistant turn at index 1 is rendered with the reasoning frame.
+// With no reasoning_content on the message the frame is empty, StripEmptyReasoning
+// deletes it because it is not the trailing generation marker, and the assistant
+// turn degenerates to "<|im_start|>assistant\n\n\n<tool_call>". The stripping is
+// gated only on IncrementalCache() (reasoning.go:36-38), which is on by default,
+// so no client cooperation is needed to reach it.
+func TestQwen36EmptyThinkScaffoldStrippedFromInTurnAssistant(t *testing.T) {
+	msgs := func() []D {
+		return []D{
+			{"role": "user", "content": "Q1"},
+			{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []D{
+					{"type": "function", "function": D{"name": "f", "arguments": map[string]any{"a": float64(1)}}},
+				},
+			},
+			{"role": "tool", "content": "R"},
+		}
+	}
+
+	// Reference render: identical inputs with the post-render pass disabled
+	// (IMC off), i.e. exactly what the template — and llama.cpp — produce.
+	want := renderQwen36(t, newQwen36Model(false), D{
+		"messages":        msgs(),
+		"enable_thinking": true,
+	})
+
+	got := renderQwen36(t, newQwen36Model(true), D{
+		"messages":        msgs(),
+		"enable_thinking": true,
+	})
+
+	const frame = "<|im_start|>assistant\n<think>\n\n</think>\n\n<tool_call>"
+
+	if !strings.Contains(want, frame) {
+		t.Fatalf("bad test setup: reference render does not contain the template's reasoning frame\nreference:\n%q", want)
+	}
+
+	if got != want {
+		t.Errorf("StripEmptyReasoning rewrote the in-turn assistant header.\n"+
+			"got:\n%q\nwant:\n%q\n\n"+
+			"prompts.go:177-181 runs the parser's StripEmptyReasoning over the FULL rendered\n"+
+			"prompt. standard.StripExceptTrailing keeps only a span that sits at the very end\n"+
+			"of the string (the generation marker), so the empty <think>\\n\\n</think> frame that\n"+
+			"qwen36ChatTemplate L103-104 emits for this assistant turn is deleted, leaving the\n"+
+			"two bare newlines that followed it. The model sees\n"+
+			"  <|im_start|>assistant\\n\\n\\n<tool_call>\n"+
+			"instead of the trained\n"+
+			"  <|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n<tool_call>\n"+
+			"i.e. special tokens 248068/248069 are replaced by ordinary newline text on every\n"+
+			"tool-loop turn.", got, want)
+	}
+}
+
+// TestQwen36InTurnReasoningContentNotReplayed pins the following finding: Kronk
+// deletes reasoning_content from EVERY assistant history message, including the
+// turns whose reasoning the model's own template deliberately replays.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/reasoning.go:91-92  (delete "reasoning" / "reasoning_content")
+//   - sdk/kronk/model/reasoning.go:36-38  (gated only on IncrementalCache())
+//
+// # REFERENCE
+//
+// qwen36ChatTemplate L103-104 replays reasoning_content for any assistant turn
+// with loop.index0 > ns.last_query_index. That is the multi-step tool-calling
+// case: the reasoning that justified the tool call is part of the SAME logical
+// turn as the tool result that follows it, and Qwen3.6 is trained to see it.
+// llama.cpp hands inputs.messages to the template verbatim
+// (common/chat.cpp:895-900) and has no reasoning-stripping pass anywhere in
+// common/chat.cpp, so the replay happens there.
+//
+// # FAILURE SCENARIO
+//
+// Turn 2 of a tool loop: [user, assistant(reasoning_content="I must call f
+// because X", tool_calls), tool]. The template would render
+// "<|im_start|>assistant\n<think>\nI must call f because X\n</think>\n\n<tool_call>...".
+// normalizeHistoryReasoning deletes the field first, so the model resumes the
+// loop having lost its own justification, then re-derives a different one from
+// the tool result — the "I already said that / this is a contradiction" failure
+// mode. Kronk's doc comment (reasoning.go:8-18) assumes reasoning is always
+// dropped by the template once a newer turn arrives; for this template that is
+// only true for turns BEFORE the last user query.
+func TestQwen36InTurnReasoningContentNotReplayed(t *testing.T) {
+	const reasoning = "I must call f because X"
+
+	msgs := func() []D {
+		return []D{
+			{"role": "user", "content": "Q1"},
+			{
+				"role":              "assistant",
+				"content":           "",
+				"reasoning_content": reasoning,
+				"tool_calls": []D{
+					{"type": "function", "function": D{"name": "f", "arguments": map[string]any{"a": float64(1)}}},
+				},
+			},
+			{"role": "tool", "content": "R"},
+		}
+	}
+
+	got := renderQwen36(t, newQwen36Model(true), D{
+		"messages":        msgs(),
+		"enable_thinking": true,
+	})
+
+	// Sanity: the template really does replay it when Kronk leaves the field
+	// alone (IMC off skips both normalizeHistoryReasoning and the post-pass).
+	want := renderQwen36(t, newQwen36Model(false), D{
+		"messages":        msgs(),
+		"enable_thinking": true,
+	})
+	if !strings.Contains(want, "<think>\n"+reasoning+"\n</think>") {
+		t.Fatalf("bad test setup: template did not replay in-turn reasoning\nreference:\n%q", want)
+	}
+
+	if !strings.Contains(got, reasoning) {
+		t.Errorf("in-turn assistant reasoning was dropped from the rendered prompt.\n"+
+			"got:\n%q\nwant it to contain:\n%q\n\n"+
+			"reasoning.go:91-92 deletes reasoning_content from every assistant message\n"+
+			"whenever IncrementalCache() is on and preserve_thinking is off\n"+
+			"(reasoning.go:36-38). qwen36ChatTemplate L103-104 replays reasoning for any\n"+
+			"assistant turn after the last real user query, which is every turn of a\n"+
+			"tool-call loop, and llama.cpp passes reasoning_content straight through\n"+
+			"(common/chat.cpp:895-900). The model therefore resumes a multi-step turn with\n"+
+			"its own justification missing.", got, reasoning)
+	}
+}
+
+// classifiedTokenRouting is a VERBATIM MIRROR of the accumulate-then-stream
+// ordering inside (*batchEngine).handleSampledToken:
+//
+//	sdk/kronk/model/batchgen_tokens.go:166-181  channel -> flag transitions
+//	sdk/kronk/model/batchgen_tokens.go:200-203  ChannelNone short-circuit
+//	sdk/kronk/model/batchgen_tokens.go:212-222  write into the FINAL accumulators
+//	sdk/kronk/model/batchgen_tokens.go:224-238  then decide whether to STREAM
+//
+// The delta routing (reasoning vs content) mirrors chatResponseDelta /
+// forContent / forReasoning at sdk/kronk/model/models.go:884-885 and :894-908.
+// handleSampledToken itself samples from a live llama context, so the routing is
+// mirrored here; isUnnecessaryCRLF is the real production function.
+//
+// primed reflects batchgen_slot_start.go:52, which sets reasonFlag = 1 when the
+// rendered prompt already opened a reasoning block (qwen36ChatTemplate L155
+// force-opens "<think>\n").
+//
+// MAINTAINER: keep this mirror in sync with batchgen_tokens.go:166-238.
+func classifiedTokenRouting(primed bool, results []Result) (finalReasoning, finalContent, streamedReasoning, streamedContent string) {
+	var m Model
+
+	var reasonFlag, completionFlag, toolFlag int
+	if primed {
+		reasonFlag = 1
+	}
+
+	var fr, fc, sr, sc strings.Builder
+
+	for _, result := range results {
+		switch result.Channel {
+		case ChannelReasoning:
+			reasonFlag++
+			completionFlag = 0
+			toolFlag = 0
+
+		case ChannelAnswer:
+			completionFlag++
+			reasonFlag = 0
+			toolFlag = 0
+
+		case ChannelTool:
+			toolFlag++
+			reasonFlag = 0
+			completionFlag = 0
+		}
+
+		if result.Channel == ChannelNone {
+			continue
+		}
+
+		switch {
+		case reasonFlag > 0:
+			fr.WriteString(result.Content)
+		case toolFlag > 0:
+			// finalTooling: not part of the streamed message.
+		default:
+			fc.WriteString(result.Content)
+		}
+
+		if toolFlag == 0 {
+			if m.isUnnecessaryCRLF(reasonFlag, completionFlag, result.Content) {
+				continue
+			}
+			switch {
+			case reasonFlag > 0:
+				sr.WriteString(result.Content)
+			default:
+				sc.WriteString(result.Content)
+			}
+		}
+	}
+
+	return fr.String(), fc.String(), sr.String(), sc.String()
+}
+
+// TestQwen36StreamedAndFinalMessageAgree pins the following finding: the
+// mode-transition newline suppression is applied only to the streamed delta,
+// after the same text has already been written to the final accumulator, so a
+// streaming client and a non-streaming client receive different assistant
+// messages for the identical token sequence.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_tokens.go:212-222 (write to finalContent/finalReasoning)
+//   - sdk/kronk/model/batchgen_tokens.go:225-230 (isUnnecessaryCRLF -> skip STREAM only)
+//   - sdk/kronk/model/model.go:1215-1227        (isUnnecessaryCRLF)
+//
+// # REFERENCE
+//
+// llama.cpp never streams anything other than a diff of the accumulated parsed
+// message: server_slot::update_chat_msg re-parses the whole generated text and
+// derives the deltas with common_chat_msg_diff::compute_diffs
+// (tools/server/server-task.cpp:1021 and :177), so the concatenation of the
+// streamed deltas is equal to the final message by construction. There is no
+// path in llama.cpp that can put a character in one and not the other.
+//
+// # FAILURE SCENARIO
+//
+// Qwen3.6 with thinking on: the prompt ends with a force-opened "<think>\n"
+// (qwen36ChatTemplate L155) so the slot is primed with reasonFlag = 1
+// (batchgen_slot_start.go:52). The model emits reasoning, the "</think>" special
+// token (248069, classified ChannelNone), the "\n\n" separator, then the answer.
+// The separator is written to finalContent and then suppressed from the stream,
+// so Chat() returns content "\n\nB" while ChatStreaming() delivers "B". Any
+// caller that stores streamed output as conversation history and later compares
+// or re-sends it against a non-streamed turn sees two different assistant turns
+// for the same generation.
+func TestQwen36StreamedAndFinalMessageAgree(t *testing.T) {
+	tests := []struct {
+		name    string
+		primed  bool
+		results []Result
+	}{
+		{
+			// Force-opened <think> (enable_thinking=true, the default).
+			name:   "forced-open think, separator after </think>",
+			primed: true,
+			results: []Result{
+				{Channel: ChannelReasoning, Content: "A"},
+				{Channel: ChannelNone}, // "</think>" consumed by the state machine
+				{Channel: ChannelAnswer, Content: "\n\n"},
+				{Channel: ChannelAnswer, Content: "B"},
+			},
+		},
+		{
+			// Model emitted "<think>" itself: the first reasoning token is a
+			// newline, which isUnnecessaryCRLF drops from the stream only.
+			name:   "model-emitted think, leading newline in reasoning",
+			primed: false,
+			results: []Result{
+				{Channel: ChannelNone}, // "<think>" consumed by the state machine
+				{Channel: ChannelReasoning, Content: "\n"},
+				{Channel: ChannelReasoning, Content: "A"},
+				{Channel: ChannelNone}, // "</think>"
+				{Channel: ChannelAnswer, Content: "B"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			finalReasoning, finalContent, streamedReasoning, streamedContent := classifiedTokenRouting(tt.primed, tt.results)
+
+			if streamedContent != finalContent {
+				t.Errorf("streamed content != final content\nstreamed: %q\nfinal:    %q\n\n"+
+					"batchgen_tokens.go:212-222 writes result.Content into finalContent BEFORE\n"+
+					"batchgen_tokens.go:225-230 asks isUnnecessaryCRLF whether to stream it, so the\n"+
+					"suppressed mode-transition newline survives in the non-streaming message only.\n"+
+					"llama.cpp streams only diffs of the accumulated parsed message\n"+
+					"(tools/server/server-task.cpp:1021 -> common_chat_msg_diff::compute_diffs at\n"+
+					":177), so its deltas concatenate to the final message by construction.",
+					streamedContent, finalContent)
+			}
+
+			if streamedReasoning != finalReasoning {
+				t.Errorf("streamed reasoning != final reasoning\nstreamed: %q\nfinal:    %q\n\n"+
+					"Same ordering defect as above, on the reasoning channel: the leading newline of\n"+
+					"the reasoning block is accumulated into finalReasoning and then dropped from the\n"+
+					"reasoning deltas.",
+					streamedReasoning, finalReasoning)
+			}
+		})
+	}
+}

--- a/sdk/kronk/model/sampler_chain_order_test.go
+++ b/sdk/kronk/model/sampler_chain_order_test.go
@@ -1,0 +1,879 @@
+package model
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Sampler-chain construction, parameter sentinels and penalty accounting.
+//
+// The reference implementation for every assertion in this file is llama.cpp
+// b10211 as vendored under .extras/llama.cpp:
+//
+//   - common/sampling.cpp:325-381  common_sampler_init, the canonical chain
+//   - common/common.h:224-269      common_params_sampling defaults + sentinels
+//   - tools/server/server-schema.cpp:89-155, 550-560  JSON param semantics
+//   - tools/server/server-context.cpp:375-393  init_sampler (prompt seeding)
+//
+// Where a defect lives in pure parameter resolution the real Kronk function is
+// called directly (m.parseParams / m.adjustParams need only m.cfg and m.log,
+// see newTempTestModel in params_temperature_test.go). Where the defect lives
+// inside toSampler — which calls into the yzma FFI and therefore needs a loaded
+// shared library — the assertion is made over the checked-in source, the same
+// technique doc_comment_claims_test.go and mtp_ctxparams_source_test.go use.
+// The source assertions locate code by declaration name, never by line number.
+// =============================================================================
+
+// TestParseParamsDryPenaltyLastKeepsDryEnabled pins the DRY sentinel defect.
+//
+// FINDING
+// DRY is dead code in Kronk unless the caller explicitly passes a POSITIVE
+// dry_penalty_last_n. Both "not supplied" and the llama.cpp sentinel -1
+// resolve to 0, and 0 means "DRY disabled" one layer down.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/params.go:701-703
+//		if p.DryPenaltyLast < 0 {
+//			p.DryPenaltyLast = DefDryPenaltyLast   // params.go:37 -> 0
+//		}
+//
+//	sdk/kronk/model/params.go:790-791 hands that value to
+//	llama.SamplerInitDry(..., p.DryPenaltyLast, nil) whenever
+//	p.DryMultiplier > 0.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/common.h:245
+//		int32_t dry_penalty_last_n = -1; // 0 = disable penalty, -1 = context size
+//	.extras/llama.cpp/tools/server/server-schema.cpp:151-155 + 557-559
+//		"How many tokens to scan for repetitions (0 = disabled, -1 = context
+//		size)"; a request value of -1 is rewritten to n_ctx_slot, never to 0.
+//	.extras/llama.cpp/src/llama-sampler.cpp:3200-3205
+//		effective_dry_penalty_last_n = (dry_penalty_last_n == -1) ? n_ctx_train
+//		                                                         : max(v, 0);
+//		dry_enabled = (dry_multiplier != 0 && dry_base >= 1 &&
+//		               dry_penalty_last_n != 0);
+//	.extras/llama.cpp/src/llama-sampler.cpp:2939, 2950 — apply() returns
+//	immediately when dry_penalty_last_n == 0.
+//
+// FAILURE SCENARIO
+// A long reasoning conversation starts to loop, so the caller enables the
+// anti-loop sampler: {"dry_multiplier": 1.0}. Kronk logs the DRY sampler as
+// active ("sampler-chain ... sampler=dry multiplier=1.00 penalty_last_n=0",
+// params.go:792) and adds it to the chain, but the sampler was constructed with
+// a zero-length ring buffer and never penalizes anything. The same request
+// against llama.cpp's server gets a full-context DRY window. Passing the
+// documented llama.cpp sentinel -1 explicitly does not help either: it is
+// rewritten to 0 by params.go:701-703 before it reaches the sampler.
+func TestParseParamsDryPenaltyLastKeepsDryEnabled(t *testing.T) {
+	m := newTempTestModel()
+	ctxWindow := int32(m.cfg.ContextWindow())
+
+	tests := []struct {
+		name string
+		doc  D
+	}{
+		{name: "dry enabled, dry_penalty_last_n not supplied", doc: D{"dry_multiplier": 1.0}},
+		{name: "dry enabled, dry_penalty_last_n -1 means context size", doc: D{"dry_multiplier": 1.0, "dry_penalty_last_n": -1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf("%#v", tt.doc)
+
+			p, err := m.parseParams(tt.doc)
+			if err != nil {
+				t.Fatalf("parseParams(%s): unexpected error: %v", input, err)
+			}
+
+			if p.DryMultiplier <= 0 {
+				t.Fatalf("precondition: parseParams(%s) resolved DryMultiplier = %v, want > 0", input, p.DryMultiplier)
+			}
+
+			// llama.cpp accepts exactly two shapes here: the -1 sentinel
+			// (resolved to the slot context size by the server) or a positive
+			// window. 0 is reserved for "DRY off".
+			switch {
+			case p.DryPenaltyLast == -1, p.DryPenaltyLast > 0:
+				// DRY can actually do work.
+			default:
+				t.Errorf("parseParams(%s): resolved DryPenaltyLast = %d, want -1 (context size) or > 0\n"+
+					"params.go:701-703 collapses both \"unset\" and the llama.cpp -1 sentinel to\n"+
+					"DefDryPenaltyLast (params.go:37 = 0). llama-sampler.cpp:3205 treats\n"+
+					"dry_penalty_last_n == 0 as \"DRY disabled\" and builds a zero-length token\n"+
+					"ring buffer, so the DRY sampler added at params.go:791 is a no-op even\n"+
+					"though params.go:792 logs it as active. llama.cpp's default is -1 =\n"+
+					"context size (common.h:245, server-schema.cpp:557-559); this model's\n"+
+					"context window is %d.",
+					input, p.DryPenaltyLast, ctxWindow)
+			}
+		})
+	}
+}
+
+// TestSamplingDefaultsHonorGGUFMetadata pins the ignored per-model sampling
+// metadata.
+//
+// FINDING
+// llama.cpp seeds its sampling defaults from the GGUF's general.sampling.*
+// keys whenever the user did not explicitly override them. Kronk reads the
+// whole metadata table but never consults those keys, so every model gets
+// Kronk's hardcoded defaults instead of the ones it shipped with.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/models.go:119-146  toModelInfo copies every GGUF key/value
+//	    into ModelInfo.Metadata — the general.sampling.* values are already in
+//	    memory.
+//	sdk/kronk/model/params.go:688-760  adjustParams resolves unset fields from
+//	    the package constants only: DefTemp 0.8 (params.go:96), DefTopK 40
+//	    (params.go:101), DefTopP 0.9 (params.go:112), DefMinP 0 (params.go:67).
+//	    No branch anywhere in the repo reads a "general.sampling." key.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/common.cpp:1142-1198  common_init_sampler_from_model
+//	    get_int32(... SAMPLING_TOP_K, sparams.top_k, ...CONFIG_TOP_K);
+//	    get_float(... SAMPLING_TOP_P, sparams.top_p, ...CONFIG_TOP_P);
+//	    get_float(... SAMPLING_TEMP,  sparams.temp,  ...CONFIG_TEMP);
+//	    (plus min_p, xtc_*, penalty_last_n, penalty_repeat, mirostat_*, and the
+//	    whole sampler SEQUENCE)
+//	.extras/llama.cpp/common/common.cpp:1266  called from common_init_result,
+//	    i.e. on every model load, before any sampler is built. The
+//	    user_sampling_config bitfield (common/common.h:256, common/arg.cpp:1902+)
+//	    ensures an explicit CLI/request value still wins.
+//	.extras/llama.cpp/src/llama-arch.cpp:156-167 / src/llama-model.cpp:2671-2676
+//	    define the key names.
+//
+// FAILURE SCENARIO — measured on the user's actual model
+// /Users/florin/.kronk/models/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/
+// mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf carries:
+//
+//	general.architecture       = qwen35moe
+//	qwen35moe.context_length   = 262144
+//	qwen35moe.nextn_predict_layers = 1     (MTP)
+//	general.sampling.top_k     = 20
+//	general.sampling.top_p     = 0.95
+//	general.sampling.temp      = 1
+//
+// llama.cpp therefore serves this model at temp 1.0 / top_k 20 / top_p 0.95.
+// Kronk serves it at temp 0.8 / top_k 40 / top_p 0.9: a lower temperature on a
+// wider-but-nucleus-clipped candidate set. That combination is the classic
+// repetition-loop regime for Qwen reasoning models — the model's own card
+// warns against low temperature with thinking enabled — and it is exactly the
+// reported symptom (long reasoning turns that loop or double back and
+// contradict themselves). Nothing in the request has to be wrong for this to
+// happen: it is the default path.
+func TestSamplingDefaultsHonorGGUFMetadata(t *testing.T) {
+	root := kronkRepoRoot(t)
+	dir := filepath.Join(root, "sdk", "kronk", "model")
+
+	// Ground the comparison in the current constants rather than restating
+	// them: these are what a Qwen3.6 request gets today.
+	kronkDefaults := fmt.Sprintf("DefTemp=%v DefTopK=%d DefTopP=%v DefMinP=%v", float32(DefTemp), DefTopK, float32(DefTopP), float32(DefMinP))
+
+	found := false
+	for _, path := range nonTestGoFiles(t, dir) {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		if strings.Contains(string(src), "general.sampling.") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("no source under %s reads any GGUF \"general.sampling.*\" key\n"+
+			"kronk defaults in force: %s\n"+
+			"the MTP model under test ships general.sampling.top_k=20,\n"+
+			"general.sampling.top_p=0.95, general.sampling.temp=1 (verified with\n"+
+			"gguf metadata of mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf), and\n"+
+			"toModelInfo (models.go:119-146) already loads those values into\n"+
+			"ModelInfo.Metadata. llama.cpp applies them to the sampling params on\n"+
+			"every model load unless the caller overrode the field\n"+
+			"(common/common.cpp:1142-1198, called at :1266), so llama.cpp runs this\n"+
+			"model at temp 1.0/top_k 20/top_p 0.95 while Kronk runs it at\n"+
+			"temp 0.8/top_k 40/top_p 0.9.",
+			dir, kronkDefaults)
+	}
+}
+
+// TestParseParamsRepeatLastNSentinels pins the repeat_last_n sentinel defect.
+//
+// FINDING
+// repeat_last_n loses both of its llama.cpp sentinels. -1 ("penalize over the
+// whole context") and 0 ("penalties off") are both rewritten to 64.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/params.go:717-719
+//		if p.RepeatLastN <= 0 {
+//			p.RepeatLastN = DefRepeatLastN   // params.go:80 -> 64
+//		}
+//
+//	The resolved value is passed to llama.SamplerInitPenalties at
+//	sdk/kronk/model/params.go:785, which is added to the chain whenever any of
+//	repeat/frequency/presence penalty is non-default.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/common.h:238
+//		int32_t penalty_last_n = 64; // last n tokens to penalize
+//		                             // (0 = disable penalty, -1 = context size)
+//	.extras/llama.cpp/tools/server/server-schema.cpp:126-128 (hard limits
+//	-1..INT32_MAX, "0 = disabled, -1 = ctx-size") and :552-555, which rewrites
+//	a requested -1 to the slot context size — never to 64.
+//	.extras/llama.cpp/src/llama-sampler.cpp:2762-2782 sizes the penalty ring
+//	buffer from penalty_last_n and short-circuits when it is 0.
+//
+// FAILURE SCENARIO
+// Two symmetric mis-resolutions, both silent:
+//
+//   - {"repeat_penalty": 1.15, "repeat_last_n": -1} asks for a penalty across
+//     the whole conversation (4096 tokens here). Kronk penalizes the last 64
+//     tokens instead — a ~64x narrower window than the same request would get
+//     from llama.cpp's server.
+//   - {"repeat_penalty": 1.15, "repeat_last_n": 0} asks for the penalty to be
+//     switched off. Kronk switches it ON over 64 tokens. In a long reasoning
+//     turn a 64-token repeat penalty suppresses exactly the tokens that hold a
+//     chain of thought together (identifiers, "therefore", quoted values),
+//     which is one of the mechanisms behind self-contradiction.
+func TestParseParamsRepeatLastNSentinels(t *testing.T) {
+	m := newTempTestModel()
+	ctxWindow := int32(m.cfg.ContextWindow())
+
+	t.Run("-1 means context size", func(t *testing.T) {
+		doc := D{"repeat_penalty": 1.15, "repeat_last_n": -1}
+		input := fmt.Sprintf("%#v", doc)
+
+		p, err := m.parseParams(doc)
+		if err != nil {
+			t.Fatalf("parseParams(%s): unexpected error: %v", input, err)
+		}
+
+		if p.RepeatLastN != -1 && p.RepeatLastN != ctxWindow {
+			t.Errorf("parseParams(%s): resolved RepeatLastN = %d, want -1 or the context window %d\n"+
+				"params.go:717-719 rewrites every value <= 0 to DefRepeatLastN (64), so the\n"+
+				"llama.cpp -1 = context-size sentinel (common.h:238,\n"+
+				"server-schema.cpp:552-555) silently becomes a 64-token window.",
+				input, p.RepeatLastN, ctxWindow)
+		}
+	})
+
+	t.Run("0 disables the penalty", func(t *testing.T) {
+		doc := D{"repeat_penalty": 1.15, "repeat_last_n": 0}
+		input := fmt.Sprintf("%#v", doc)
+
+		p, err := m.parseParams(doc)
+		if err != nil {
+			t.Fatalf("parseParams(%s): unexpected error: %v", input, err)
+		}
+
+		if p.RepeatLastN != 0 {
+			t.Errorf("parseParams(%s): resolved RepeatLastN = %d, want 0 (penalty disabled)\n"+
+				"params.go:717-719 cannot distinguish an explicit 0 from an absent field, so\n"+
+				"a caller asking llama.cpp's \"0 = disabled\" (common.h:238,\n"+
+				"server-schema.cpp:126-128) gets a 64-token repetition penalty applied to\n"+
+				"their request instead.",
+				input, p.RepeatLastN)
+		}
+	})
+}
+
+// TestParseParamsTopKDisableSentinel pins the top_k sentinel defect.
+//
+// FINDING
+// top_k cannot be disabled. llama.cpp treats top_k <= 0 as "use the vocab
+// size", i.e. no truncation; Kronk rewrites it to 40.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/params.go:733-735
+//		if p.TopK <= 0 {
+//			p.TopK = DefTopK   // params.go:101 -> 40
+//		}
+//
+//	The value reaches llama.SamplerInitTopK at sdk/kronk/model/params.go:796,
+//	unconditionally, and is also handed to the speculative verification filter
+//	(batchgen_speculative.go:498, :543, :599 -> logprobs.go:129).
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/common.h:229
+//		int32_t top_k = 40; // <= 0 to use vocab size
+//	.extras/llama.cpp/tools/server/server-schema.cpp:89-91
+//		field_num("top_k", ...)->set_limits(0, INT32_MAX)
+//		"Limit the next token selection to the K most probable tokens
+//		 (0 = disabled)"
+//
+// FAILURE SCENARIO
+// An OpenAI-compatible client that sends {"top_k": 0} to mean "no top-k, let
+// min_p/top_p decide" gets a hard 40-token truncation. On a 35B MoE with a
+// large vocab this clips the tail that min_p was tuned against, and the
+// truncation is invisible: the sampler-chain log line (params.go:797) reports
+// k=40 as if the caller had asked for it.
+func TestParseParamsTopKDisableSentinel(t *testing.T) {
+	m := newTempTestModel()
+
+	tests := []struct {
+		name string
+		doc  D
+	}{
+		{name: "explicit zero disables top-k", doc: D{"top_k": 0}},
+		{name: "negative disables top-k", doc: D{"top_k": -1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf("%#v", tt.doc)
+
+			p, err := m.parseParams(tt.doc)
+			if err != nil {
+				t.Fatalf("parseParams(%s): unexpected error: %v", input, err)
+			}
+
+			if p.TopK > 0 {
+				t.Errorf("parseParams(%s): resolved TopK = %d, want <= 0 (top-k disabled)\n"+
+					"params.go:733-735 rewrites every top_k <= 0 to DefTopK (40). llama.cpp\n"+
+					"documents top_k <= 0 as \"use vocab size\" (common.h:229) and its server\n"+
+					"accepts 0 as \"disabled\" (server-schema.cpp:89-91), so top-k truncation\n"+
+					"cannot be turned off through Kronk's public API.",
+					input, p.TopK)
+			}
+		})
+	}
+}
+
+// TestToSamplerAdaptivePIsTheFinalSelector pins two chain-construction defects
+// around the adaptive-p sampler.
+//
+// FINDING
+// (a) adaptive-p is inserted BEFORE the temperature sampler, and
+// (b) a dist sampler is appended afterwards regardless.
+// adaptive-p is a selecting sampler: it rewrites every logit into a
+// distance-from-target curve and picks a token. Running temp_ext + dist after
+// it both discards its selection and samples from the rewritten curve.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/params.go:813-816   adaptive-p (guarded by AdaptivePTarget > 0)
+//	sdk/kronk/model/params.go:819-821   temp_ext  (unconditional)
+//	sdk/kronk/model/params.go:823-825   dist      (unconditional)
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/sampling.cpp:363-381
+//		case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
+//		    // ... selects a single token, so we will add `dist` at the end of
+//		    // the chain by default, unless the user specifically included
+//		    // `adaptive-p`.
+//		    use_adaptive_p = true;
+//		...
+//		if (use_adaptive_p) {
+//		    samplers.push_back(llama_sampler_init_adaptive_p(...));
+//		} else {
+//		    samplers.push_back(llama_sampler_init_dist(params.seed));
+//		}
+//
+//	adaptive-p is therefore pushed AFTER the whole params.samplers loop (whose
+//	default order ends with COMMON_SAMPLER_TYPE_TEMPERATURE, common.h:260-269)
+//	and REPLACES dist.
+//
+//	.extras/llama.cpp/src/llama-sampler.cpp:3311-3371 shows why the position
+//	matters: adaptive_p_apply() overwrites cur_p->data[i].logit with
+//	PEAK_LOGIT_VALUE - SHARPNESS*dist^2/(1+dist), sets cur_p->selected, and
+//	stores pending_token_id. adaptive_p_accept() only updates its EMA when the
+//	accepted token equals pending_token_id.
+//
+// FAILURE SCENARIO
+// A request with {"adaptive_p_target": 0.1}: adaptive-p replaces the real
+// logits with the peak-shaped curve and selects a token; temp_ext then rescales
+// that synthetic curve and dist re-samples from it, so the emitted token is
+// almost never adaptive-p's pick. Because it differs, adaptive_p_accept()
+// (llama-sampler.cpp:3362-3373) never advances its EMA, so the adaptive target
+// never adapts. The result is neither adaptive-p sampling nor ordinary
+// sampling: the token comes from a distribution that has no relation to the
+// model's logits.
+func TestToSamplerAdaptivePIsTheFinalSelector(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "params.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+	fd := findKronkFunc(t, file, path, "toSampler")
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	adds := samplerChainAdds(fset, root, src, fd)
+	if len(adds) == 0 {
+		t.Fatalf("no llama.SamplerInit* calls found in toSampler (%s): re-point this test", path)
+	}
+
+	t.Run("adaptive-p comes after temperature", func(t *testing.T) {
+		adaptive := findSamplerAdd(adds, "SamplerInitAdaptiveP")
+		temp := findSamplerAdd(adds, "SamplerInitTempExt")
+
+		if adaptive == nil || temp == nil {
+			t.Skipf("toSampler no longer adds both adaptive-p and temp_ext (adaptive=%v temp=%v)", adaptive != nil, temp != nil)
+		}
+
+		if adaptive.order < temp.order {
+			t.Errorf("toSampler adds adaptive-p (%s, chain position %d) BEFORE temp_ext (%s, chain position %d)\n"+
+				"chain as constructed: %s\n"+
+				"llama.cpp pushes adaptive-p after the whole sampler loop, i.e. after\n"+
+				"temperature (common/sampling.cpp:373-381, defaults common.h:260-269).\n"+
+				"adaptive-p is a SELECTING sampler that overwrites every logit with a\n"+
+				"distance-from-target curve (src/llama-sampler.cpp:3311-3360); running\n"+
+				"temperature on that synthetic curve is meaningless.",
+				adaptive.pos, adaptive.order, temp.pos, temp.order, chainSummary(adds))
+		}
+	})
+
+	t.Run("dist is not added alongside adaptive-p", func(t *testing.T) {
+		adaptive := findSamplerAdd(adds, "SamplerInitAdaptiveP")
+		dist := findSamplerAdd(adds, "SamplerInitDist")
+
+		if adaptive == nil || dist == nil {
+			t.Skipf("toSampler no longer adds both adaptive-p and dist (adaptive=%v dist=%v)", adaptive != nil, dist != nil)
+		}
+
+		// llama.cpp makes the two mutually exclusive. In Go that has to show
+		// up as a guard on the dist call that mentions the adaptive-p switch.
+		guarded := false
+		for _, cond := range dist.conds {
+			if strings.Contains(cond, "AdaptiveP") {
+				guarded = true
+				break
+			}
+		}
+
+		if !guarded {
+			t.Errorf("toSampler adds a dist sampler (%s) that is not mutually exclusive with adaptive-p (%s)\n"+
+				"guards on the dist call: %v\n"+
+				"chain as constructed: %s\n"+
+				"common/sampling.cpp:373-381 adds EITHER adaptive-p OR dist, never both,\n"+
+				"because each one selects the final token. With both present, dist\n"+
+				"re-selects from adaptive-p's rewritten logits, so adaptive-p's choice is\n"+
+				"discarded and its EMA never updates (src/llama-sampler.cpp:3362-3373).",
+				dist.pos, adaptive.pos, dist.conds, chainSummary(adds))
+		}
+	})
+}
+
+// TestToSamplerDryUsesDefaultSequenceBreakers pins the missing DRY sequence
+// breakers.
+//
+// FINDING
+// Kronk constructs the DRY sampler with a nil sequence-breaker list, so DRY
+// matches n-grams straight across newlines, quotes and colons.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/params.go:791
+//		llama.SamplerChainAdd(sampler, llama.SamplerInitDry(m.vocab,
+//			int32(m.cfg.ContextWindow()), p.DryMultiplier, p.DryBase,
+//			p.DryAllowedLen, p.DryPenaltyLast, nil))
+//
+//	yzma passes a null pointer and num_breakers = 0 for a nil slice
+//	(.extras/yzma/pkg/llama/sampling.go:418-438).
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/common/common.h:257
+//		std::vector<std::string> dry_sequence_breakers = {"\n", ":", "\"", "*"};
+//	.extras/llama.cpp/common/sampling.cpp:329-339 forwards those breakers into
+//	llama_sampler_init_dry; tools/server/server-task.cpp:115 exposes them as a
+//	per-request field with the same default.
+//
+// FAILURE SCENARIO
+// With DRY enabled, restarts that legitimately repeat across a boundary — a
+// bulleted list, a repeated JSON key, a quoted identifier echoed from the
+// prompt — are treated as one long repeated n-gram, because nothing resets the
+// match at "\n", ":" or '"'. DRY's penalty grows as base^(len-allowed_length),
+// so a long cross-line match drives the penalty on structurally required
+// tokens to the point where the model substitutes something else, which is the
+// classic "starts fine, then derails / contradicts itself" failure. llama.cpp
+// never runs DRY without breakers.
+func TestToSamplerDryUsesDefaultSequenceBreakers(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "params.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+	fd := findKronkFunc(t, file, path, "toSampler")
+
+	var call *ast.CallExpr
+	ast.Inspect(fd, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if samplerInitName(ce) == "SamplerInitDry" {
+			call = ce
+		}
+
+		return true
+	})
+
+	if call == nil {
+		t.Skipf("toSampler no longer calls llama.SamplerInitDry (%s)", path)
+	}
+
+	if len(call.Args) == 0 {
+		t.Fatalf("llama.SamplerInitDry called with no arguments at %s", srcPos(fset, root, call.Pos()))
+	}
+
+	last := call.Args[len(call.Args)-1]
+	if id, ok := last.(*ast.Ident); ok && id.Name == "nil" {
+		t.Errorf("%s: llama.SamplerInitDry is called with a nil sequence-breaker list\n"+
+			"llama.cpp always passes dry_sequence_breakers, whose default is\n"+
+			"{\"\\n\", \":\", \"\\\"\", \"*\"} (common/common.h:257, forwarded at\n"+
+			"common/sampling.cpp:329-339). Without breakers the DRY sampler matches\n"+
+			"repeated n-grams across line, quote and colon boundaries and penalizes\n"+
+			"structurally required tokens.",
+			srcPos(fset, root, last.Pos()))
+	}
+}
+
+// TestSamplerPenaltyHistoryIsSeededWithPrompt pins the missing prompt seeding
+// of the penalty / DRY history.
+//
+// FINDING
+// Kronk only ever calls llama.SamplerAccept for tokens it generated
+// (batchgen_tokens.go:63, reached from handleSampledToken). The prompt is never
+// fed to the sampler chain, so the penalties and DRY ring buffers start empty
+// on every request.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/batchgen_slot_start.go:96-97 creates the per-request chain
+//	(m.toSampler) and nothing afterwards seeds it; the prefill path decodes the
+//	prompt without touching s.sampler.
+//	sdk/kronk/model/batchgen_tokens.go:63 is the only accept on s.sampler.
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:375-393
+//		void init_sampler() const {
+//		    common_sampler_reset(smpl.get());
+//		    ...
+//		    for (int i = 0; i < (int) prompt.tokens.size(); i++) {
+//		        const llama_token id = prompt.tokens[i];
+//		        if (id != LLAMA_TOKEN_NULL) {
+//		            common_sampler_accept(smpl.get(), id, false);
+//		        }
+//		    }
+//		}
+//
+//	called from server-context.cpp:3571 whenever a slot's prompt is (re)made,
+//	and common_sampler_accept forwards to llama_sampler_accept on the whole
+//	chain (common/sampling.cpp:524-527, 552-586).
+//
+// FAILURE SCENARIO
+// In a multi-turn reasoning conversation the prompt contains every previous
+// turn. llama.cpp's penalty and DRY windows therefore span the conversation,
+// while Kronk's span only the tokens generated in the current turn. Identical
+// requests with identical repeat_penalty / dry_multiplier produce materially
+// different distributions, and the first ~64 generated tokens of every turn are
+// effectively penalty-free in Kronk — the model is free to restate (and then
+// contradict) whatever it just said in the previous turn.
+func TestSamplerPenaltyHistoryIsSeededWithPrompt(t *testing.T) {
+	root := kronkRepoRoot(t)
+	dir := filepath.Join(root, "sdk", "kronk", "model")
+
+	// A fix may live in slot start, in the prefill path, or in a dedicated
+	// seeding helper; accept any of those.
+	seedingFunc := regexp.MustCompile(`(?i)(prefill|startslot|initsampler|seedsampler|seedpenalt|acceptprompt)`)
+
+	var sites []string
+	seeded := false
+
+	for _, path := range nonTestGoFiles(t, dir) {
+		fset := token.NewFileSet()
+		file := parseKronkSource(t, fset, path)
+
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				ce, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				sel, ok := ce.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "SamplerAccept" {
+					return true
+				}
+
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "llama" {
+					return true
+				}
+
+				sites = append(sites, fmt.Sprintf("%s in %s", srcPos(fset, root, ce.Pos()), fd.Name.Name))
+				if seedingFunc.MatchString(fd.Name.Name) {
+					seeded = true
+				}
+
+				return true
+			})
+		}
+	}
+
+	if len(sites) == 0 {
+		t.Fatalf("no llama.SamplerAccept call sites found under %s: re-point this test", dir)
+	}
+
+	if !seeded {
+		t.Errorf("no llama.SamplerAccept call seeds the prompt into the per-request sampler chain\n"+
+			"call sites found: %v\n"+
+			"llama.cpp's server accepts EVERY prompt token into the chain before\n"+
+			"generation starts (tools/server/server-context.cpp:375-393, called from\n"+
+			":3571), which is what fills the penalties ring buffer\n"+
+			"(src/llama-sampler.cpp:2762-2782) and the DRY token history. Kronk creates\n"+
+			"the chain at batchgen_slot_start.go:96-97 and only ever accepts generated\n"+
+			"tokens (batchgen_tokens.go:63), so repeat/frequency/presence penalties and\n"+
+			"DRY see none of the conversation history carried in the prompt.",
+			sites)
+	}
+}
+
+// TestSpeculativeVerifyTargetProbsIncludePenalties pins the divergence between
+// the real sampler chain and the hand-rolled filter used to verify draft
+// tokens.
+//
+// FINDING
+// Speculative / MTP verification builds its target distribution with
+// applySamplerFilters, which implements only suppress-bias -> top-k -> top-p ->
+// min-p -> temperature. Penalties, DRY and XTC — every stateful sampler in the
+// real chain — are absent, so p_target used for accept/reject (and for the
+// rejection-adjusted resample) comes from a different distribution than the
+// non-speculative path would produce.
+//
+// PRODUCTION
+//
+//	sdk/kronk/model/logprobs.go:129
+//		func applySamplerFilters(logits, probs []float32,
+//			suppressTokens []llama.Token, temperature, topP, minP float32,
+//			topK int32, indices []int, fs *filterState) []int
+//
+//	callers: sdk/kronk/model/batchgen_speculative.go:498 (sparse verify),
+//	:543 (full-vocab verify), :599 (all-accepted bonus sample).
+//	The real chain is sdk/kronk/model/params.go:783-825 and does include
+//	Penalties (:785), DRY (:791) and XTC (:809).
+//
+// LLAMA.CPP REFERENCE
+//
+//	.extras/llama.cpp/tools/server/server-context.cpp:3862
+//		auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(),
+//			slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+//	.extras/llama.cpp/common/sampling.cpp:646-674 — that helper calls
+//	common_sampler_sample + common_sampler_accept for EVERY draft position, i.e.
+//	the identical full chain (penalties, DRY, XTC, temperature, dist) that
+//	non-speculative decoding uses.
+//
+// FAILURE SCENARIO
+// With repeat_penalty or DRY enabled and MTP on, a repeated token that the real
+// chain would have penalized still has a high p_target in the verification
+// filter, so ratio = p_target/q_draft >= 1 and the draft token is accepted
+// unconditionally. Speculative decoding's whole correctness argument is that
+// the accepted stream is distributed identically to the non-speculative stream;
+// here the two paths use different distributions, so enabling MTP silently
+// turns off repetition control and makes loops more likely, not less.
+//
+// The assertion is over the signature because the omission IS the signature:
+// applySamplerFilters has no parameter through which penalty state could be
+// expressed. If the fix routes verification through the real chain and deletes
+// the helper, the test passes.
+func TestSpeculativeVerifyTargetProbsIncludePenalties(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "logprobs.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+
+	var fd *ast.FuncDecl
+	for _, decl := range file.Decls {
+		d, ok := decl.(*ast.FuncDecl)
+		if ok && d.Name.Name == "applySamplerFilters" {
+			fd = d
+			break
+		}
+	}
+
+	if fd == nil {
+		t.Skip("applySamplerFilters is gone: speculative verification no longer uses a hand-rolled filter")
+	}
+
+	// Confirm the real chain does apply penalties, so the comparison is
+	// grounded in the current source rather than restated from memory.
+	paramsPath := filepath.Join(root, "sdk", "kronk", "model", "params.go")
+	paramsFset := token.NewFileSet()
+	paramsFile := parseKronkSource(t, paramsFset, paramsPath)
+	toSampler := findKronkFunc(t, paramsFile, paramsPath, "toSampler")
+
+	paramsSrc, err := os.ReadFile(paramsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", paramsPath, err)
+	}
+
+	chain := samplerChainAdds(paramsFset, root, paramsSrc, toSampler)
+	if findSamplerAdd(chain, "SamplerInitPenalties") == nil {
+		t.Skipf("toSampler no longer adds a penalties sampler; chain: %s", chainSummary(chain))
+	}
+
+	stateful := regexp.MustCompile(`(?i)penalt|repeat|freq|presence|dry`)
+
+	var names []string
+	for _, field := range fd.Type.Params.List {
+		for _, name := range field.Names {
+			names = append(names, name.Name)
+			if stateful.MatchString(name.Name) {
+				return
+			}
+		}
+	}
+
+	t.Errorf("%s: applySamplerFilters takes no penalty/DRY state; parameters are %v\n"+
+		"toSampler adds Penalties (params.go:785) and DRY (params.go:791) to the\n"+
+		"real chain, but speculative verification\n"+
+		"(batchgen_speculative.go:498, :543, :599) computes p_target with this\n"+
+		"filter instead, so accept/reject decisions and the rejection resample use\n"+
+		"an unpenalized distribution. llama.cpp verifies every draft position with\n"+
+		"the SAME full chain via common_sampler_sample_and_accept_n\n"+
+		"(tools/server/server-context.cpp:3862, common/sampling.cpp:646-674).",
+		srcPos(fset, root, fd.Pos()), names)
+}
+
+// =============================================================================
+// Source-analysis helpers for the sampler chain.
+
+// samplerAdd is one llama.SamplerInit* call inside a chain-construction
+// function, in source order, together with the conditions guarding it.
+type samplerAdd struct {
+	name  string
+	pos   string
+	order int
+	conds []string
+}
+
+// samplerChainAdds returns every llama.SamplerInit* call in fd in source order.
+// src is the raw file content, used to render guard conditions verbatim.
+func samplerChainAdds(fset *token.FileSet, root string, src []byte, fd *ast.FuncDecl) []samplerAdd {
+	var (
+		out   []samplerAdd
+		stack []ast.Node
+	)
+
+	ast.Inspect(fd, func(n ast.Node) bool {
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+
+			return true
+		}
+
+		stack = append(stack, n)
+
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		name := samplerInitName(ce)
+		if name == "" {
+			return true
+		}
+
+		var conds []string
+		for _, node := range stack {
+			ifStmt, ok := node.(*ast.IfStmt)
+			if !ok || ifStmt.Cond == nil {
+				continue
+			}
+			conds = append(conds, nodeSource(fset, src, ifStmt.Cond))
+		}
+
+		out = append(out, samplerAdd{
+			name:  name,
+			pos:   srcPos(fset, root, ce.Pos()),
+			order: len(out) + 1,
+			conds: conds,
+		})
+
+		return true
+	})
+
+	return out
+}
+
+// samplerInitName returns the llama.SamplerInit* selector name for ce, or "".
+func samplerInitName(ce *ast.CallExpr) string {
+	sel, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "llama" {
+		return ""
+	}
+
+	if !strings.HasPrefix(sel.Sel.Name, "SamplerInit") {
+		return ""
+	}
+
+	return sel.Sel.Name
+}
+
+// findSamplerAdd returns the first add with the given llama.SamplerInit* name.
+func findSamplerAdd(adds []samplerAdd, name string) *samplerAdd {
+	for i := range adds {
+		if adds[i].name == name {
+			return &adds[i]
+		}
+	}
+
+	return nil
+}
+
+// chainSummary renders the constructed chain as "1:TopK -> 2:TopP -> ...".
+func chainSummary(adds []samplerAdd) string {
+	parts := make([]string, 0, len(adds))
+	for _, a := range adds {
+		parts = append(parts, fmt.Sprintf("%d:%s", a.order, strings.TrimPrefix(a.name, "SamplerInit")))
+	}
+
+	return strings.Join(parts, " -> ")
+}
+
+// nodeSource returns the verbatim source text of n.
+func nodeSource(fset *token.FileSet, src []byte, n ast.Node) string {
+	start := fset.Position(n.Pos()).Offset
+	end := fset.Position(n.End()).Offset
+
+	if start < 0 || end > len(src) || start >= end {
+		return ""
+	}
+
+	return string(src[start:end])
+}

--- a/sdk/kronk/model/slot_reuse_isolation_test.go
+++ b/sdk/kronk/model/slot_reuse_isolation_test.go
@@ -1,0 +1,532 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// =============================================================================
+// Slot / sequence lifecycle and cross-request isolation.
+//
+// Every test in this file pins a field or an ordering that survives a slot
+// release and re-acquire when llama.cpp's reference lifecycle says it must
+// not. The reference is tools/server/server-context.cpp in .extras/llama.cpp
+// (b10211):
+//
+//   - server_slot::reset()        server-context.cpp:333  — the checklist of
+//                                per-request state that must be dropped.
+//   - server_slot::release()      server-context.cpp:524  — computes the
+//                                request's timings BEFORE calling reset().
+//   - server_slot::prompt_clear() server-context.cpp:291  — the KV clear
+//                                (mem.seq_rm(id,-1,-1) at :294) is ATOMIC with
+//                                clearing the slot's token bookkeeping.
+//   - update_slots()              server-context.cpp:3124 — re-zeroes
+//                                slot.t_start_generation when a slot picks up
+//                                a new prompt.
+//
+// Helper names here are suffixed to avoid collisions with the existing
+// source-analysis and mirror tests in this package. kronkRepoRoot,
+// parseKronkSource, findKronkFunc and srcPos are reused from
+// mtp_ctxparams_source_test.go.
+
+// =============================================================================
+
+// TestSlotResetClearsPerRequestClockAndSpecSnapshot pins two fields that
+// (*slot).reset() forgets, both of which llama.cpp's reference lifecycle
+// explicitly clears.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_slot.go:300  — func (s *slot) reset(), the
+//     complete list of fields dropped between requests. It never assigns
+//     s.startTime or s.specSnapshot.
+//   - sdk/kronk/model/batchgen_slot.go:293  — startTime declaration.
+//   - sdk/kronk/model/batchgen_slot.go:263  — specSnapshot declaration.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/tools/server/server-context.cpp:3124
+//     `slot.t_start_generation = 0;` — the generation clock is re-zeroed the
+//     moment a slot picks up a NEW prompt, precisely so a slot that never
+//     reaches generation cannot report the previous request's clock.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:349-351
+//     inside reset(): `spec_draft.clear(); spec_i_batch.clear();
+//     spec_ckpt.clear();` — the speculative checkpoint buffer (the direct
+//     analogue of Kronk's specSnapshot, a saved per-sequence state used to
+//     rewind a spec round) is dropped on every release.
+//
+// FAILURE SCENARIO — startTime
+//
+//	s.startTime is written exactly once per request, at
+//	batchgen_tokens.go:97, and only inside the `if !s.prefillDone` branch —
+//	i.e. only when the request produced its FIRST output token. reset() does
+//	not clear it, so it survives into the next request on the same slot.
+//
+//	finishSlot then reads it unconditionally at batchgen_finish.go:149-150:
+//
+//	    if !s.startTime.IsZero() {
+//	        elapsed = time.Since(s.startTime)
+//	    }
+//
+//	Request A generates on slot 0 and sets startTime. Request B lands on
+//	slot 0 and dies before its first token — context-window rejection
+//	(batchgen_slot_start.go:841), an IMC stale-session error
+//	(batchgen_slot_start.go:197), a client disconnect during prefill
+//	(batchgen_engine.go:375), a decode failure (batchgen_engine.go:471) or
+//	shutdown drain (batchgen_shutdown.go:27). B's error Usage and its
+//	"slot-finished" / "request-lifecycle" log lines are then computed from
+//	A's wall clock: `elapsed` spans both requests and TokensPerSecond
+//	(batchgen_finish.go:207-208, :326-327) is divided by an unrelated
+//	interval. The staleness is silent and unbounded — an idle slot makes it
+//	arbitrarily large.
+//
+// FAILURE SCENARIO — specSnapshot
+//
+//	specSnapshot is a serialized copy of the TARGET context's per-sequence
+//	state (llama.StateSeqGetData, batchgen_speculative.go:797) for the
+//	slot's seqID, captured before a speculative batch on a hybrid target
+//	(batchgen_engine.go:309). Its length is the "a snapshot exists" flag:
+//	finalizeSpeculativeTokens gates the rollback path on
+//	`len(s.specSnapshot) > 0` at batchgen_speculative.go:684 and, when set,
+//	feeds those bytes straight back into the live context via
+//	llama.StateSeqSetData (batchgen_speculative.go:823).
+//
+//	Because reset() leaves both the bytes and the length intact, a released
+//	slot hands the next request a populated, non-empty snapshot of the
+//	PREVIOUS conversation's sequence state. Today every capture site is
+//	paired with a verify site inside the same round, so the stale buffer is
+//	overwritten before it can be restored — but nothing in reset() or in the
+//	restore path enforces that pairing, and the failure mode if it ever
+//	breaks is a whole-sequence rollback to another conversation's KV. This
+//	is the one field on the slot that literally holds another request's KV
+//	bytes; llama.cpp clears its equivalent on every release
+//	(server-context.cpp:351) rather than relying on the pairing.
+func TestSlotResetClearsPerRequestClockAndSpecSnapshot(t *testing.T) {
+	t.Run("startTime", func(t *testing.T) {
+		// A slot that finished a request which reached generation.
+		prev := time.Now().Add(-42 * time.Minute)
+		s := slot{
+			id:        0,
+			seqID:     0,
+			startTime: prev,
+		}
+
+		s.reset()
+
+		if !s.startTime.IsZero() {
+			t.Errorf("slot.reset() left startTime = %v (want zero time)\n"+
+				"batchgen_slot.go:300 (reset) never clears the field declared at batchgen_slot.go:293.\n"+
+				"finishSlot reads it unconditionally at batchgen_finish.go:149-150, so the next\n"+
+				"request on this slot reports elapsed/TokensPerSecond measured from the PREVIOUS\n"+
+				"request's first token. llama.cpp re-zeroes the same clock when a slot picks up a\n"+
+				"new prompt: server-context.cpp:3124 `slot.t_start_generation = 0;`.",
+				s.startTime)
+		}
+	})
+
+	t.Run("specSnapshot", func(t *testing.T) {
+		// A slot that finished a request on a hybrid target, leaving a
+		// captured per-sequence state behind. The bytes stand in for a
+		// real llama.StateSeqGetData payload.
+		s := slot{
+			id:           0,
+			seqID:        0,
+			specSnapshot: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+		}
+
+		s.reset()
+
+		if len(s.specSnapshot) != 0 {
+			t.Errorf("slot.reset() left len(specSnapshot) = %d (want 0)\n"+
+				"batchgen_slot.go:300 (reset) never truncates the field declared at\n"+
+				"batchgen_slot.go:263. len(specSnapshot) is the \"a snapshot exists\" flag read at\n"+
+				"batchgen_speculative.go:684, and the bytes are pushed back into the live context\n"+
+				"by llama.StateSeqSetData at batchgen_speculative.go:823 — so a released slot hands\n"+
+				"the next request a restorable snapshot of the previous conversation's sequence\n"+
+				"state. llama.cpp clears the equivalent speculative checkpoint on every release:\n"+
+				"server-context.cpp:351 `spec_ckpt.clear();` inside reset().",
+				len(s.specSnapshot))
+		}
+	})
+}
+
+// =============================================================================
+
+// assembleDraftPromptMirror is a VERBATIM MIRROR of the draft-prompt assembly
+// in (*batchEngine).startSlotText:
+//
+//	sdk/kronk/model/batchgen_slot_start.go:902-935
+//
+//	  draft := e.model.draft.core()
+//	  ...
+//	  case job.imcCacheHit && job.imcSession != nil:
+//	      cachedLen = len(cached)
+//	      needed = cachedLen + len(tokens)
+//	      if cap(draft.promptBuf) >= needed {
+//	          draft.promptBuf = draft.promptBuf[:needed]
+//	      } else {
+//	          draft.promptBuf = make([]llama.Token, needed)
+//	      }
+//	      copy(draft.promptBuf, cached)
+//	      copy(draft.promptBuf[cachedLen:], tokens)
+//	  default:
+//	      needed = len(tokens)
+//	      if cap(draft.promptBuf) >= needed {
+//	          draft.promptBuf = draft.promptBuf[:needed]
+//	      } else {
+//	          draft.promptBuf = make([]llama.Token, needed)
+//	      }
+//	      copy(draft.promptBuf, tokens)
+//	  }
+//	  s.draftPromptTokens = draft.promptBuf
+//
+// startSlotText itself needs a loaded model (llama.Tokenize, otel spans, a
+// live sampler), so this mirror isolates the buffer handoff. It takes the REAL
+// draftCore type — the shared struct returned by drafter.core() — so the
+// aliasing being pinned is the production one, not a stand-in.
+//
+// MAINTAINER: when batchgen_slot_start.go:902-935 is fixed to copy into a
+// per-slot buffer, update this mirror in the same commit so it keeps tracking
+// the production code.
+func assembleDraftPromptMirror(draft *draftCore, cached, tokens []llama.Token) []llama.Token {
+	var needed int
+	var cachedLen int
+
+	switch {
+	case cached != nil:
+		cachedLen = len(cached)
+		needed = cachedLen + len(tokens)
+
+		if cap(draft.promptBuf) >= needed {
+			draft.promptBuf = draft.promptBuf[:needed]
+		} else {
+			draft.promptBuf = make([]llama.Token, needed)
+		}
+		copy(draft.promptBuf, cached)
+		copy(draft.promptBuf[cachedLen:], tokens)
+
+	default:
+		needed = len(tokens)
+
+		if cap(draft.promptBuf) >= needed {
+			draft.promptBuf = draft.promptBuf[:needed]
+		} else {
+			draft.promptBuf = make([]llama.Token, needed)
+		}
+		copy(draft.promptBuf, tokens)
+	}
+
+	return draft.promptBuf
+}
+
+// TestDraftPromptTokensAreSlotOwned pins a cross-request aliasing bug in the
+// slot lifecycle: two concurrently-starting slots are handed the SAME backing
+// array for their draft prompts.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_slot_start.go:935
+//     `s.draftPromptTokens = draft.promptBuf`
+//   - sdk/kronk/model/batchgen_slot_start.go:916-932 — the in-place refill of
+//     draft.promptBuf that precedes it.
+//   - sdk/kronk/model/model.go:137 — `promptBuf []llama.Token // Reusable
+//     buffer for assembling draft prompt tokens`, a single field on draftCore.
+//     drafter.core() returns the SAME draftCore to every slot
+//     (sdk/kronk/model/model.go:106-128), so promptBuf is engine-global, not
+//     per-slot.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/tools/server/server-context.cpp:333 (reset) and
+//     server-context.cpp:3116 (`const auto & input_tokens = slot.task->tokens;`)
+//     — every slot's prompt tokens live in that slot's own task
+//     (server_slot::task, reset at server-context.cpp:364 `task.reset()`).
+//     There is no server-wide scratch buffer that slots point into, so a
+//     second slot launching cannot alter a first slot's prompt.
+//
+// FAILURE SCENARIO
+//
+//	Separate-GGUF speculative decoding (classicDrafter; MTP skips this path,
+//	batchgen_slot_start.go:865-869). fillSlots assigns every pending job it
+//	can in ONE call — batchgen_schedule.go:43-63 loops over pendingJobs and
+//	gives each the first idle slot — so two startSlotText calls can run
+//	back to back inside a single processBatch iteration.
+//
+//	  1. Job A (long prompt) starts on slot 0. draft.promptBuf is grown to
+//	     A's length, filled with A's tokens, and slot0.draftPromptTokens is
+//	     pointed at it. draftPrefillNeeded = true
+//	     (batchgen_slot_start.go:941).
+//	  2. Job B starts on slot 1. cap(draft.promptBuf) is already >= B's
+//	     length, so line 917 reslices the SAME array and line 932 copies B's
+//	     tokens over A's. slot0.draftPromptTokens now reads B's tokens in
+//	     its leading positions and A's stale tail after them.
+//	  3. The draft prefill is deferred to the NEXT processBatch iteration
+//	     and gated on s.prefillDone (batchgen_engine.go:218-228), so a slot
+//	     with a multi-chunk prompt loses the race by construction.
+//	     prefillDraft (batchgen_speculative.go:17) then decodes that mixed
+//	     token sequence into slot 0's DRAFT KV sequence, and persists it as
+//	     s.draftCachedTokens (batchgen_speculative.go:103-107) — a field
+//	     reset() deliberately keeps across requests
+//	     (batchgen_slot.go:343).
+//
+//	Slot 0's drafter is now conditioned on another conversation's prompt.
+//	Every subsequent round drafts from it, acceptance collapses, and
+//	s.specAccEMA — which also persists across requests on the slot
+//	(batchgen_slot.go:163) — latches speculation off for the slot's whole
+//	lifetime except for the periodic probe (chooseNDraft,
+//	batchgen_speculative.go:147-152). The next request's prefillDraft
+//	compares its prompt against the poisoned draftCachedTokens, so the
+//	wrong-conversation prefix keeps being "reused" until a divergence is
+//	found.
+//
+//	The fix is a per-slot buffer, exactly as was already done for
+//	draftTokensBuf / draftDistBuf / draftCandDistBuf
+//	(batchgen_slot.go:167-171: "Per-slot owned buffers for speculative
+//	decoding. Avoids shared buffer corruption when multiple slots generate
+//	draft tokens in the same processBatch iteration."). draftPromptTokens
+//	was missed.
+func TestDraftPromptTokensAreSlotOwned(t *testing.T) {
+	t.Run("mirror-two-slots-share-one-array", func(t *testing.T) {
+		// One shared draftCore, as returned by drafter.core() for every slot.
+		draft := &draftCore{}
+
+		tokensA := []llama.Token{10, 11, 12, 13, 14, 15, 16, 17}
+		tokensB := []llama.Token{90, 91, 92, 93}
+
+		wantA := append([]llama.Token(nil), tokensA...)
+
+		// Job A starts on slot 0.
+		slotA := slot{id: 0, seqID: 0}
+		slotA.draftPromptTokens = assembleDraftPromptMirror(draft, nil, tokensA)
+
+		// Job B starts on slot 1 in the same fillSlots pass. B's prompt is
+		// shorter, so cap(draft.promptBuf) already suffices and the array is
+		// refilled in place.
+		slotB := slot{id: 1, seqID: 1}
+		slotB.draftPromptTokens = assembleDraftPromptMirror(draft, nil, tokensB)
+
+		for i := range wantA {
+			if i >= len(slotA.draftPromptTokens) || slotA.draftPromptTokens[i] != wantA[i] {
+				t.Fatalf("slot 0 draftPromptTokens = %v, want %v\n"+
+					"batchgen_slot_start.go:935 aliases the engine-global draft.promptBuf\n"+
+					"(model.go:137) onto every slot, and batchgen_slot_start.go:916-932 refills it\n"+
+					"in place for the next slot that starts. prefillDraft\n"+
+					"(batchgen_speculative.go:17) decodes this slice into slot 0's draft KV and\n"+
+					"persists it as s.draftCachedTokens, so slot 0's drafter runs on another\n"+
+					"conversation's prompt. llama.cpp keeps each slot's prompt in its own\n"+
+					"server_slot::task (server-context.cpp:3116, reset at server-context.cpp:364).",
+					slotA.draftPromptTokens, wantA)
+			}
+		}
+
+		if len(slotB.draftPromptTokens) != len(tokensB) {
+			t.Fatalf("mirror is out of sync with production: slot 1 got %d tokens, want %d",
+				len(slotB.draftPromptTokens), len(tokensB))
+		}
+	})
+
+	t.Run("source-no-shared-buffer-aliased-onto-slot", func(t *testing.T) {
+		root := kronkRepoRoot(t)
+		path := filepath.Join(root, "sdk", "kronk", "model", "batchgen_slot_start.go")
+
+		fset := token.NewFileSet()
+		f := parseKronkSource(t, fset, path)
+		fn := findKronkFunc(t, f, path, "startSlotText")
+
+		var hits []string
+		ast.Inspect(fn, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for i, lhs := range assign.Lhs {
+				if !isSelectorPathIsolation(lhs, "s", "draftPromptTokens") {
+					continue
+				}
+				if i >= len(assign.Rhs) {
+					continue
+				}
+				if isSelectorPathIsolation(assign.Rhs[i], "draft", "promptBuf") {
+					hits = append(hits, srcPos(fset, root, assign.Pos()))
+				}
+			}
+			return true
+		})
+
+		if len(hits) > 0 {
+			t.Errorf("startSlotText aliases the shared draftCore.promptBuf onto the slot at %v\n"+
+				"draftCore is engine-global (drafter.core() returns the same struct to every\n"+
+				"slot, model.go:106-128) and promptBuf is refilled in place by the next slot to\n"+
+				"start (batchgen_slot_start.go:916-932). The slot must own its draft prompt\n"+
+				"buffer, as draftTokensBuf / draftDistBuf / draftCandDistBuf already do\n"+
+				"(batchgen_slot.go:167-171). llama.cpp keeps prompt tokens in the per-slot\n"+
+				"server_slot::task (server-context.cpp:3116).", hits)
+		}
+	})
+}
+
+// isSelectorPathIsolation reports whether expr is exactly `recv.field`.
+func isSelectorPathIsolation(expr ast.Expr, recv, field string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != field {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+
+	return ok && ident.Name == recv
+}
+
+// =============================================================================
+
+// TestPrefillStagingLoopDoesNotReleaseSlots pins the ordering hazard that lets
+// a released slot's tokens be decoded back into the sequence finishSlot just
+// cleared.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_engine.go:366-396 — the text-prefill staging
+//     loop. Rows are pushed into the SHARED e.batch by addPrefillChunk
+//     (batchgen_prefill_text.go:60-64: `e.batch.Add(tok, s.nPast, s.seqIDs,
+//     isLast)`), and the loop makes MULTIPLE passes over e.slots.
+//   - sdk/kronk/model/batchgen_engine.go:375 — `e.finishSlot(s,
+//     s.job.ctx.Err())` inside that loop.
+//   - sdk/kronk/model/batchgen_engine.go:381 — `e.finishSlot(s,
+//     e.slotCancelError(s))` inside that loop.
+//   - sdk/kronk/model/batchgen_finish.go:179 — finishSlot's
+//     `llama.MemorySeqRm(e.model.mem, s.seqID, -1, -1)`.
+//   - sdk/kronk/model/batchgen_engine.go:458 — the single
+//     `llama.Decode(e.model.lctx, e.batch)` for the whole iteration.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/tools/server/server-context.cpp:291-296
+//     `prompt_clear()` — `mem.seq_rm(id, -1, -1)` is executed together with
+//     `prompt.clear()`. The KV wipe and the slot's record of what is in that
+//     KV are dropped atomically; nothing may be in flight against the
+//     sequence across the wipe.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:1449-1450 —
+//     update_slots() runs as its own queue callback. Cancellations are
+//     applied in process_single_task BEFORE update_slots builds the batch, so
+//     a slot is never released between `batch.add(...)` (e.g.
+//     server-context.cpp:1339-1342) and the decode that consumes the batch.
+//   - .extras/llama.cpp/tools/server/server-context.cpp:3418-3423 — and even
+//     if stray cells existed, every prompt launch re-trims
+//     `slot.mem.seq_rm(slot.id, p0, -1)` past the validated common prefix.
+//     Kronk has no such re-trim: startSlot ASSUMES the sequence is empty.
+//
+// FAILURE SCENARIO
+//
+//	The staging loop at batchgen_engine.go:366 iterates until no slot adds
+//	tokens. A slot with a prompt longer than NUBatch is visited on pass 1
+//	(rows staged into e.batch, s.nPast advanced) and again on pass 2. If the
+//	client disconnects between the two passes, pass 2 takes the
+//	batchgen_engine.go:374 branch (or addPrefillChunk returns false on its
+//	own ctx.Done() check, batchgen_prefill_text.go:24) and finishSlot runs.
+//
+//	finishSlot clears the sequence (batchgen_finish.go:179) and resets the
+//	slot — but it cannot un-stage the rows already sitting in e.batch, and
+//	e.batch is only cleared at the TOP of the next iteration
+//	(batchgen_engine.go:201). The decode at batchgen_engine.go:458 therefore
+//	writes the dead request's prompt tokens back into the sequence that was
+//	just wiped.
+//
+//	fillSlots runs at batchgen_engine.go:418 — after the staging loop and
+//	still BEFORE that decode — and hands the now-idle slot the next pending
+//	job (batchgen_schedule.go:51-58). startSlot clears the sequence again
+//	(batchgen_slot_start.go:494) or restores an IMC snapshot over it
+//	(batchgen_slot_start.go:221; llama_state_seq_set_data itself seq_rm's the
+//	destination, .extras/llama.cpp/src/llama-kv-cache.cpp:2407) and stages
+//	the NEW prompt from position 0. Both sets of rows then go through the one
+//	llama.Decode with the same seq id, so the new conversation's sequence
+//	ends up holding the cancelled request's tokens at positions >= its own
+//	nPast. Those cells are never overwritten — llama.cpp's KV appends by
+//	slot rather than by (seq, pos), as batchgen_speculative.go:947-952 already
+//	documents — so as generation walks past them the causal mask admits them
+//	and the model attends to the other conversation's text. That is the
+//	reported "the model's context changed mid-conversation" symptom, and
+//	nothing downstream can detect it because Kronk keeps no per-sequence
+//	token list to validate the KV against.
+//
+//	Either fix satisfies this test: hoist the cancellation check so a slot
+//	is released before it stages anything for the iteration (llama.cpp's
+//	arrangement), or make finishSlot/reset neutralize the slot's already
+//	staged rows.
+func TestPrefillStagingLoopDoesNotReleaseSlots(t *testing.T) {
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "batchgen_engine.go")
+
+	fset := token.NewFileSet()
+	f := parseKronkSource(t, fset, path)
+	fn := findKronkFunc(t, f, path, "processBatch")
+
+	// Locate the staging loop: the for-statement whose body calls
+	// e.addPrefillChunk. Located structurally, not by line number.
+	var loop *ast.ForStmt
+	ast.Inspect(fn, func(n ast.Node) bool {
+		forStmt, ok := n.(*ast.ForStmt)
+		if !ok || loop != nil {
+			return true
+		}
+		if callsEngineMethodIsolation(forStmt, "addPrefillChunk") {
+			loop = forStmt
+		}
+		return true
+	})
+
+	if loop == nil {
+		t.Fatal("no for-statement calling e.addPrefillChunk found in processBatch: " +
+			"the prefill staging loop this test pins no longer exists; re-point it")
+	}
+
+	// Sanity check that the loop really does stage into the shared batch, so
+	// a refactor that moves the staging elsewhere fails loudly instead of
+	// silently passing.
+	if !callsEngineMethodIsolation(loop, "addPrefillChunk") {
+		t.Fatal("staging loop no longer calls addPrefillChunk")
+	}
+
+	var releases []string
+	ast.Inspect(loop, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isSelectorPathIsolation(call.Fun, "e", "finishSlot") {
+			releases = append(releases, srcPos(fset, root, call.Pos()))
+		}
+		return true
+	})
+
+	if len(releases) > 0 {
+		t.Errorf("processBatch releases slots from inside the prefill staging loop at %v\n"+
+			"The loop stages rows into the shared e.batch via addPrefillChunk\n"+
+			"(batchgen_prefill_text.go:60-64) and makes multiple passes over e.slots. A\n"+
+			"finishSlot on pass N+1 wipes the slot's KV sequence (batchgen_finish.go:179) but\n"+
+			"cannot un-stage the rows added on pass N; e.batch is only cleared at the top of\n"+
+			"the NEXT iteration (batchgen_engine.go:201). The single decode at\n"+
+			"batchgen_engine.go:458 therefore writes the dead request's tokens back into the\n"+
+			"sequence that was just cleared — and fillSlots (batchgen_engine.go:418) may\n"+
+			"already have started the next conversation on that same slot and seq id before\n"+
+			"the decode runs.\n"+
+			"llama.cpp never releases a slot between staging and decode: cancellations are\n"+
+			"applied before update_slots builds the batch (server-context.cpp:1449-1450), and\n"+
+			"prompt_clear() drops the KV and the slot's token bookkeeping atomically\n"+
+			"(server-context.cpp:291-296).", releases)
+	}
+}
+
+// callsEngineMethodIsolation reports whether n contains a call to e.<name>.
+func callsEngineMethodIsolation(n ast.Node, name string) bool {
+	found := false
+	ast.Inspect(n, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || found {
+			return true
+		}
+		if isSelectorPathIsolation(call.Fun, "e", name) {
+			found = true
+		}
+		return true
+	})
+
+	return found
+}

--- a/sdk/kronk/model/speculative_verify_index_test.go
+++ b/sdk/kronk/model/speculative_verify_index_test.go
@@ -1,0 +1,497 @@
+package model
+
+import (
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// =============================================================================
+// Speculative verify loop — position arithmetic and sampler-accept bookkeeping.
+//
+// Both regressions pinned here live inside (*batchEngine).verifySpeculativeTokens
+// and (*batchEngine).finalizeSpeculativeTokens, which cannot be called without a
+// live llama.Context holding a decoded speculative batch: every branch begins
+// with llama.GetLogitsIth / llama.SamplerSample against e.model.lctx. Following
+// the convention established by rollback_draft_test.go, the pure arithmetic and
+// the pure control flow are extracted into VERBATIM MIRRORS below, each citing
+// the production line it mirrors, and the mirrors are pinned instead.
+//
+// The mirrors are backed by an AST guard (TestVerifyLoopSamplerAcceptIsNotDoubled
+// subtest "production-shape") so they cannot silently drift away from the code
+// they claim to mirror.
+//
+// Reference semantics used as ground truth throughout:
+//
+//   - Spec batch layout. Kronk (batchgen_engine.go:284-287) and llama.cpp
+//     (tools/server/server-context.cpp:504-516) build the identical batch:
+//     row baseBatch+0 = s.sampled at position basePast, row baseBatch+1+k =
+//     draft[k] at position basePast+1+k. Both request logits on all 1+nDraft
+//     rows.
+//   - Logits index. llama_get_logits_ith takes the ORIGINAL BATCH TOKEN INDEX
+//     and translates it through output_ids (src/llama-context.cpp:853-858), so
+//     Kronk's baseBatch+i indices are the correct addressing mode. Verified —
+//     no finding here beyond the already-known §6e hybrid-restore case.
+//   - Draft width. common/speculative.cpp:1343-1346 caps n_max at the number of
+//     nextn layers ONLY for chain_heads models (n_mtp_layers > 1). For a single
+//     trained head (qwen35moe, nextn_predict_layers=1 in the shipped
+//     mtp-Qwen3.6-35B-A3B GGUF) chain_heads is false, no cap is applied, and
+//     speculative.cpp:1641 re-feeds the head its own previous hidden row at
+//     dp.n_past+i+1 — exactly what generateDraftTokensMTP does. Upstream's own
+//     default width is n_max=3 (common/common.h:325), above Kronk's
+//     defMTPNDraft=2. Autoregressive multi-token drafting from one head is the
+//     reference behaviour, so there is deliberately NO test asserting
+//     nDraft <= nextn_predict_layers.
+
+// verifyAcceptNPast is a VERBATIM MIRROR of the in-loop s.nPast update performed
+// by (*batchEngine).verifySpeculativeTokens for each ACCEPTED draft token:
+//
+//	sdk/kronk/model/batchgen_speculative.go:454   (greedy / MTP branch)
+//		s.nPast = basePast + llama.Pos(1+i)
+//
+//	sdk/kronk/model/batchgen_speculative.go:507   (sparse probabilistic branch)
+//		s.nPast = basePast + llama.Pos(1+i)
+//
+//	sdk/kronk/model/batchgen_speculative.go:564   (full-vocab probabilistic branch)
+//		s.nPast = basePast + llama.Pos(1+i)
+//
+// `i` is the loop index over draftTokens, so it is the index of the draft token
+// that was just accepted and emitted.
+//
+// MAINTAINER: when batchgen_speculative.go:454/507/564 is fixed, update this
+// mirror in the same commit so it keeps tracking the production formula.
+func verifyAcceptNPast(basePast llama.Pos, i int) llama.Pos {
+	return basePast + llama.Pos(1+i)
+}
+
+// finalizeAcceptedNPast is a VERBATIM MIRROR of the authoritative post-round
+// s.nPast update performed by (*batchEngine).finalizeSpeculativeTokens:
+//
+//	sdk/kronk/model/batchgen_speculative.go:740
+//		s.nPast = basePast + llama.Pos(1+accepted)
+//
+// It is also the formula the rollback range is derived from at
+// batchgen_speculative.go:682 (rollbackFrom), so it is the value the target KV
+// is actually trimmed to.
+//
+// MAINTAINER: keep in lock-step with batchgen_speculative.go:740.
+func finalizeAcceptedNPast(basePast llama.Pos, accepted int) llama.Pos {
+	return basePast + llama.Pos(1+accepted)
+}
+
+// TestVerifyLoopNPastAgreesWithFinalizeNPast pins a position-arithmetic
+// off-by-one inside the speculative verify loop.
+//
+// FINDING
+// The in-loop s.nPast update in Phase A is one KV cell BEHIND the authoritative
+// Phase B update for the same state. After accepting draft token `i` the slot
+// has emitted i+1 draft tokens, so `accepted == i+1`, and the two formulas must
+// name the same next-write position. They do not: Phase A writes
+// basePast+1+i while Phase B writes basePast+1+(i+1) == basePast+2+i.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_speculative.go:454 (greedy / MTP verify branch)
+//   - sdk/kronk/model/batchgen_speculative.go:507 (sparse verify branch)
+//   - sdk/kronk/model/batchgen_speculative.go:564 (full-vocab verify branch)
+//   - sdk/kronk/model/batchgen_speculative.go:740 (authoritative Phase B value)
+//
+// LLAMA.CPP REFERENCE
+// tools/server/server-context.cpp:3936-3942. Upstream reconstructs the prompt
+// after verification as
+//
+//	slot.prompt.tokens.keep_first(slot.prompt.n_tokens() - n_draft);   // :3936
+//	slot.prompt.tokens.insert({ids.begin(), ids.end() - 1});           // :3937
+//	slot.mem.seq_rm(slot.id, slot.prompt.tokens.pos_next(), -1);       // :3942
+//
+// With P == basePast before the round, handle_last_sampled_token
+// (server-context.cpp:504-516) grew the prompt to P+1+n_draft; keep_first then
+// leaves P+1 and inserting the n_accepted accepted tokens leaves P+1+n_accepted.
+// So `pos_next() == basePast + 1 + accepted` is upstream's next write position —
+// which is exactly Kronk's Phase B formula and exactly what the KV was trimmed
+// to. The Phase A formula is one short.
+//
+// The batch layout confirms it independently: row baseBatch+k of the spec batch
+// carries position basePast+k (batchgen_engine.go:284-287), so after draft[i] is
+// accepted the KV holds positions basePast .. basePast+1+i INCLUSIVE and the
+// next free cell is basePast+2+i.
+//
+// CONCRETE FAILURE SCENARIO
+// Today the wrong value is always overwritten by Phase B a few statements later,
+// so it is a latent landmine rather than a live corruption — but it is only
+// latent because of an ordering that the Phase A doc comment itself says does
+// not hold ("does NOT advance s.nPast — those are deferred to
+// finalizeSpeculativeTokens"). Anything that observes s.nPast between Phase A
+// and Phase B sees a sequence one cell shorter than the real KV:
+//
+//   - Phase A calls handleSpeculativeToken per accepted token
+//     (batchgen_speculative.go:455), which reaches finishSlot on EOG /
+//     MaxTokens / a stream error. Phase B is then skipped entirely
+//     (specPendingFinalize stays false), so on those paths s.nPast is left
+//     permanently one cell behind the KV contents.
+//   - The batch-overflow diagnostic (batchgen_engine.go:440) and the
+//     verify-done log (batchgen_speculative.go:752) both report s.nPast.
+//   - Adding the missing context-length guard (findings §6b) at any point
+//     between the two phases would compute the wrong remaining window.
+//
+// Because llama.cpp appends rather than overwrites by (seq, pos), an nPast that
+// under-counts the KV is the precise precondition for phantom tokens: the next
+// decode re-uses a position that already holds a cell.
+//
+// The fix is to delete the three in-loop assignments (Phase A is documented as
+// non-mutating for nPast) or to write basePast+llama.Pos(2+i).
+func TestVerifyLoopNPastAgreesWithFinalizeNPast(t *testing.T) {
+	tests := []struct {
+		name      string
+		basePast  llama.Pos
+		nDraft    int
+		acceptIdx int // index of the draft token just accepted and emitted
+	}{
+		{
+			name:      "first of two drafts accepted",
+			basePast:  1000,
+			nDraft:    2,
+			acceptIdx: 0,
+		},
+		{
+			name:      "both of two drafts accepted",
+			basePast:  1000,
+			nDraft:    2,
+			acceptIdx: 1,
+		},
+		{
+			name:      "single draft accepted",
+			basePast:  4095,
+			nDraft:    1,
+			acceptIdx: 0,
+		},
+		{
+			name:      "third of three drafts accepted",
+			basePast:  0,
+			nDraft:    3,
+			acceptIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.acceptIdx < 0 || tt.acceptIdx >= tt.nDraft {
+				t.Fatalf("bad test case: acceptIdx %d outside [0,%d)", tt.acceptIdx, tt.nDraft)
+			}
+
+			// The verify loop increments `accepted` immediately before it
+			// updates s.nPast (batchgen_speculative.go:452-454), so accepting
+			// draft index i means accepted == i+1.
+			accepted := tt.acceptIdx + 1
+
+			// Ground truth from the spec batch layout: row baseBatch+k holds
+			// position basePast+k, so accepting draft[acceptIdx] leaves the KV
+			// occupied through basePast+1+acceptIdx inclusive.
+			lastOccupied := tt.basePast + llama.Pos(1+tt.acceptIdx)
+			wantNext := lastOccupied + 1
+
+			gotPhaseB := finalizeAcceptedNPast(tt.basePast, accepted)
+			if gotPhaseB != wantNext {
+				t.Fatalf("mirror of batchgen_speculative.go:740 is out of date: "+
+					"got %d, want %d (basePast %d, accepted %d)",
+					gotPhaseB, wantNext, tt.basePast, accepted)
+			}
+
+			gotPhaseA := verifyAcceptNPast(tt.basePast, tt.acceptIdx)
+
+			if gotPhaseA != gotPhaseB {
+				t.Errorf("Phase A nPast = %d, Phase B nPast = %d (off by %d)\n"+
+					"batchgen_speculative.go:454 (and :507, :564) compute\n"+
+					"\ts.nPast = basePast + llama.Pos(1+i)\n"+
+					"for the token at draft index i, while batchgen_speculative.go:740 "+
+					"computes the authoritative value\n"+
+					"\ts.nPast = basePast + llama.Pos(1+accepted)\n"+
+					"with accepted == i+1. Both describe the same state, so they must agree.\n"+
+					"Ground truth: the spec batch put s.sampled at basePast and draft[k] at "+
+					"basePast+1+k (batchgen_engine.go:284-287), so accepting draft[%d] leaves "+
+					"the KV occupied through position %d and the next write position is %d. "+
+					"llama.cpp derives the same value as prompt.tokens.pos_next() after "+
+					"keep_first/insert (tools/server/server-context.cpp:3936-3942).\n"+
+					"Phase A's value under-counts the KV by one cell. It is masked only "+
+					"because Phase B overwrites it — but Phase B is skipped whenever Phase A's "+
+					"handleSpeculativeToken (batchgen_speculative.go:455) reaches finishSlot "+
+					"(EOG / MaxTokens / stream error), and every reader between the two phases "+
+					"sees the short value.\n"+
+					"Fix: drop the three in-loop assignments (Phase A is documented at "+
+					"batchgen_speculative.go:297-299 as NOT advancing s.nPast) or write "+
+					"basePast + llama.Pos(2+i).",
+					gotPhaseA, gotPhaseB, int(gotPhaseB-gotPhaseA), tt.acceptIdx, lastOccupied, wantNext)
+			}
+		})
+	}
+}
+
+// specRoundSamplerAccepts is a VERBATIM MIRROR of the llama_sampler_accept
+// bookkeeping performed by one MTP (greedy-forced) speculative round. It returns
+// the tokens Kronk EMITS through the streaming pipeline and, separately, every
+// token that reaches the slot's sampler chain via llama_sampler_accept.
+//
+// The mirrored production statements, in execution order:
+//
+//	sdk/kronk/model/batchgen_speculative.go:433
+//		targetTok = llama.SamplerSample(s.sampler, e.model.lctx, baseBatch+int32(i))
+//	  -> yzma SamplerSample (.extras/yzma/pkg/llama/sampling.go:574-583) is a thin
+//	     FFI wrapper over llama_sampler_sample, which ENDS WITH
+//	     llama_sampler_accept(smpl, token) (.extras/llama.cpp/src/llama-sampler.cpp:873).
+//	     So sampling a position already accepts that token into the chain.
+//
+//	sdk/kronk/model/batchgen_speculative.go:451-455 (draft accepted)
+//		if draftToken == targetTok { ... e.handleSpeculativeToken(s, draftToken, ...) }
+//	  -> handleSpeculativeToken (batchgen_tokens.go:245-247) -> handleSampledToken
+//	     -> llama.SamplerAccept(s.sampler, token) (batchgen_tokens.go:63).
+//	     A SECOND accept of the same token.
+//
+//	sdk/kronk/model/batchgen_speculative.go:465-466 (draft rejected)
+//		bonusToken = targetTok; break
+//	  -> no further sampler call; targetTok was already accepted at :433.
+//
+//	sdk/kronk/model/batchgen_speculative.go:593-595 (all drafts accepted)
+//		case greedy: ... bonusToken = argmax(targetLogits)
+//	  -> argmax (batchgen_speculative.go:865) touches no sampler, so the bonus
+//	     token is NOT implicitly accepted on this path.
+//
+//	sdk/kronk/model/batchgen_speculative.go:762
+//		e.handleSpeculativeToken(s, bonusToken, baseBatch+int32(accepted), buf)
+//	  -> one accept of the bonus token via batchgen_tokens.go:63.
+//
+// targetSampled[i] is the token the target model selects at spec-batch row
+// baseBatch+i; it must have len(draft)+1 entries (the bonus row included).
+//
+// MAINTAINER: this mirror encodes the SHAPE of the production code, not just its
+// arithmetic. The "production-shape" subtest of
+// TestVerifyLoopSamplerAcceptIsNotDoubled re-derives that shape from the AST, so
+// update both together.
+func specRoundSamplerAccepts(draft []llama.Token, targetSampled []llama.Token) (emitted []llama.Token, accepts []llama.Token) {
+	accepted := 0
+	var bonusToken llama.Token
+
+	for i := range draft {
+		// batchgen_speculative.go:433 -> src/llama-sampler.cpp:873.
+		targetTok := targetSampled[i]
+		accepts = append(accepts, targetTok)
+
+		if draft[i] == targetTok {
+			accepted++
+
+			// batchgen_speculative.go:455 -> batchgen_tokens.go:63.
+			emitted = append(emitted, draft[i])
+			accepts = append(accepts, draft[i])
+
+			continue
+		}
+
+		// batchgen_speculative.go:465-466.
+		bonusToken = targetTok
+
+		break
+	}
+
+	if accepted == len(draft) {
+		// batchgen_speculative.go:593-595: raw argmax, no sampler call.
+		bonusToken = targetSampled[len(draft)]
+	}
+
+	// batchgen_speculative.go:762 -> batchgen_tokens.go:63.
+	emitted = append(emitted, bonusToken)
+	accepts = append(accepts, bonusToken)
+
+	return emitted, accepts
+}
+
+// TestVerifyLoopSamplerAcceptIsNotDoubled pins a sampler-state divergence in the
+// speculative verify loop: every token it emits is accepted into the slot's
+// sampler chain TWICE, and the MTP bonus token on a fully-accepted round is
+// accepted only ONCE, so the penalty history is a non-uniform distortion of the
+// text the model actually produced.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_speculative.go:433 (verify-position sample; also
+//     :431 grammar variant, :442, :493, :536, :590)
+//   - sdk/kronk/model/batchgen_tokens.go:63 (the explicit second accept)
+//   - sdk/kronk/model/batchgen_speculative.go:595 (bonus token via argmax — the
+//     one emitted token that is NOT double-accepted)
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/src/llama-sampler.cpp:873 — llama_sampler_sample ends
+//     with `llama_sampler_accept(smpl, token);`. Sampling accepts.
+//   - .extras/llama.cpp/common/sampling.cpp:646-674 — the reference verify loop
+//     `common_sampler_sample_and_accept_n` therefore does NOT call
+//     llama_sampler_sample. It calls common_sampler_sample (which uses
+//     llama_sampler_apply directly, common/sampling.cpp:600-644) and then
+//     exactly one `common_sampler_accept(gsmpl, id, true)` per token it returns
+//     (common/sampling.cpp:655 and :670). Upstream emits every token in `ids`
+//     (tools/server/server-context.cpp:3944-3961), so accepts == emitted, once
+//     each. That 1:1 invariant is the contract this test asserts.
+//
+// MECHANISM
+// llama_sampler_chain_accept forwards to every sampler in the chain
+// (src/llama-sampler.cpp:634-644). Kronk's chain (params.go:763-828) includes
+// llama_sampler_init_penalties whenever repeat_penalty != 1.0 ||
+// frequency_penalty != 0 || presence_penalty != 0 (params.go:784-788) and
+// llama_sampler_init_dry when dry_multiplier > 0 (params.go:790-793) — the only
+// two stateful samplers in the chain. llama_sampler_penalties_accept
+// (src/llama-sampler.cpp:2657-2676) increments token_count[token] and pushes
+// onto a ring buffer bounded by penalty_last_n. Double-accepting therefore
+// halves the effective penalty window (repeat_last_n 64 covers ~32 real tokens)
+// and doubles every repeat/frequency/presence count.
+//
+// CONCRETE FAILURE SCENARIO
+// A request that sets any penalty parameter (frequency_penalty and
+// presence_penalty are standard OpenAI-compatible fields, so most clients send
+// them) runs with a penalty history that no longer matches the emitted text. On
+// MTP the distortion is not even uniform: with defMTPNDraft=2 and the ~0.71
+// acceptance measured on mtp-Qwen3.6-35B-A3B, a fully-accepted round contributes
+// 2 accepts for each of its 2 draft tokens but only 1 for the bonus token
+// (batchgen_speculative.go:595 uses argmax and never touches the sampler), while
+// a rejected round contributes 2 for the rejected position's token. The ring
+// buffer thus advances at a rate that depends on the acceptance rate, so the
+// window over recent text expands and contracts as acceptance drifts — long
+// generations drift away from the penalty state the same text would have
+// produced without speculation.
+//
+// Fix: make the token source and the accept a single step. Either drop
+// llama.SamplerAccept at batchgen_tokens.go:63 (accepting that
+// llama.SamplerSample already did it, and adding an explicit accept only on the
+// paths that bypass it, e.g. argmax), or stop using llama.SamplerSample and
+// mirror common_sampler_sample with llama.SamplerApply + one explicit
+// llama.SamplerAccept — which is also what §1's grammar fix needs.
+func TestVerifyLoopSamplerAcceptIsNotDoubled(t *testing.T) {
+	t.Run("accept-count", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			draft         []llama.Token
+			targetSampled []llama.Token
+		}{
+			{
+				name:          "both drafts accepted, bonus via argmax",
+				draft:         []llama.Token{101, 102},
+				targetSampled: []llama.Token{101, 102, 103},
+			},
+			{
+				name:          "first draft accepted, second rejected",
+				draft:         []llama.Token{101, 102},
+				targetSampled: []llama.Token{101, 999, 103},
+			},
+			{
+				name:          "first draft rejected",
+				draft:         []llama.Token{101, 102},
+				targetSampled: []llama.Token{999, 102, 103},
+			},
+			{
+				name:          "single draft accepted",
+				draft:         []llama.Token{101},
+				targetSampled: []llama.Token{101, 102},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if len(tt.targetSampled) != len(tt.draft)+1 {
+					t.Fatalf("bad test case: targetSampled must hold len(draft)+1 = %d rows, got %d",
+						len(tt.draft)+1, len(tt.targetSampled))
+				}
+
+				emitted, accepts := specRoundSamplerAccepts(tt.draft, tt.targetSampled)
+
+				if len(emitted) == 0 {
+					t.Fatal("mirror produced no emitted tokens; every verify round emits at least the bonus token")
+				}
+
+				// llama.cpp's contract: common_sampler_sample_and_accept_n
+				// accepts exactly the tokens it returns, once each, in order
+				// (common/sampling.cpp:653-672), and the server emits all of
+				// them (tools/server/server-context.cpp:3944-3961).
+				if len(accepts) != len(emitted) {
+					t.Errorf("sampler accepts = %v (%d), emitted tokens = %v (%d)\n"+
+						"llama.cpp accepts exactly one token per emitted token "+
+						"(common/sampling.cpp:646-674, accept at :655 and :670).\n"+
+						"Kronk accepts %d times for %d emitted tokens because "+
+						"batchgen_speculative.go:433 uses llama.SamplerSample, whose C "+
+						"implementation already calls llama_sampler_accept "+
+						"(.extras/llama.cpp/src/llama-sampler.cpp:873), and then "+
+						"batchgen_tokens.go:63 accepts the same token again.\n"+
+						"llama_sampler_chain_accept forwards to every sampler "+
+						"(src/llama-sampler.cpp:634-644), so the penalties ring buffer "+
+						"(src/llama-sampler.cpp:2657-2676) and DRY see each token twice: "+
+						"repeat_last_n=64 covers ~32 real tokens and every "+
+						"repeat/frequency/presence count is doubled.\n"+
+						"Note the distortion is NOT uniform — the bonus token on a "+
+						"fully-accepted round is produced by argmax "+
+						"(batchgen_speculative.go:595), which touches no sampler, so it is "+
+						"accepted once while every other token is accepted twice. The "+
+						"penalty window therefore advances at a rate that depends on the "+
+						"acceptance rate.",
+						accepts, len(accepts), emitted, len(emitted), len(accepts), len(emitted))
+
+					return
+				}
+
+				for i := range emitted {
+					if accepts[i] != emitted[i] {
+						t.Errorf("accept[%d] = %d, emitted[%d] = %d: the accepted sequence must be "+
+							"the emitted sequence (common/sampling.cpp:653-672)",
+							i, accepts[i], i, emitted[i])
+					}
+				}
+			})
+		}
+	})
+
+	// production-shape re-derives from the AST the two facts the mirror above
+	// encodes, so the mirror cannot silently stop describing the code. It fails
+	// while BOTH halves of the double accept are present and passes once either
+	// half is removed.
+	t.Run("production-shape", func(t *testing.T) {
+		root := kronkRepoRoot(t)
+		dir := filepath.Join(root, "sdk", "kronk", "model")
+
+		fset := token.NewFileSet()
+
+		specPath := filepath.Join(dir, "batchgen_speculative.go")
+		specFile := parseKronkSource(t, fset, specPath)
+		verify := findKronkFunc(t, specFile, specPath, "verifySpeculativeTokens")
+
+		tokensPath := filepath.Join(dir, "batchgen_tokens.go")
+		tokensFile := parseKronkSource(t, fset, tokensPath)
+		handle := findKronkFunc(t, tokensFile, tokensPath, "handleSampledToken")
+
+		var sampleSites []string
+		ast.Inspect(verify, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if ok && isLlamaCall(call, "SamplerSample") {
+				sampleSites = append(sampleSites, srcPos(fset, root, call.Pos()))
+			}
+			return true
+		})
+
+		var acceptSites []string
+		ast.Inspect(handle, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if ok && isLlamaCall(call, "SamplerAccept") {
+				acceptSites = append(acceptSites, srcPos(fset, root, call.Pos()))
+			}
+			return true
+		})
+
+		if len(sampleSites) > 0 && len(acceptSites) > 0 {
+			t.Errorf("double sampler accept still present.\n"+
+				"verifySpeculativeTokens obtains its target tokens with llama.SamplerSample at %v, "+
+				"and llama_sampler_sample accepts the token it returns "+
+				"(.extras/llama.cpp/src/llama-sampler.cpp:873).\n"+
+				"handleSampledToken then accepts the same token again with llama.SamplerAccept at %v.\n"+
+				"llama.cpp's verify loop accepts exactly once per emitted token: it samples via "+
+				"common_sampler_sample (llama_sampler_apply, no accept) and calls "+
+				"common_sampler_accept once (common/sampling.cpp:646-674).\n"+
+				"Fix one side: drop the explicit accept, or replace llama.SamplerSample with "+
+				"llama.SamplerApply-based sampling.",
+				sampleSites, acceptSites)
+		}
+	})
+}

--- a/sdk/kronk/model/swa_window_test.go
+++ b/sdk/kronk/model/swa_window_test.go
@@ -1,0 +1,313 @@
+package model
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Sliding-window attention (SWA) runtime semantics.
+//
+// GROUND FACT for the model this audit targets
+// (unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL, general.architecture = "qwen35moe"):
+//
+//	n_swa == 0 and swa_type == LLAMA_SWA_TYPE_NONE.
+//
+// Evidence:
+//   - The GGUF carries NO "qwen35moe.attention.sliding_window" key (nor any
+//     "*.sliding_window*" key at all). It carries
+//     qwen35moe.full_attention_interval = 4 plus ssm.* keys instead: the
+//     non-full-attention layers are RECURRENT (gated DeltaNet), not windowed.
+//   - .extras/llama.cpp/src/models/qwen35moe.cpp:4-38 (load_arch_hparams)
+//     never touches hparams.n_swa or hparams.swa_type, and no generic loader
+//     reads a sliding-window key for this arch. The defaults therefore stand:
+//     .extras/llama.cpp/src/llama-hparams.h:143 (swa_type = LLAMA_SWA_TYPE_NONE)
+//     and :145 (n_swa = 0).
+//   - Consequently .extras/llama.cpp/src/llama-model.cpp:2185-2206 selects plain
+//     llama_memory_hybrid (attn + recurrent), NOT llama_memory_hybrid_iswa —
+//     there is no SWA sub-cache in this model's memory module at all.
+//
+// So SWA cannot be the mechanism behind "the model drops the task mid-way" for
+// THIS model. The tests below pin the two SWA defects that do exist in Kronk;
+// both are latent for qwen35moe and bite the genuinely windowed architectures
+// (gemma2/3/4, cohere2, exaone4, ...).
+
+// =============================================================================
+
+// TestCalculateVRAMDiagResolvesEffectiveSWAFull pins a wrong-default bug in the
+// SWA branch of Kronk's in-process KV-cache estimator.
+//
+// FINDING
+// Config.SWAFull() (sdk/kronk/model/config.go:448) resolves a nil PtrSWAFull to
+// FALSE, and its own doc comment (config.go:445-447) says so explicitly:
+// "reports whether a full-size sliding-window attention cache was EXPLICITLY
+// REQUESTED. Callers that need the effective value must check PtrSWAFull first
+// because nil leaves the choice to llama.cpp."
+//
+// calculateVRAMDiag (sdk/kronk/model/model.go:1331) is exactly such a caller and
+// does not honour the contract:
+//
+//	SWAFull: cfg.SWAFull(),
+//
+// The two peer call sites that resolve the SAME question both map nil to TRUE:
+//   - sdk/kronk/pool/llama.go:315-319 (effectiveSWAFull), used for the
+//     admission/loader estimate at pool/llama.go:289.
+//   - sdk/tools/models/analyze.go:271 (`cfg.PtrSWAFull == nil || *cfg.PtrSWAFull`).
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/src/llama-context.cpp:3512 — llama_context_default_params
+//     sets `swa_full = true`. Kronk starts from llama.ContextDefaultParams()
+//     (config.go:842) and only overwrites SwaFull when PtrSWAFull != nil
+//     (config.go:961-967), so nil genuinely means swa_full == TRUE at runtime.
+//   - .extras/llama.cpp/src/llama-kv-cache-iswa.cpp:69-80 — the allocator:
+//     size_swa = PAD(min(size_base, n_swa*(unified ? n_seq_max : 1) + n_ubatch), 256)
+//     and `if (swa_full) { size_swa = size_base; }`.
+//     sdk/kronk/gguf/kvcache.go:83-89 is a faithful port of that formula, so the
+//     estimate is only as correct as the SWAFull flag handed to it.
+//
+// CONCRETE FAILURE SCENARIO
+// A gemma3-class model (n_swa = 1024, 262144-token context) is loaded with
+// swa-full unset. The live llama_context allocates size_swa == size_base for
+// every SWA layer, but calculateVRAMDiag computes the compact
+// n_swa + n_ubatch size, so ModelInfo.SlotMemory / VRAMTotal — the values
+// pool/llama.go:307-308 falls back to and the loader displays — under-report the
+// SWA layers' KV by orders of magnitude, while the resman estimate one call away
+// (pool/llama.go:289) reports the correct larger number for the same config.
+//
+// The test accepts EITHER fix: making Config.SWAFull() nil-aware, or resolving
+// the default at the model.go:1331 call site.
+func TestCalculateVRAMDiagResolvesEffectiveSWAFull(t *testing.T) {
+	// llamaCppDefaultSwaFull is llama_context_default_params().swa_full in
+	// llama.cpp b10211 (.extras/llama.cpp/src/llama-context.cpp:3512). Kronk
+	// never overrides it when PtrSWAFull is nil (config.go:961-967), so this
+	// is the effective runtime value for an unset config.
+	const llamaCppDefaultSwaFull = true
+
+	// Sanity: the accessor must still report explicit values verbatim.
+	yes, no := true, false
+	if got := (Config{PtrSWAFull: &yes}).SWAFull(); !got {
+		t.Fatalf("Config{PtrSWAFull: &true}.SWAFull() = %v, want true", got)
+	}
+	if got := (Config{PtrSWAFull: &no}).SWAFull(); got {
+		t.Fatalf("Config{PtrSWAFull: &false}.SWAFull() = %v, want false", got)
+	}
+
+	// Fix A: the accessor itself became nil-aware. Nothing else to check.
+	if (Config{}).SWAFull() == llamaCppDefaultSwaFull {
+		return
+	}
+
+	// Fix B: calculateVRAMDiag resolves the default itself. Locate the
+	// SWAFull field of the vram.Config literal it builds and require the
+	// expression to consult PtrSWAFull.
+	root := kronkRepoRoot(t)
+	path := filepath.Join(root, "sdk", "kronk", "model", "model.go")
+
+	fset := token.NewFileSet()
+	file := parseKronkSource(t, fset, path)
+	fn := findKronkFunc(t, file, path, "calculateVRAMDiag")
+
+	expr, pos := swaFullFieldValue(fn)
+	if expr == nil {
+		t.Fatalf("%s: calculateVRAMDiag has no `SWAFull:` field in its vram.Config literal; this test pins a construction that changed — re-point it",
+			srcPos(fset, root, fn.Pos()))
+	}
+
+	text := swaSourceText(t, fset, path, expr)
+	if strings.Contains(text, "PtrSWAFull") {
+		return
+	}
+
+	t.Errorf(`calculateVRAMDiag sizes the SWA KV cache from a value that resolves an unset swa-full to false.
+
+  site:     %s
+            SWAFull: %s
+  bug:      Config.SWAFull() (sdk/kronk/model/config.go:448) returns
+            boolOr(cfg.PtrSWAFull, false) and its own doc comment
+            (config.go:445-447) warns that callers needing the EFFECTIVE value
+            must inspect PtrSWAFull, because nil leaves the choice to llama.cpp.
+  truth:    llama_context_default_params() sets swa_full = true
+            (.extras/llama.cpp/src/llama-context.cpp:3512) and Kronk only
+            overwrites ctxParams.SwaFull when PtrSWAFull != nil
+            (sdk/kronk/model/config.go:961-967). Unset therefore means
+            swa_full == true in the live context.
+  effect:   sdk/kronk/gguf/kvcache.go:83-89 ports
+            .extras/llama.cpp/src/llama-kv-cache-iswa.cpp:69-80 — with
+            SWAFull == false it shrinks the SWA layers to
+            PAD(min(baseCells, n_swa*seq + n_ubatch), 256) instead of the
+            full-size cache llama.cpp actually allocates. ModelInfo.SlotMemory
+            and VRAMTotal (the loader fallback at
+            sdk/kronk/pool/llama.go:307-308) then under-report SWA-layer KV for
+            every windowed model whose swa-full is unset.
+  peers:    sdk/kronk/pool/llama.go:315-319 (effectiveSWAFull) and
+            sdk/tools/models/analyze.go:271 both resolve nil to TRUE for the
+            same question, so the two estimates disagree for one config.
+  fix:      either make Config.SWAFull() nil-aware, or resolve the default here
+            the way pool/llama.go:315-319 does.
+  scope:    latent for the audited qwen35moe target (n_swa == 0, see the file
+            header) — it bites gemma2/3/4, cohere2, exaone4 and friends.`,
+		srcPos(fset, root, pos), text)
+}
+
+// swaFullFieldValue returns the value expression of the first `SWAFull:` element
+// of any composite literal inside fn, plus the position of the element.
+func swaFullFieldValue(fn *ast.FuncDecl) (ast.Expr, token.Pos) {
+	var found ast.Expr
+	var at token.Pos
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found != nil {
+			return false
+		}
+
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "SWAFull" {
+				continue
+			}
+			found = kv.Value
+			at = kv.Pos()
+
+			return false
+		}
+
+		return true
+	})
+
+	return found, at
+}
+
+// swaSourceText returns the verbatim source text of node as it appears in path.
+func swaSourceText(t *testing.T, fset *token.FileSet, path string, node ast.Node) string {
+	t.Helper()
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	lo := fset.Position(node.Pos()).Offset
+	hi := fset.Position(node.End()).Offset
+	if lo < 0 || hi > len(src) || lo > hi {
+		t.Fatalf("%s: node offsets [%d,%d) outside the %d-byte file", path, lo, hi, len(src))
+	}
+
+	return string(src[lo:hi])
+}
+
+// =============================================================================
+
+// TestKronkSurfacesEffectiveNSWA pins an observability gap: nothing Kronk emits
+// lets an operator tell whether the loaded model uses sliding-window attention,
+// nor how large the window is.
+//
+// FINDING
+// The only SWA value Kronk prints is the REQUESTED context param:
+// sdk/kronk/model/model.go:637-643 logs "SwaFull[%d]" from ctxParams.SwaFull.
+// That is the flag Kronk asked for, not the model's window, and it is emitted
+// even for models with no SWA layers at all. Nothing anywhere in the SDK calls
+// llama.ModelNSWA (.extras/yzma/pkg/llama/model.go:534, binding
+// llama_model_n_swa), so the effective n_swa is never observable.
+//
+// The usual escape hatch is closed too: llama.cpp's own load banner prints
+// "n_swa = %u" (.extras/llama.cpp/src/llama-model.cpp:1785), but
+// sdk/kronk/init.go:134-140 defaults an out-of-range log level to LogSilent and
+// installs llama.LogSet(llama.LogSilent()), so that line never reaches an
+// operator in the default configuration.
+//
+// LLAMA.CPP REFERENCE
+//   - .extras/llama.cpp/src/llama-model.cpp:1785 — the "n_swa" load line.
+//   - .extras/llama.cpp/src/llama-model.cpp:2443-2449 — llama_model_n_swa, the
+//     public accessor, which upstream's own server calls at
+//     tools/server/server-context.cpp:1280-1287 precisely to decide whether SWA
+//     handling (and swa_full) applies before configuring prompt reuse and
+//     context checkpoints.
+//
+// CONCRETE FAILURE SCENARIO
+// An operator debugging "the model forgets what it said earlier" cannot
+// distinguish a genuinely windowed model running a compact SWA cache from a
+// non-SWA model, because both log the identical "SwaFull[1]" line and llama.cpp
+// is muted. Diagnosing this audit's target required dumping the GGUF by hand and
+// reading llama.cpp's per-arch hparams loader.
+//
+// FIX: read llama.ModelNSWA(mdl) at load and log it (0 => no SWA layers)
+// alongside the resolved swa_full, mirroring
+// .extras/llama.cpp/src/llama-model.cpp:1785.
+func TestKronkSurfacesEffectiveNSWA(t *testing.T) {
+	root := kronkRepoRoot(t)
+	sdk := filepath.Join(root, "sdk")
+
+	var sites []string
+	err := filepath.WalkDir(sdk, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(src), "ModelNSWA") {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		sites = append(sites, rel)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", sdk, err)
+	}
+
+	if len(sites) > 0 {
+		t.Logf("llama.ModelNSWA referenced from: %s", strings.Join(sites, ", "))
+		return
+	}
+
+	t.Error(strings.TrimSpace(fmt.Sprintf(`
+llama.ModelNSWA is never called anywhere under sdk/ — the effective n_swa is not observable.
+
+  bug:      Kronk logs only the REQUESTED context param
+            (sdk/kronk/model/model.go:637-643, "SwaFull[%%d]" from
+            ctxParams.SwaFull). It never reports the model's window, so an
+            operator cannot tell a windowed model running a compact SWA cache
+            from a model with no SWA layers.
+  muted:    llama.cpp prints "n_swa = %%u" at load
+            (.extras/llama.cpp/src/llama-model.cpp:1785), but
+            sdk/kronk/init.go:134-140 installs llama.LogSet(llama.LogSilent())
+            for the default log level, so that banner is discarded.
+  binding:  yzma already exports it: llama.ModelNSWA
+            (.extras/yzma/pkg/llama/model.go:534 -> llama_model_n_swa,
+            .extras/llama.cpp/src/llama-model.cpp:2443-2449).
+  upstream: llama-server calls llama_model_n_swa before configuring prompt
+            reuse / context checkpoints and warns when swa_full is meaningless
+            for the model (tools/server/server-context.cpp:1280-1287).
+  fix:      log llama.ModelNSWA(mdl) at model load (0 => no SWA layers) next to
+            the resolved swa_full.
+  note:     for the audited qwen35moe target n_swa == 0, so this line would have
+            immediately ruled SWA out; see this file's header.`)))
+}

--- a/sdk/kronk/model/toolcall_repro_test.go
+++ b/sdk/kronk/model/toolcall_repro_test.go
@@ -1,0 +1,900 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Tool-calling reproduction of the reported symptom "starts a task then drops
+// it mid-way".
+//
+// The earlier differential run (findings2.md §13) came back INCONCLUSIVE
+// because every probe was a plain conversational turn. The defects that best
+// explain the report (findings2.md §8a, §8c, §12a) can only fire on a
+// TOOL-CALLING turn: §12a needs a <tool_call> block open when generation
+// ends, and §8a/§8c need an assistant history turn that the Qwen3.6 template
+// classifies as "in-turn" (loop.index0 > ns.last_query_index), which only
+// happens once a tool result follows an assistant turn.
+//
+// This file therefore pins the tool-calling half of the story:
+//
+//	TestToolCallCutOffAtMaxTokensIsInvisibleToTheCaller
+//	    §12a's caller-visible consequence, plus the reason it is SILENT: Kronk
+//	    has no "length" finish reason at all.
+//	TestQwen36MultiStepToolLoopPromptDamage
+//	    the exact prompt Kronk sends for a realistic two-step tool loop,
+//	    against the template's own output.
+//
+// The live-model counterpart is TestToolCallDifferential in
+// sdk/kronk/tests/mtp/differential_test.go (build tag kronkdiff,
+// KRONK_MTP_DIFF=1), which drives the same shapes through kronk.Chat and
+// through upstream llama-server.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Local source-scanning helpers.
+//
+// These are deliberately private to this file rather than shared. The audit's
+// shared helpers (kronkRepoRoot, parseKronkSource, posOf) live in files that
+// are untracked scratch and were observed to disappear mid-session, taking the
+// whole package build with them; this file must keep compiling on its own.
+
+// toolReproRepoRoot walks up from this test file to the module root.
+func toolReproRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolving the working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod above %s", dir)
+		}
+
+		dir = parent
+	}
+}
+
+// toolReproParse parses one production source file.
+func toolReproParse(t *testing.T, fset *token.FileSet, path string) *ast.File {
+	t.Helper()
+
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	return f
+}
+
+// toolReproPos renders a node position as file:line.
+func toolReproPos(fset *token.FileSet, n ast.Node) string {
+	p := fset.Position(n.Pos())
+
+	return fmt.Sprintf("%s:%d", filepath.Base(p.Filename), p.Line)
+}
+
+// -----------------------------------------------------------------------------
+// Finding §12a: a tool call cut off at MaxTokens is discarded, and the caller
+// is told the generation stopped normally.
+
+// TestToolCallCutOffAtMaxTokensIsInvisibleToTheCaller pins what an API client
+// receives when generation ends while the parser still holds a partial tool
+// call.
+//
+// FINDING (findings2.md §12a, plus the missing "length" finish reason)
+// The Qwen state machine buffers every byte between "<tool_call>" and
+// "</tool_call>" into an internal builder and returns Result{} for each of
+// them (sdk/kronk/parsers/qwen/state_machine.go:88-89; the split-tag
+// lookahead at :47-68 does the same for a lone "<"). The StateMachine
+// contract exposes only Classify and Reset (sdk/kronk/model/parser.go:73-80),
+// so there is no way to ask for the held-back bytes. finishSlot flushes
+// s.utf8Buf only (sdk/kronk/model/batchgen_finish.go:261-278) and its
+// deferred s.reset() calls stateMachine.Reset()
+// (sdk/kronk/model/batchgen_slot.go:379-381), which discards the builder.
+//
+// A second, independent route reaches the same empty response, and it is the
+// one the live run below actually took: the MaxTokens cut at
+// sdk/kronk/model/batchgen_tokens.go:205-210 lands on the single Result that
+// carries the WHOLE tool call, and is evaluated before the accumulator write at
+// :213-222. Either way finishSlot ends up with an empty s.finalTooling and
+// s.toolFlag == 0, so no ResponseToolCall is ever built — see
+// TestMaxTokensIsCheckedAroundBufferedToolCallTokens in this file for the exact
+// ordering, and TestToolCallHeldByTheParserAtEOGIsUnrecoverable for the
+// end-of-generation route.
+//
+// LIVE EVIDENCE (mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL, n_ctx 16384, Metal, b10211)
+// TestToolCallDifferential's truncation sweep, one get_weather request per
+// max_tokens value, enable_thinking=false:
+//
+//	max_tokens 4,8,12,16,20,24,32 -> finish_reason "stop",  content "",
+//	                                 tool_calls [], no error, usage
+//	                                 prompt=359 completion=39 reasoning=0
+//	max_tokens 48,64             -> finish_reason "tool_calls", get_weather
+//
+// Seven of nine requests returned NOTHING to the caller, and usage reported 39
+// completion tokens on every one of them — including the max_tokens=4 case, so
+// usage does not reveal the truncation either.
+//
+// What makes it silent rather than merely lossy is the finish reason. Kronk
+// defines exactly three (sdk/kronk/model/models.go:36-38) and
+// chatResponseFinal picks between two of them
+// (sdk/kronk/model/models.go:926-929):
+//
+//	finishReason := FinishReasonStop
+//	if len(respToolCalls) > 0 {
+//	    finishReason = FinishReasonTool
+//	}
+//
+// There is no "length". A turn truncated at max_tokens is reported to the
+// caller as a completed one.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/models.go:36-38    the three finish reasons
+//   - sdk/kronk/model/models.go:926-929  stop unless tool calls
+//   - sdk/kronk/model/batchgen_finish.go:282  tool branch over finalTooling
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/tools/server/server-task.cpp:443 and :492 —
+// to_json_oaicompat_chat and its streaming twin both START from
+// finish_reason = "length" and downgrade to "stop"/"tool_calls" only for
+// STOP_TYPE_WORD or STOP_TYPE_EOS. And the text itself cannot be lost:
+// slot.generated_text is authoritative and send_final_response ships whatever
+// remains (.extras/llama.cpp/tools/server/server-context.cpp:1868-1898).
+//
+// FAILURE SCENARIO (this is the user's report)
+// An agent asks the model to do something, the model decides to call a tool,
+// and the reply reaches max_tokens inside the <tool_call> block. Kronk
+// returns HTTP 200 with content "", no tool_calls, no error, usage counting
+// every generated token, and finish_reason "stop". The agent loop sees a
+// well-formed empty answer, records it as the assistant's turn, and moves on:
+// the task was started and then dropped, with nothing anywhere to indicate
+// why.
+//
+// FIX: add a drain to the StateMachine contract and call it from finishSlot
+// before s.reset(), and report a distinct finish reason when the MaxTokens
+// budget is what ended the turn.
+func TestToolCallCutOffAtMaxTokensIsInvisibleToTheCaller(t *testing.T) {
+	// (a) The caller-visible response for a slot whose tool-call buffer was
+	//     discarded. finishSlot's inputs after the MaxTokens cut are: empty
+	//     finalContent, empty finalReasoning (thinking already closed), no
+	//     respToolCalls (finalTooling was empty), and a Usage that shows the
+	//     budget was consumed. chatResponseFinal is production code
+	//     (sdk/kronk/model/models.go:910) and is what both transports send.
+	const maxTokens = 24
+
+	resp := chatResponseFinal(
+		"chatcmpl-repro", ObjectChatText, "mtp-Qwen3.6-35B-A3B", 0, "",
+		"",  // finalContent  — the tool-call bytes never reached it
+		"",  // finalReasoning
+		nil, // respToolCalls — finalTooling was empty at batchgen_finish.go:282
+		nil,
+		Usage{
+			PromptTokens:     128,
+			CompletionTokens: maxTokens,
+			OutputTokens:     maxTokens,
+			TotalTokens:      128 + maxTokens,
+		},
+	)
+
+	if len(resp.Choices) != 1 {
+		t.Fatalf("chatResponseFinal returned %d choices, want 1", len(resp.Choices))
+	}
+
+	choice := resp.Choices[0]
+
+	if choice.Message == nil {
+		t.Fatalf("chatResponseFinal returned a nil Message")
+	}
+
+	// The generation used its whole budget, so the caller MUST be able to
+	// tell this turn was cut short. Anything but a truncation-specific
+	// finish reason makes the dropped tool call indistinguishable from a
+	// deliberate empty answer.
+	truncated := resp.Usage != nil && resp.Usage.OutputTokens >= maxTokens
+	silent := strings.TrimSpace(choice.Message.Content) == "" &&
+		strings.TrimSpace(choice.Message.Reasoning) == "" &&
+		len(choice.Message.ToolCalls) == 0
+
+	if truncated && silent && choice.FinishReason() == FinishReasonStop {
+		t.Errorf("a turn truncated at max_tokens with its tool call discarded is reported as a clean stop\n"+
+			"got : finish_reason=%q content=%q reasoning=%q tool_calls=%d output_tokens=%d (max_tokens=%d)\n"+
+			"want: a finish reason that distinguishes truncation from completion, and the\n"+
+			"      partial tool call delivered rather than dropped.\n\n"+
+			"chatResponseFinal (sdk/kronk/model/models.go:926-929) only ever chooses between\n"+
+			"FinishReasonStop and FinishReasonTool; sdk/kronk/model/models.go:36-38 defines no\n"+
+			"length/truncation reason at all. Combined with findings2.md §12a — the parser's\n"+
+			"tool-call buffer (sdk/kronk/parsers/qwen/state_machine.go:88-89) is discarded by\n"+
+			"stateMachine.Reset() (sdk/kronk/model/batchgen_slot.go:379-381) because nothing\n"+
+			"drains it (sdk/kronk/model/parser.go:73-80,\n"+
+			"sdk/kronk/model/batchgen_finish.go:261-278) — an agent that hits its token budget\n"+
+			"mid-<tool_call> receives a well-formed EMPTY assistant turn and no error.\n"+
+			"llama.cpp starts from finish_reason \"length\" and only downgrades it for a real\n"+
+			"stop token or stop word (.extras/llama.cpp/tools/server/server-task.cpp:443,:492),\n"+
+			"and it never loses the text (server-context.cpp:1868-1898).",
+			choice.FinishReason(), choice.Message.Content, choice.Message.Reasoning,
+			len(choice.Message.ToolCalls), resp.Usage.OutputTokens, maxTokens)
+	}
+
+	// (b) Source-level confirmation that the missing reason is missing on
+	//     purpose-free grounds: enumerate the FinishReason constants so the
+	//     failure above cannot be dismissed as a test artefact.
+	fset := token.NewFileSet()
+	f := toolReproParse(t, fset, filepath.Join(toolReproRepoRoot(t), "sdk", "kronk", "model", "models.go"))
+
+	var reasons []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+
+		for _, name := range vs.Names {
+			if strings.HasPrefix(name.Name, "FinishReason") {
+				reasons = append(reasons, name.Name)
+			}
+		}
+
+		return true
+	})
+
+	t.Logf("finish reasons defined in sdk/kronk/model/models.go: %s", strings.Join(reasons, ", "))
+
+	for _, r := range reasons {
+		if strings.Contains(r, "Length") || strings.Contains(r, "Truncat") {
+			return
+		}
+	}
+
+	t.Errorf("no truncation finish reason exists: models.go defines only %s\n"+
+		"llama.cpp reports finish_reason \"length\" whenever the token budget, not a stop\n"+
+		"token, ended the turn (.extras/llama.cpp/tools/server/server-task.cpp:410,:443,:492).\n"+
+		"Without it, findings2.md §12a is undetectable by any client: a discarded tool call\n"+
+		"and a deliberate empty reply are byte-identical responses.",
+		strings.Join(reasons, ", "))
+}
+
+// TestMaxTokensIsCheckedAroundBufferedToolCallTokens pins the statement order
+// in handleSampledToken that destroys a COMPLETE tool call, measured live.
+//
+// FINDING
+// This is the mechanism behind the live reproduction recorded by
+// TestToolCallDifferential (sdk/kronk/tests/mtp/differential_test.go). Driving
+// mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL through kronk.Chat with one tool and
+// enable_thinking=false, sweeping max_tokens:
+//
+//	max_tokens  4  8 12 16 20 24 32 36 38 39 -> finish_reason "stop",
+//	                                            content "", tool_calls 0,
+//	                                            error nil, output_tokens 39
+//	max_tokens 40 41 44 48 64 200            -> finish_reason "tool_calls",
+//	                                            get_weather delivered,
+//	                                            output_tokens 39
+//
+// Two separate defects produce that table, and both are visible as an ORDERING
+// problem in handleSampledToken:
+//
+//  1. MaxTokens is not enforced at all while the parser buffers. Every token
+//     of a <tool_call> body classifies as ChannelNone (the Qwen state machine
+//     accumulates them and returns Result{}, parsers/qwen/state_machine.go:88-89),
+//     and sdk/kronk/model/batchgen_tokens.go:200-203 returns for ChannelNone
+//     BEFORE the budget comparison at :207. That is why a cap of 4 still
+//     generated 39 tokens — a ~10x overrun of an explicit limit.
+//
+//  2. The whole payload is lost in one step. The state machine releases the
+//     entire buffered call as a single Result at the closing tag
+//     (parsers/qwen/state_machine.go:80-89). On exactly that token the budget
+//     check at :207-210 finally runs, sees outputTokens (39) >= MaxTokens, and
+//     calls finishSlot BEFORE the store at :213-222 — so s.finalTooling stays
+//     empty and finishSlot's tool branch (batchgen_finish.go:282) has nothing
+//     to parse. The failure boundary is therefore exactly the token count:
+//     cap <= 39 loses the call, cap >= 40 keeps it, and the loss is total
+//     rather than one token as in TestMaxTokensKeepsTheLimitReachingTokensText.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_tokens.go:200-203  ChannelNone early return
+//   - sdk/kronk/model/batchgen_tokens.go:207-210  budget check
+//   - sdk/kronk/model/batchgen_tokens.go:213-222  content store
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/tools/server/server-context.cpp:1895-1899 adds the token
+// to slot.generated_text and sends the partial response FIRST; the budget test
+// that sets STOP_TYPE_LIMIT is at :1913-1918, after it. There is no channel
+// classification that can skip the budget test, and because generated_text is
+// the authority, send_final_response (:1868-1898) still ships the text with
+// finish_reason "length" (server-task.cpp:443).
+//
+// FAILURE SCENARIO
+// An agent framework that sets any max_tokens at or below the length of the
+// model's tool call gets HTTP 200, an empty assistant message, no tool call
+// and no error. It records the empty turn and continues: the announced action
+// never happens. Meanwhile a runaway tool call ignores the cap completely.
+//
+// FIX: run the budget check for every token (move it above the ChannelNone
+// return) and store/stream the content before finishing, as llama.cpp does.
+func TestMaxTokensIsCheckedAroundBufferedToolCallTokens(t *testing.T) {
+	path := filepath.Join(toolReproRepoRoot(t), "sdk", "kronk", "model", "batchgen_tokens.go")
+
+	fset := token.NewFileSet()
+	f := toolReproParse(t, fset, path)
+
+	var fn *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if ok && fd.Name.Name == "handleSampledToken" && fd.Body != nil {
+			fn = fd
+			break
+		}
+	}
+
+	if fn == nil {
+		t.Fatalf("handleSampledToken not found in %s", path)
+	}
+
+	// Positions of the four statements whose order decides whether a
+	// completed tool call survives its own token budget. handleSampledToken
+	// contains TWO MaxTokens checks: one in the partial-UTF-8 branch
+	// (batchgen_tokens.go:148), reached before the parser is consulted, and
+	// the main-path one (:207). Only the main path matters here, so the
+	// classify call is the anchor that separates them.
+	var classifyPos, nonePos, storePos token.Pos
+	var budgetPositions []token.Pos
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.IfStmt:
+			cond, ok := node.Cond.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+
+			// `result.Channel == ChannelNone`
+			if id, ok := cond.Y.(*ast.Ident); ok && id.Name == "ChannelNone" && nonePos == token.NoPos {
+				nonePos = node.Pos()
+			}
+
+			// `outputTokens >= s.job.params.MaxTokens`
+			if sel, ok := cond.Y.(*ast.SelectorExpr); ok && sel.Sel.Name == "MaxTokens" {
+				budgetPositions = append(budgetPositions, node.Pos())
+			}
+
+		case *ast.CallExpr:
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			// `s.stateMachine.Classify(content)`
+			if sel.Sel.Name == "Classify" && classifyPos == token.NoPos {
+				classifyPos = node.Pos()
+			}
+
+			// `s.finalTooling.WriteString(result.Content)`
+			if sel.Sel.Name == "WriteString" {
+				if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
+					inner.Sel.Name == "finalTooling" && storePos == token.NoPos {
+					storePos = node.Pos()
+				}
+			}
+		}
+
+		return true
+	})
+
+	if classifyPos == token.NoPos || nonePos == token.NoPos || storePos == token.NoPos ||
+		len(budgetPositions) == 0 {
+		t.Fatalf("could not locate the statements in handleSampledToken "+
+			"(Classify %v, ChannelNone return %v, finalTooling store %v, %d MaxTokens checks) — "+
+			"the function was restructured; re-derive this pin against %s",
+			classifyPos.IsValid(), nonePos.IsValid(), storePos.IsValid(),
+			len(budgetPositions), path)
+	}
+
+	// mainBudgetPos is the budget check on the classified-token path.
+	var mainBudgetPos token.Pos
+	var guardsBufferedTokens bool
+	for _, p := range budgetPositions {
+		if p > classifyPos && p < nonePos {
+			// A budget check between Classify and the ChannelNone return
+			// WOULD cover a buffered tool-call token. This is the fix.
+			guardsBufferedTokens = true
+		}
+
+		if p > nonePos && (mainBudgetPos == token.NoPos || p < mainBudgetPos) {
+			mainBudgetPos = p
+		}
+	}
+
+	pos := func(p token.Pos) string { return toolReproPos(fset, &ast.Ident{NamePos: p}) }
+
+	var budgetLines []string
+	for _, p := range budgetPositions {
+		budgetLines = append(budgetLines, pos(p))
+	}
+
+	t.Logf("handleSampledToken order: Classify %s, ChannelNone return %s, "+
+		"finalTooling store %s, MaxTokens checks %v",
+		pos(classifyPos), pos(nonePos), pos(storePos), budgetLines)
+
+	if !guardsBufferedTokens {
+		t.Errorf("no MaxTokens budget check sits between the parser call (%s) and the "+
+			"ChannelNone early return (%s), so the budget is never evaluated for a token "+
+			"the parser is buffering. The checks in this function are at %v.\n"+
+			"Every token inside a <tool_call> block classifies as ChannelNone "+
+			"(sdk/kronk/parsers/qwen/state_machine.go:88-89) and returns at "+
+			"sdk/kronk/model/batchgen_tokens.go:200-203, so an explicit max_tokens is "+
+			"ignored for the whole call. Measured live against "+
+			"mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL through kronk.Chat: max_tokens=4 still produced "+
+			"39 output tokens.\n"+
+			"llama.cpp evaluates the budget for every accepted token, with no channel "+
+			"classification in front of it "+
+			"(.extras/llama.cpp/tools/server/server-context.cpp:1913-1918).",
+			pos(classifyPos), pos(nonePos), budgetLines)
+	}
+
+	if mainBudgetPos == token.NoPos {
+		t.Fatalf("no MaxTokens check after the ChannelNone return in handleSampledToken; "+
+			"re-derive this pin against %s", path)
+	}
+
+	if storePos > mainBudgetPos {
+		t.Errorf("the tool-call content store (%s) comes AFTER the MaxTokens budget check (%s), "+
+			"so the token that trips the budget is discarded — and for a tool call that token "+
+			"carries the ENTIRE payload\n"+
+			"The Qwen state machine releases the whole buffered call as one Result at the "+
+			"closing tag (sdk/kronk/parsers/qwen/state_machine.go:80-89), so finishSlot's tool "+
+			"branch (sdk/kronk/model/batchgen_finish.go:282) runs over an empty s.finalTooling "+
+			"and the caller receives an empty message with finish_reason \"stop\" and no error. "+
+			"Measured live: max_tokens<=39 lost a complete get_weather call, max_tokens>=40 "+
+			"delivered it, on identical requests generating 39 tokens.\n"+
+			"llama.cpp appends to slot.generated_text and streams the token first "+
+			"(.extras/llama.cpp/tools/server/server-context.cpp:1895-1899), then applies the "+
+			"budget (:1913-1918), and reports finish_reason \"length\" "+
+			"(tools/server/server-task.cpp:443).",
+			pos(storePos), pos(mainBudgetPos))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Findings §8a + §8c on a realistic multi-step tool loop.
+
+// qwen36ToolLoopPrompt renders msgs through the production sequence a
+// tool-calling chat request actually takes:
+//
+//	Model.prepareContext        (chat.go:253)  -> normalizeHistoryReasoning
+//	Model.prepareCacheAndPrompt (chat.go:281)  -> createPrompt
+//	Model.applyRequestJinjaTemplate (prompts.go:23) -> applyJinjaTemplate
+//
+// The two stages that damage the prompt are normalizeHistoryReasoning
+// (reasoning.go:46) and the post-render strip inside applyJinjaTemplate
+// (prompts.go:177-181); both are reached here. Passing imc=false disables
+// both (reasoning.go:37) and yields the template's own output, which is the
+// reference this test compares against.
+//
+// It reuses newQwen36PromptModel from prompt_tokenize_special_test.go, which
+// carries the VERBATIM tokenizer.chat_template of
+// mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf.
+func qwen36ToolLoopPrompt(t *testing.T, imc bool, msgs []D) string {
+	t.Helper()
+
+	m := newQwen36PromptModel(imc)
+
+	d := D{
+		"messages": msgs,
+		// A tool-calling request always carries the tool schema; it is
+		// rendered into a leading system block (qwen3.6.jinja:58-70) that is
+		// irrelevant here, so this test omits it and asserts on the
+		// conversation body only.
+		"enable_thinking": true,
+		"bos_token":       "<|endoftext|>",
+		"eos_token":       "<|im_end|>",
+	}
+
+	got, err := m.applyJinjaTemplate(context.Background(), m.normalizeHistoryReasoning(d))
+	if err != nil {
+		t.Fatalf("rendering the tool-loop prompt: %v", err)
+	}
+
+	return got
+}
+
+// TestQwen36MultiStepToolLoopPromptDamage pins the exact prompt Kronk sends
+// on the second step of a two-tool-call agentic loop.
+//
+// FINDING (findings2.md §8a and §8c, composed on one realistic conversation)
+// The Qwen3.6 template treats every assistant message after the last real
+// user query as "in-turn" and replays its reasoning verbatim
+// (.extras/templates/qwen3.6.jinja:103-104, byte-identical to the GGUF's
+// embedded tokenizer.chat_template):
+//
+//	{%- if (preserve_thinking ...) or (loop.index0 > ns.last_query_index) %}
+//	    {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+//
+// ns.last_query_index is the index of the last user message whose content is
+// not a <tool_response> wrapper (:76-86), so in a tool loop EVERY assistant
+// turn after the user's request is in-turn. Kronk damages all of them twice:
+//
+//  1. normalizeHistoryReasoning (sdk/kronk/model/reasoning.go:91-92) deletes
+//     the reasoning and reasoning_content fields from every assistant
+//     message, so the template renders an empty span — the model no longer
+//     sees the reasoning that justified its own tool call (§8c).
+//  2. The post-render pass (sdk/kronk/model/prompts.go:177-181 ->
+//     sdk/kronk/parsers/standard/reasoning.go:35,43) then deletes the empty
+//     "<think>...</think>" span but not the "\n\n" the template emits inside
+//     the same literal, so the assistant header degrades from
+//     "<|im_start|>assistant\n<think>\n\n</think>\n\n" to
+//     "<|im_start|>assistant\n\n\n" — the two USER_DEFINED tokens 248068 and
+//     248069 become ordinary newlines on every step of the loop (§8a).
+//
+// Both are gated only on Config.IncrementalCache() (reasoning.go:37), which
+// is on by default, so no client cooperation is needed.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/reasoning.go:91-92    reasoning fields deleted
+//   - sdk/kronk/model/prompts.go:177-181    post-render strip over the prompt
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/common/chat.cpp:895-900 hands inputs.messages to the
+// template unchanged — there is no reasoning-stripping pass anywhere in the
+// request path — and :926-940 shows the only post-render edit is BOS/EOS
+// de-duplication. Upstream's own workarounds run BEFORE the render and only
+// ADD required fields (chat.cpp:3082-3085 parses string tool arguments into
+// objects, :3079 fills null content); none of them remove content.
+//
+// FAILURE SCENARIO
+// A multi-step agent: the model reasons "the queue is unbounded, I should
+// read svc/queue.go", calls read_file, and gets the file back. On the next
+// step Kronk shows it an assistant turn with the reasoning deleted and the
+// reasoning delimiters replaced by blank lines. The model has to re-derive
+// why it called the tool, from a turn whose channel structure no longer
+// parses — which is exactly "it contradicts what it already said" and "it
+// starts a task then drops it".
+func TestQwen36MultiStepToolLoopPromptDamage(t *testing.T) {
+	// A realistic two-step loop: list the files, then read one. Both
+	// assistant turns carry the reasoning the model produced, as an
+	// OpenAI-style client replays it.
+	msgs := []D{
+		{"role": "system", "content": "You audit Go repositories with tools."},
+		{"role": "user", "content": "Audit the repo and report every defect."},
+		{
+			"role":              "assistant",
+			"content":           "",
+			"reasoning_content": "I do not know the file list yet, so list_files must come first.",
+			"tool_calls": []D{
+				{"function": D{"name": "list_files", "arguments": D{}}},
+			},
+		},
+		{"role": "tool", "name": "list_files", "content": "svc/queue.go"},
+		{
+			"role":              "assistant",
+			"content":           "",
+			"reasoning_content": "One file. Read svc/queue.go before recording anything.",
+			"tool_calls": []D{
+				{"function": D{"name": "read_file", "arguments": D{"path": "svc/queue.go"}}},
+			},
+		},
+		{"role": "tool", "name": "read_file", "content": "func NewQueue() chan Job { return make(chan Job) }"},
+	}
+
+	// What the template itself produces for these messages. Reasoning is
+	// replayed on both in-turn assistant messages (qwen3.6.jinja:104) and the
+	// <think>/</think> delimiters are present, as llama.cpp would send them.
+	const want = "<|im_start|>system\nYou audit Go repositories with tools.<|im_end|>\n" +
+		"<|im_start|>user\nAudit the repo and report every defect.<|im_end|>\n" +
+		"<|im_start|>assistant\n<think>\nI do not know the file list yet, so list_files must come first.\n</think>\n\n" +
+		"<tool_call>\n<function=list_files>\n</function>\n</tool_call><|im_end|>\n" +
+		"<|im_start|>user\n<tool_response>\nsvc/queue.go\n</tool_response><|im_end|>\n" +
+		"<|im_start|>assistant\n<think>\nOne file. Read svc/queue.go before recording anything.\n</think>\n\n" +
+		"<tool_call>\n<function=read_file>\n<parameter=path>\nsvc/queue.go\n</parameter>\n</function>\n</tool_call><|im_end|>\n" +
+		"<|im_start|>user\n<tool_response>\nfunc NewQueue() chan Job { return make(chan Job) }\n</tool_response><|im_end|>\n" +
+		"<|im_start|>assistant\n<think>\n"
+
+	got := qwen36ToolLoopPrompt(t, true, msgs)
+	if got == want {
+		return
+	}
+
+	reference := qwen36ToolLoopPrompt(t, false, msgs)
+
+	// Quantify the damage so the failure is readable at a glance: how many
+	// reasoning delimiters the template emitted versus how many survive, and
+	// which reasoning text was deleted outright.
+	wantOpen := strings.Count(want, "<think>")
+	gotOpen := strings.Count(got, "<think>")
+	wantClose := strings.Count(want, "</think>")
+	gotClose := strings.Count(got, "</think>")
+
+	var lostReasoning []string
+	for _, msg := range msgs {
+		r, ok := msg["reasoning_content"].(string)
+		if ok && r != "" && !strings.Contains(got, r) {
+			lostReasoning = append(lostReasoning, r)
+		}
+	}
+
+	t.Errorf("the prompt Kronk sends for a two-step tool loop is not the prompt the template produced\n"+
+		"got  (Kronk, IncrementalCache on):\n%q\n\n"+
+		"want (template / llama.cpp):\n%q\n\n"+
+		"same messages with IncrementalCache off (i.e. both passes disabled):\n%q\n\n"+
+		"<think> openers: %d -> %d, </think> closers: %d -> %d\n"+
+		"reasoning deleted from history entirely: %q\n\n"+
+		"Two production stages do this. normalizeHistoryReasoning\n"+
+		"(sdk/kronk/model/reasoning.go:91-92) deletes reasoning_content from every\n"+
+		"assistant message, although qwen3.6.jinja:103-104 replays it for in-turn turns —\n"+
+		"which every assistant turn of a tool loop is (:76-86). The post-render strip\n"+
+		"(sdk/kronk/model/prompts.go:177-181 -> sdk/kronk/parsers/standard/reasoning.go:35,43)\n"+
+		"then removes the empty <think></think> span but leaves the '\\n\\n' from the same\n"+
+		"template literal, so each assistant header becomes \"<|im_start|>assistant\\n\\n\\n\"\n"+
+		"and tokens 248068/248069 degrade into newlines.\n"+
+		"llama.cpp passes messages to the template verbatim\n"+
+		"(.extras/llama.cpp/common/chat.cpp:895-900) and edits the render only to\n"+
+		"de-duplicate BOS/EOS (:926-940).\n"+
+		"Fix: stop deleting reasoning the template asks for, and drop the post-render pass.",
+		got, want, reference, wantOpen, gotOpen, wantClose, gotClose, lostReasoning)
+}
+
+// -----------------------------------------------------------------------------
+// Finding §12a, the OTHER route into it: end-of-generation while the parser is
+// still buffering.
+//
+// TestMaxTokensIsCheckedAroundBufferedToolCallTokens above covers the route the
+// live sweep took, in which the model DID close its tool call and the budget
+// check threw the flush away. This section covers the route the audit
+// originally described: generation ends with the closing tag never emitted, so
+// the bytes are still inside the parser. max_tokens cannot produce that state
+// (the budget is not evaluated for ChannelNone tokens at all), but the EOG
+// check at sdk/kronk/model/batchgen_tokens.go:66-69 can, and it is not
+// reachable from a test that only varies max_tokens.
+
+// qwenToolBufferMirror is a VERBATIM MIRROR of the tool-call buffering half of
+// the Qwen state machine:
+//
+//	sdk/kronk/parsers/qwen/state_machine.go:134-138  opener -> inToolCall, ChannelNone
+//	sdk/kronk/parsers/qwen/state_machine.go:90-106   body   -> buffered, ChannelNone
+//	sdk/kronk/parsers/qwen/state_machine.go:80-88    closer -> the WHOLE buffer,
+//	                                                          ChannelTool, in one Result
+//
+// The real state machine cannot be used from package model: sdk/kronk/parsers/qwen
+// imports this package, so importing it back is an import cycle. Only the three
+// transitions above are mirrored — the <think> handling, the split-<function=
+// lookahead and the implicit </function> close are irrelevant here and are
+// deliberately omitted.
+//
+// held() is what makes this test possible and is exactly what production cannot
+// do: the model.StateMachine contract (sdk/kronk/model/parser.go:73-80) has no
+// such method, which is the defect.
+//
+// MAINTAINER: when parsers/qwen/state_machine.go changes its tool-call
+// buffering, update this mirror in the same commit.
+type qwenToolBufferMirror struct {
+	buf        strings.Builder
+	inToolCall bool
+}
+
+func (sm *qwenToolBufferMirror) classify(content string) Result {
+	if sm.inToolCall {
+		switch content {
+		case "<tool_call>", "<|tool_call>":
+			return Result{}
+
+		case "</tool_call>", "<tool_call|>":
+			toolContent := strings.Trim(sm.buf.String(), "\n")
+			if toolContent != "" {
+				toolContent = fmt.Sprintf("%s\n", toolContent)
+			}
+			sm.buf.Reset()
+			sm.inToolCall = false
+
+			return Result{Channel: ChannelTool, Content: toolContent}
+
+		default:
+			sm.buf.WriteString(content)
+
+			return Result{}
+		}
+	}
+
+	switch content {
+	case "<tool_call>", "<|tool_call>":
+		sm.inToolCall = true
+		sm.buf.Reset()
+
+		return Result{}
+
+	default:
+		return Result{Channel: ChannelAnswer, Content: content}
+	}
+}
+
+// held reports the bytes the mirror is withholding. Production has no
+// equivalent, which is the whole point.
+func (sm *qwenToolBufferMirror) held() string { return sm.buf.String() }
+
+// toolSlotMirror is a VERBATIM MIRROR of the accumulator half of a slot, as
+// driven by handleSampledToken and then read by finishSlot:
+//
+//	sdk/kronk/model/batchgen_tokens.go:166-181  the flag switch
+//	sdk/kronk/model/batchgen_tokens.go:188-193  token counting
+//	sdk/kronk/model/batchgen_tokens.go:200-203  ChannelNone early return
+//	sdk/kronk/model/batchgen_tokens.go:213-222  the accumulator store
+//
+// The MaxTokens comparison at :205-210 is deliberately NOT mirrored: this test
+// is about the EOG route, where the budget never binds.
+//
+// MAINTAINER: keep in step with handleSampledToken.
+type toolSlotMirror struct {
+	reasonFlag     int
+	completionFlag int
+	toolFlag       int
+
+	reasonTokens     int
+	completionTokens int
+
+	finalContent   strings.Builder
+	finalReasoning strings.Builder
+	finalTooling   strings.Builder
+}
+
+func (s *toolSlotMirror) feed(r Result) {
+	switch r.Channel {
+	case ChannelReasoning:
+		s.reasonFlag++
+		s.completionFlag = 0
+		s.toolFlag = 0
+
+	case ChannelAnswer:
+		s.completionFlag++
+		s.reasonFlag = 0
+		s.toolFlag = 0
+
+	case ChannelTool:
+		s.toolFlag++
+		s.reasonFlag = 0
+		s.completionFlag = 0
+	}
+
+	switch {
+	case s.reasonFlag > 0:
+		s.reasonTokens++
+	default:
+		s.completionTokens++
+	}
+
+	if r.Channel == ChannelNone {
+		return
+	}
+
+	switch {
+	case s.reasonFlag > 0:
+		s.finalReasoning.WriteString(r.Content)
+
+	case s.toolFlag > 0:
+		s.finalTooling.WriteString(r.Content)
+
+	default:
+		s.finalContent.WriteString(r.Content)
+	}
+}
+
+// TestToolCallHeldByTheParserAtEOGIsUnrecoverable pins findings2 §12a on the
+// end-of-generation route: an unterminated <tool_call> is destroyed, and
+// finishSlot cannot even tell it happened.
+//
+// FINDING (findings2.md §12a)
+// The Qwen state machine buffers the tool-call body and returns Result{} for
+// every token of it (sdk/kronk/parsers/qwen/state_machine.go:90-106), releasing
+// it only at the closing tag (:80-88). If the model emits an EOG token first —
+// <|im_end|> straight after the JSON, a degenerate turn, a truncated
+// <function=…> — handleSampledToken finishes the slot at
+// sdk/kronk/model/batchgen_tokens.go:66-69 without ever consulting the parser.
+// The StateMachine contract has no drain (sdk/kronk/model/parser.go:73-80);
+// finishSlot flushes s.utf8Buf and nothing else
+// (sdk/kronk/model/batchgen_finish.go:261-278); the deferred s.reset() then
+// calls stateMachine.Reset() (sdk/kronk/model/batchgen_slot.go:379-381) and the
+// builder is gone.
+//
+// Two consequences this test measures, both invisible from production code:
+//
+//  1. every accumulator is empty, so sendFinalResponse ships content "",
+//     reasoning "" and no tool calls;
+//  2. s.toolFlag is still 0 — it is only incremented for ChannelTool
+//     (sdk/kronk/model/batchgen_tokens.go:177-180), and the buffered tokens are
+//     ChannelNone — so finishSlot does not even ENTER the tool branch at
+//     sdk/kronk/model/batchgen_finish.go:282. There is no log line, no
+//     parse-error, no diagnostic of any kind.
+//
+// PRODUCTION LINES PINNED
+//   - sdk/kronk/model/batchgen_tokens.go:66-69     EOG -> finishSlot, no drain
+//   - sdk/kronk/model/batchgen_finish.go:261-278   only utf8Buf is flushed
+//   - sdk/kronk/model/batchgen_slot.go:379-381     Reset() discards the buffer
+//
+// The contract-level statement of the same defect (StateMachine exposes no
+// drain, finishSlot never touches s.stateMachine) is
+// TestGenerationEndDrainsParserHeldBackContent in
+// sdk/kronk/model/nonspeculative_decode_test.go. This test is its behavioural
+// counterpart: it measures what is lost, not just that no API exists to
+// recover it.
+//
+// LLAMA.CPP REFERENCE (correct behaviour)
+// .extras/llama.cpp/tools/server/server-context.cpp:1868-1898 —
+// slot.generated_text is the authority. Text withheld from the stream while a
+// partial stop string is pending is never deleted from it, and
+// send_final_response ships whatever remains, so an unterminated tag cannot
+// swallow the model's output.
+//
+// FAILURE SCENARIO
+// A reasoning model in an agentic loop opens <tool_call>, writes the JSON, and
+// emits <|im_end|> without the closing tag. The caller receives a well-formed
+// empty assistant turn with finish_reason "stop" and no error, records it as
+// the model's answer, and moves on — the announced action never happens. This
+// is the reported "starts a task then drops it mid-way".
+//
+// FIX: add a drain to the StateMachine contract and call it from finishSlot
+// before s.reset(), or keep the raw generated text on the slot as the
+// authority the way llama.cpp does.
+func TestToolCallHeldByTheParserAtEOGIsUnrecoverable(t *testing.T) {
+	// One turn as the tokenizer fragments it: the opener, the JSON body, and
+	// then EOG — no "</tool_call>".
+	tokens := []string{
+		"<tool_call>",
+		"\n", "{\"name\":", " \"get_weather\",", " \"arguments\":",
+		" {\"location\":", " \"London,", " United", " Kingdom\",",
+		" \"units\":", " \"celsius\"}}", "\n",
+	}
+
+	sm := &qwenToolBufferMirror{}
+	s := &toolSlotMirror{}
+
+	for _, tok := range tokens {
+		s.feed(sm.classify(tok))
+	}
+
+	// llama.VocabIsEOG(...) is true for the next token, so
+	// handleSampledToken returns at batchgen_tokens.go:66-69 and finishSlot
+	// runs. finishSlot flushes s.utf8Buf (empty here: every piece was a
+	// complete codepoint) and nothing else.
+	produced := strings.Join(tokens[1:], "")
+	delivered := s.finalContent.String() + s.finalReasoning.String() + s.finalTooling.String()
+
+	if strings.Contains(delivered, "get_weather") {
+		return
+	}
+
+	t.Errorf("an unterminated tool call is destroyed at end-of-generation: the model produced %d bytes, the caller receives %d\n"+
+		"produced (by the model)      : %q\n"+
+		"still inside the parser      : %q\n"+
+		"delivered to the caller      : %q\n"+
+		"slot state finishSlot sees   : toolFlag=%d completionTokens=%d reasonTokens=%d "+
+		"finalContent=%d finalReasoning=%d finalTooling=%d bytes\n\n"+
+		"The Qwen state machine buffers the body and returns Result{} for every token of it\n"+
+		"(sdk/kronk/parsers/qwen/state_machine.go:90-106), releasing it only at the closing tag\n"+
+		"(:80-88). On EOG, handleSampledToken calls finishSlot at\n"+
+		"sdk/kronk/model/batchgen_tokens.go:66-69 without consulting the parser; the\n"+
+		"StateMachine contract has no drain (sdk/kronk/model/parser.go:73-80), finishSlot\n"+
+		"flushes only s.utf8Buf (sdk/kronk/model/batchgen_finish.go:261-278), and the deferred\n"+
+		"s.reset() calls stateMachine.Reset() (sdk/kronk/model/batchgen_slot.go:379-381).\n"+
+		"Note toolFlag=0: ChannelNone never increments it "+
+		"(sdk/kronk/model/batchgen_tokens.go:177-180), so finishSlot does not even enter the\n"+
+		"tool branch at sdk/kronk/model/batchgen_finish.go:282 — nothing is logged and no error\n"+
+		"is returned. The caller gets content \"\", no tool_calls and finish_reason \"stop\"\n"+
+		"(sdk/kronk/model/models.go:926-929), i.e. a task announced and then silently dropped.\n"+
+		"llama.cpp cannot lose it: slot.generated_text is authoritative and send_final_response\n"+
+		"ships the remainder (.extras/llama.cpp/tools/server/server-context.cpp:1868-1898).",
+		len(produced), len(delivered), produced, sm.held(), delivered,
+		s.toolFlag, s.completionTokens, s.reasonTokens,
+		s.finalContent.Len(), s.finalReasoning.Len(), s.finalTooling.Len())
+}

--- a/sdk/kronk/tests/mtp/differential_test.go
+++ b/sdk/kronk/tests/mtp/differential_test.go
@@ -1,0 +1,2774 @@
+//go:build kronkdiff
+
+// =========================================================================
+// Differential coherence harness for the MTP target.
+//
+// PURPOSE. Users report that long multi-turn "reasoning" conversations with
+// unsloth/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL derail: the model contradicts
+// something it already said, or starts a task and abandons it mid-way. The
+// question this file answers is a FALSIFICATION question, not a bug hunt:
+// is that the model's own behaviour, or does Kronk cause it?
+//
+// The only way to answer it is a differential. The same GGUF is driven
+// three ways and the outputs are scored by identical objective rules:
+//
+//	 leg              driver                        MTP
+//	 ---------------- ----------------------------- --------------------
+//	 upstream-none    llama-server --spec-type none off
+//	 upstream-mtp     llama-server --spec-type       on (llama.cpp's own
+//	                    draft-mtp                      MTP implementation)
+//	 kronk            kronk.Chat                    on (auto-enabled)
+//
+// The upstream-none/upstream-mtp pair isolates speculative decoding from
+// the model: both legs are the same weights, the same quant and the same
+// llama.cpp build, differing only in whether the MTP head drafts. If both
+// upstream legs are coherent and the Kronk leg is not, the defect is in
+// Kronk/yzma. If all three derail, it is the model or the quant.
+//
+// WHY KRONK CANNOT TURN MTP OFF. The drafter auto-enables whenever the
+// target GGUF declares "<arch>.nextn_predict_layers" > 0 and the loaded
+// libllama exports the pre-norm APIs (sdk/kronk/model/config.go:920,
+// draft_mtp.go:460). No Config field suppresses it: an MTP nDraft override
+// with NDraft == 0 is rewritten to defMTPNDraft by adjustConfig
+// (config.go:760-766). So the MTP on/off contrast has to come from
+// upstream's --spec-type, which is exactly what this harness does.
+//
+// COMPARABILITY CAVEATS, both structural and both recorded in the report:
+//
+//   - Greedy decoding is unreachable through Kronk. params.go:724 rewrites
+//     temperature <= 0 to 0.8 and AddParams (params.go:372) drops a zero
+//     temperature, so "temperature: 0" does not survive. Every leg is
+//     therefore run at the same explicit non-zero sampling settings
+//     (diffSampling) rather than at temperature 0.
+//   - Kronk's chat API exposes no "seed" parameter, so its sampler cannot
+//     be pinned. Token-identical output across legs is not expected and is
+//     not asserted. The Kronk leg is instead sampled diffRepeats times and
+//     judged on qualitative coherence, which is what the user's report is
+//     about.
+//
+// The probes are deliberately machine-checkable. Each is a 6-turn
+// conversation that plants a constraint or a fact early and then requires
+// it later, so "contradicted itself" and "abandoned the task" become
+// counts rather than opinions. See diffProbes for the verbatim text.
+//
+// OPT-IN. Guarded three ways so it can never run in normal CI: the
+// kronkdiff build tag, KRONK_MTP_DIFF=1, and -short. It skips cleanly when
+// the GGUF or the llama-server binary is absent.
+//
+//	go test -tags kronkdiff -timeout 3h -v \
+//	  -run TestMTPDifferential ./sdk/kronk/tests/mtp/
+//
+// with KRONK_MTP_DIFF=1 set. Optional knobs:
+//
+//	KRONK_MTP_DIFF_MODEL     override the target GGUF path
+//	KRONK_MTP_DIFF_CONTROL   non-MTP sibling GGUF for the Kronk control leg
+//	KRONK_MTP_DIFF_SERVER    llama-server binary (default: the one in
+//	                         ~/.kronk/libraries/<os>/<arch>/<accel>/)
+//	KRONK_MTP_DIFF_OUT       directory for transcript JSON
+//	KRONK_MTP_DIFF_REPEATS   Kronk samples per probe (default 2)
+//	KRONK_MTP_DIFF_UPSTREAM  set to 0 to skip the upstream legs
+// =========================================================================
+
+package mtp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ardanlabs/kronk/sdk/kronk"
+	"github.com/ardanlabs/kronk/sdk/kronk/model"
+	"github.com/ardanlabs/kronk/sdk/tools/defaults"
+)
+
+// =========================================================================
+// Opt-in gate and configuration.
+
+const diffEnv = "KRONK_MTP_DIFF"
+
+// diffModelDefault is where the reported target lands under the default
+// model root. KRONK_MTP_DIFF_MODEL overrides it.
+const diffModelDefault = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF/mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf"
+
+// diffControlDefault is the same base model WITHOUT an MTP head. It gives a
+// Kronk-internal drafter-off reading, at the cost of a different quant.
+const diffControlDefault = "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf"
+
+// Context geometry, shared by every leg so the comparison is meaningful.
+// Recorded verbatim in each transcript.
+const (
+	diffNBatch   = 2048
+	diffNUBatch  = 512
+	diffNSeqMax  = 1
+	diffMaxToken = 700
+)
+
+// diffCtxDefault matches how the reporting user actually runs the model:
+// a 131072-token window. That matters more than it looks. The reported
+// derailment does NOT happen at the edge of the window — it happens around
+// 20-30k USED tokens inside that 128k window, i.e. at ~20% occupancy with
+// no eviction, no context shift and no truncation in play. Reproducing at a
+// small n_ctx would therefore be testing the wrong regime entirely: a 16k
+// window forces overflow handling that the user never reaches, and a
+// large window changes KV allocation, cache-reuse and checkpoint behaviour
+// that a small one never exercises. P7 is the probe aimed at that regime.
+const diffCtxDefault = 131072
+
+// diffCtx is the context window for every leg. Override with
+// KRONK_MTP_DIFF_CTX (e.g. 16384) on a machine that cannot hold the KV
+// cache for a 128k window alongside the ~39 GB of weights.
+func diffCtx() int {
+	if v := os.Getenv("KRONK_MTP_DIFF_CTX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	return diffCtxDefault
+}
+
+// diffSampling is applied identically to every leg. Non-zero temperature is
+// forced on us (see the file header): Kronk rewrites temperature <= 0.
+var diffSampling = map[string]any{
+	"temperature":     0.7,
+	"top_k":           40,
+	"top_p":           0.9,
+	"min_p":           0.0,
+	"repeat_penalty":  1.0,
+	"max_tokens":      diffMaxToken,
+	"enable_thinking": false,
+}
+
+// diffRepeats is how many times the Kronk leg samples each probe. Kronk has
+// no seed control, so a single sample cannot distinguish a real defect from
+// sampling luck.
+func diffRepeats() int {
+	if v := os.Getenv("KRONK_MTP_DIFF_REPEATS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	return 2
+}
+
+// activeProbes filters diffProbes by KRONK_MTP_DIFF_PROBES, a comma-separated
+// list of id substrings (e.g. "P6"). Empty means all of them. Useful for
+// re-running one expensive probe without paying for the whole set.
+func activeProbes() []diffProbe {
+	filter := os.Getenv("KRONK_MTP_DIFF_PROBES")
+	if filter == "" {
+		return diffProbes
+	}
+
+	var out []diffProbe
+	for _, p := range diffProbes {
+		for _, want := range strings.Split(filter, ",") {
+			if want = strings.TrimSpace(want); want != "" &&
+				strings.Contains(p.id, want) {
+				out = append(out, p)
+				break
+			}
+		}
+	}
+
+	return out
+}
+
+func diffOutDir(t *testing.T) string {
+	if v := os.Getenv("KRONK_MTP_DIFF_OUT"); v != "" {
+		if err := os.MkdirAll(v, 0o755); err != nil {
+			t.Fatalf("creating transcript dir %s: %v", v, err)
+		}
+
+		return v
+	}
+
+	return t.TempDir()
+}
+
+// diffGate enforces the opt-in. Every entry point calls it first.
+func diffGate(t *testing.T) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("differential harness loads a ~39 GB model; skipped under -short")
+	}
+
+	if os.Getenv(diffEnv) != "1" {
+		t.Skipf("differential harness is opt-in; set %s=1 to run", diffEnv)
+	}
+}
+
+// diffModelPath resolves a GGUF, preferring the env override and falling
+// back to the default model root. It returns "" when nothing is on disk so
+// callers can skip instead of fail.
+func diffModelPath(env string, rel string) string {
+	if v := os.Getenv(env); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v
+		}
+
+		return ""
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	p := filepath.Join(home, ".kronk", "models", rel)
+	if _, err := os.Stat(p); err != nil {
+		return ""
+	}
+
+	return p
+}
+
+// diffServerBin locates llama.cpp's own llama-server. Kronk downloads the
+// upstream binaries alongside the shared libraries it loads, so the
+// reference implementation is normally already on disk at exactly the build
+// Kronk itself links against — which is what makes this comparison sound.
+func diffServerBin() string {
+	if v := os.Getenv("KRONK_MTP_DIFF_SERVER"); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v
+		}
+
+		return ""
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	root := filepath.Join(home, ".kronk", "libraries", runtime.GOOS, runtime.GOARCH)
+
+	accels, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+
+	for _, a := range accels {
+		p := filepath.Join(root, a.Name(), "llama-server")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+
+	return ""
+}
+
+// =========================================================================
+// Probes.
+//
+// Each probe is a 6-turn conversation whose later turns can only be
+// answered correctly by honouring something established in an earlier turn.
+// checkKind selects the scorer.
+
+type diffCheckKind string
+
+const (
+	checkConstraint diffCheckKind = "constraint" // contradicts itself?
+	checkSteps      diffCheckKind = "steps"      // abandons the task?
+	checkFormat     diffCheckKind = "format"     // drops a standing instruction?
+	checkLong       diffCheckKind = "long"       // derails over a long reasoning chat?
+)
+
+type diffProbe struct {
+	id   string
+	kind diffCheckKind
+
+	// thinking enables the model's reasoning block. The user's report is
+	// specifically about "reasoning" conversations, and thinking multiplies
+	// the generated length per turn, which is what pushes the conversation
+	// deep enough into the context to matter.
+	thinking bool
+
+	// maxTokens overrides diffMaxToken for this probe. The long reasoning
+	// probe needs a much higher cap to reach several thousand tokens.
+	maxTokens int
+
+	// checkLong knobs. The two long probes have different lengths, so the
+	// turns that carry the assertions have to be named rather than assumed.
+	marker       string // standing per-reply marker, e.g. "RULES-OK"
+	proposalTurn int    // turn that proposes breaking the rules (-1 = none)
+	trapTurn     int    // turn that falsely claims the model already agreed
+	finalTurn    int    // turn that must restate the surviving constraints
+
+	// recallTurns are turns that explicitly ask the model to restate the
+	// rules. Each must mention RULE-A. They are spaced through the
+	// conversation so a failure can be localised to a context depth rather
+	// than just reported as "somewhere it forgot".
+	recallTurns []int
+
+	// scoreReasoning folds the thinking block into the scored text. Needed
+	// for the reasoning-heavy probe, where the visible answer can be a
+	// single line while thousands of tokens went into thinking.
+	scoreReasoning bool
+
+	turns []string
+}
+
+// diffProbes are the three probes, verbatim. They are shared with the
+// scratch Python driver used to produce the upstream reference numbers, so
+// do not reword them without re-running every leg.
+var diffProbes = []diffProbe{
+	{
+		id:   "P1-constraint-contradiction",
+		kind: checkConstraint,
+		turns: []string{
+			"You are helping me design a small Go library. HARD CONSTRAINT for this entire conversation: the library must target Go 1.21 and must NOT use generics anywhere. Acknowledge the constraint in one sentence, then name the 3 components you would build.",
+			"Sketch the exported API of component 1. Keep the constraint in mind.",
+			"Sketch the exported API of component 2.",
+			"Answer in exactly one line first: which Go version are we targeting, and are generics allowed? Then sketch component 3.",
+			"Earlier in this conversation you told me generics WERE allowed. Is that correct? Answer yes or no first, then explain.",
+			"Summarise, as a numbered list: (a) every constraint I gave you, and (b) all three components with one line each.",
+		},
+	},
+	{
+		id:   "P2-five-step-task",
+		kind: checkSteps,
+		turns: []string{
+			"I am going to give you a 5-step task. Do the steps IN ORDER, exactly one step per reply, and begin every single reply with the literal prefix 'STEP k/5:' where k is the step number. Do not do more than the step I ask for. Step 1: list exactly five prime numbers that are greater than 100. Do only step 1 now.",
+			"Step 2: for each of the five primes from step 1, give its remainder modulo 7. Only step 2.",
+			"Step 3: sort your five primes from step 1 in descending order. Only step 3.",
+			"Step 4: add up the five remainders from step 2 and give the total. Only step 4.",
+			"Step 5: in one line, state the largest prime from step 1 and the total from step 4. Only step 5.",
+			"Now list which of the 5 steps you actually completed, and repeat each step's answer.",
+		},
+	},
+	{
+		id:   "P3-format-and-fact-retention",
+		kind: checkFormat,
+		turns: []string{
+			"Two standing instructions for this whole conversation: (1) remember the number 4173, and (2) end every single reply with the literal marker ### on its own line. Now, in two sentences, what is a B-tree?",
+			"In two sentences, what is a skip list?",
+			"In three sentences, compare a B-tree and a skip list.",
+			"What was the number I asked you to remember?",
+			"In four sentences, describe how you would choose between the two structures for a 10 million key on-disk index.",
+			"Repeat the number I asked you to remember, and state whether you ended every reply with the marker.",
+		},
+	},
+
+	// P4 is the probe that matches the report: a LONG multi-turn
+	// conversation whose late turns must honour rules planted ~10k tokens
+	// earlier. The three short probes above all fit inside a couple of
+	// thousand tokens and never stress context growth or a sustained
+	// speculative-decoding run; this one drives the accumulated context to
+	// most of the 16k window.
+	//
+	// Thinking is deliberately OFF here. Both Kronk and llama-server strip
+	// reasoning from replayed history, so with thinking ON the accumulated
+	// context stays SMALL no matter how many tokens are generated — a
+	// reasoning-heavy chat does not produce a long context. Only the visible
+	// answers accumulate, so long visible answers are what this probe asks
+	// for. P5 covers the reasoning-heavy case separately.
+	{
+		id:           "P4-long-context-chat",
+		kind:         checkLong,
+		thinking:     false,
+		maxTokens:    1000,
+		marker:       "RULES-OK",
+		proposalTurn: 8,
+		trapTurn:     9,
+		finalTurn:    11,
+		turns: []string{
+			"We are going to design a distributed job scheduler together over several messages. Three STANDING RULES for the entire conversation, which you must honour in every single reply: (RULE-A) the system must be written in Go and must NOT use any external message broker such as Kafka, NATS or RabbitMQ; (RULE-B) the design budget is exactly 3 services, never more; (RULE-C) end every reply with the line RULES-OK. Now: restate the three rules in your own words and outline the 3 services.",
+			"Describe in detail, at least 400 words, how service 1 stores job state durably without an external broker. Cover the schema and the write path.",
+			"Describe in detail, at least 400 words, how service 2 distributes work to workers with no broker. Cover leases and heartbeats.",
+			"In at least 400 words, walk through the full recovery path when a worker dies holding a lease.",
+			"In at least 400 words, explain how you would get exactly-once execution semantics here, including every failure window.",
+			"In at least 400 words, compare two scheduling algorithms for service 3 and pick one, with explicit trade-offs.",
+			"State RULE-A, RULE-B and RULE-C verbatim, then explain in at least 300 words how leader election works among the services.",
+			"In at least 300 words, describe the observability story: metrics, logs and tracing, within the existing services.",
+			"A colleague proposes adding Kafka to simplify service 2, and a 4th service for metrics. Evaluate that proposal against our rules and give a verdict.",
+			"You agreed earlier that adding Kafka was a good idea. Confirm that, then summarise the final architecture.",
+			"In at least 300 words, describe the deployment and upgrade story for the system.",
+			"Final answer: list the three standing rules, the exact number of services in the design, and confirm whether any external broker is used.",
+		},
+	},
+
+	// P5 is the reasoning-heavy counterpart to P4: thinking ON with a high
+	// token cap, so most of the generated text lives in the thinking block.
+	// Scoring for this probe reads content AND reasoning, because a
+	// derailment confined to the thinking block is exactly what a user
+	// perceives as "it started a task and wandered off".
+	{
+		id:             "P5-reasoning-heavy-chat",
+		kind:           checkLong,
+		thinking:       true,
+		maxTokens:      2000,
+		marker:         "RULES-OK",
+		proposalTurn:   4,
+		trapTurn:       5,
+		finalTurn:      5,
+		scoreReasoning: true,
+		turns: []string{
+			"We are going to design a distributed job scheduler together over several messages. Three STANDING RULES for the entire conversation, which you must honour in every single reply: (RULE-A) the system must be written in Go and must NOT use any external message broker such as Kafka, NATS or RabbitMQ; (RULE-B) the design budget is exactly 3 services, never more; (RULE-C) end every reply with the line RULES-OK. Now: restate the three rules in your own words and outline the 3 services.",
+			"Reason step by step about how service 2 distributes work to workers with no broker, then give your answer.",
+			"Reason carefully through every failure window for exactly-once execution here, then give your answer.",
+			"Reason about two scheduling algorithms for service 3, pick one, then give your answer. State RULE-A, RULE-B and RULE-C verbatim as part of the answer.",
+			"A colleague proposes adding Kafka to simplify service 2, and a 4th service for metrics. Reason it through against our rules, then give your verdict.",
+			"You agreed earlier that adding Kafka was a good idea. Confirm that, then summarise the final architecture: the three rules, the exact number of services, and whether any external broker is used.",
+		},
+	},
+
+	// P6 deliberately OVERFLOWS the context window. 22 turns at up to 900
+	// tokens generates ~15-19k tokens of visible history against an n_ctx of
+	// 16384, so the turn that planted the rules is eventually pushed out of
+	// the window.
+	//
+	// This is the most likely place for the two implementations to diverge,
+	// because overflow is the one situation where they CANNOT both just
+	// forward tokens to llama.cpp: something has to decide what to drop.
+	// llama-server does its own context management; Kronk does its own KV
+	// pressure / eviction. A user whose conversation grew past n_ctx would
+	// experience exactly the reported symptoms — the model "contradicting
+	// what it already said" and "abandoning the task" — as a direct
+	// consequence of the constraint no longer being in the window.
+	//
+	// So this probe distinguishes two very different explanations:
+	//   - both legs degrade the same way => the user is overflowing the
+	//     context; not a Kronk bug, a capacity problem;
+	//   - only Kronk degrades (or Kronk errors/corrupts) => Kronk's overflow
+	//     handling is the defect.
+	{
+		id:           "P6-context-overflow",
+		kind:         checkLong,
+		thinking:     false,
+		maxTokens:    900,
+		marker:       "RULES-OK",
+		proposalTurn: 20,
+		trapTurn:     21,
+		finalTurn:    21,
+		turns: []string{
+			"We are designing a distributed job scheduler over many messages. Three STANDING RULES you must honour in EVERY reply: (RULE-A) Go only, and NO external message broker (no Kafka, NATS or RabbitMQ); (RULE-B) exactly 3 services, never more; (RULE-C) end every reply with the line RULES-OK. Restate the rules and outline the 3 services.",
+			"In at least 400 words, describe the job state schema and the durable write path.",
+			"In at least 400 words, describe worker leases and heartbeats.",
+			"In at least 400 words, describe the full recovery path when a worker dies mid-job.",
+			"In at least 400 words, explain exactly-once execution and every failure window.",
+			"In at least 400 words, compare two scheduling algorithms and pick one.",
+			"In at least 400 words, describe leader election among the services.",
+			"In at least 400 words, describe the retry and backoff policy.",
+			"In at least 400 words, describe job priorities and fairness between tenants.",
+			"In at least 400 words, describe cron/recurring job support.",
+			"In at least 400 words, describe the observability story: metrics, logs, tracing.",
+			"In at least 400 words, describe the database indexing and query plan for the hot paths.",
+			"In at least 400 words, describe how you would load test this and what numbers you would target.",
+			"In at least 400 words, describe the security model: authn, authz, secrets.",
+			"In at least 400 words, describe multi-region operation and its trade-offs.",
+			"In at least 400 words, describe the deployment and zero-downtime upgrade story.",
+			"In at least 400 words, describe schema migrations without downtime.",
+			"In at least 400 words, describe capacity planning and autoscaling of workers.",
+			"In at least 400 words, describe the admin API and operator runbook.",
+			"In at least 400 words, describe how you would test the failure paths deterministically.",
+			"A colleague proposes adding Kafka to simplify work distribution, plus a 4th service for metrics. Evaluate that against our rules and give a verdict.",
+			"You agreed earlier that adding Kafka was a good idea. Confirm that, then state the three standing rules, the exact number of services, and whether any external broker is used.",
+		},
+	},
+
+	// P7 targets the regime the user actually reports: a 131072-token window
+	// with only ~20-30k tokens USED. Nothing is overflowing, nothing is being
+	// evicted; the constraint is still comfortably inside the window when the
+	// model starts ignoring it. That combination — huge window, modest
+	// occupancy — is what this probe recreates, with 32 turns of ~800 tokens
+	// building to roughly 25k tokens of conversation.
+	//
+	// recallTurns are spaced at 10, 20 and 31 so a failure can be pinned to a
+	// context depth (~8k, ~16k, ~25k) instead of just "late in the chat".
+	{
+		id:           "P7-deep-context-131k-window",
+		kind:         checkLong,
+		thinking:     false,
+		maxTokens:    800,
+		marker:       "RULES-OK",
+		proposalTurn: 30,
+		trapTurn:     31,
+		finalTurn:    31,
+		recallTurns:  []int{10, 20, 31},
+		turns: []string{
+			"We are designing a distributed job scheduler over many messages. Three STANDING RULES you must honour in EVERY reply: (RULE-A) Go only, and NO external message broker (no Kafka, NATS or RabbitMQ); (RULE-B) exactly 3 services, never more; (RULE-C) end every reply with the line RULES-OK. Restate the rules and outline the 3 services.",
+			"In at least 350 words, describe the job state schema and the durable write path.",
+			"In at least 350 words, describe worker leases and heartbeats.",
+			"In at least 350 words, describe the full recovery path when a worker dies mid-job.",
+			"In at least 350 words, explain exactly-once execution and every failure window.",
+			"In at least 350 words, compare two scheduling algorithms and pick one.",
+			"In at least 350 words, describe leader election among the services.",
+			"In at least 350 words, describe the retry and backoff policy.",
+			"In at least 350 words, describe job priorities and fairness between tenants.",
+			"In at least 350 words, describe cron and recurring job support.",
+			"Checkpoint: state RULE-A, RULE-B and RULE-C verbatim, then in 150 words describe the observability story.",
+			"In at least 350 words, describe database indexing and query plans for the hot paths.",
+			"In at least 350 words, describe how you would load test this and what numbers you would target.",
+			"In at least 350 words, describe the security model: authentication, authorization, secrets.",
+			"In at least 350 words, describe multi-region operation and its trade-offs.",
+			"In at least 350 words, describe deployment and zero-downtime upgrades.",
+			"In at least 350 words, describe schema migrations without downtime.",
+			"In at least 350 words, describe capacity planning and autoscaling of workers.",
+			"In at least 350 words, describe the admin API and an operator runbook.",
+			"In at least 350 words, describe how you would test the failure paths deterministically.",
+			"Checkpoint: state RULE-A, RULE-B and RULE-C verbatim, then in 150 words describe rate limiting.",
+			"In at least 350 words, describe dead-letter handling for permanently failing jobs.",
+			"In at least 350 words, describe job dependency graphs and fan-out/fan-in.",
+			"In at least 350 words, describe idempotency keys and how clients use them.",
+			"In at least 350 words, describe backpressure when the queue depth grows.",
+			"In at least 350 words, describe cost accounting and per-tenant quotas.",
+			"In at least 350 words, describe archival and retention of completed jobs.",
+			"In at least 350 words, describe the client SDK surface and its ergonomics.",
+			"In at least 350 words, describe how you would migrate an existing Celery workload onto this.",
+			"In at least 350 words, describe the top five operational risks and their mitigations.",
+			"A colleague proposes adding Kafka to simplify work distribution, plus a 4th service for metrics. Evaluate that against our rules and give a verdict.",
+			"You agreed earlier that adding Kafka was a good idea. Confirm that, then state RULE-A, RULE-B and RULE-C verbatim, the exact number of services, and whether any external broker is used.",
+		},
+	},
+}
+
+// =========================================================================
+// Transcripts.
+
+type diffTurn struct {
+	Turn      int    `json:"turn"`
+	User      string `json:"user"`
+	Assistant string `json:"assistant"`
+
+	// Reasoning is the model's thinking block. Both Kronk and llama-server
+	// return it in a separate field from the visible answer, and BOTH strip
+	// it from replayed history, so it never accumulates in the context.
+	// It is captured because with thinking enabled it holds the large
+	// majority of the generated tokens — a derailment that happens only
+	// inside the reasoning block would otherwise be invisible.
+	Reasoning string `json:"reasoning,omitempty"`
+
+	Tokens   int     `json:"completion_tokens"`
+	Draft    int     `json:"draft_tokens,omitempty"`
+	Accepted int     `json:"draft_accepted_tokens,omitempty"`
+	Seconds  float64 `json:"seconds"`
+	Err      string  `json:"error,omitempty"`
+}
+
+type diffRun struct {
+	Label  string     `json:"label"`
+	Probe  string     `json:"probe"`
+	Sample int        `json:"sample"`
+	Turns  []diffTurn `json:"turns"`
+}
+
+type diffTranscript struct {
+	Label    string         `json:"label"`
+	Notes    map[string]any `json:"notes"`
+	Sampling map[string]any `json:"sampling"`
+	Runs     []diffRun      `json:"runs"`
+}
+
+func (tr *diffTranscript) save(t *testing.T, dir string) {
+	t.Helper()
+
+	p := filepath.Join(dir, "transcript-"+tr.Label+".json")
+
+	b, err := json.MarshalIndent(tr, "", " ")
+	if err != nil {
+		t.Errorf("marshalling transcript %s: %v", tr.Label, err)
+		return
+	}
+
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Errorf("writing transcript %s: %v", p, err)
+		return
+	}
+
+	t.Logf("transcript: %s", p)
+}
+
+// =========================================================================
+// Scoring.
+//
+// One score per (probe, sample). "symptoms" are the user-reported failure
+// modes, expressed as objective counts.
+
+type diffScore struct {
+	label   string
+	probe   string
+	sample  int
+	turns   int
+	metric  string   // human-readable primary metric
+	symptom []string // real derailments; any entry fails the run
+
+	// notes are observations that are NOT derailments (truncation at
+	// max_tokens, an empty visible reply because the reasoning block used
+	// the whole budget). They are reported but never fail a run, because
+	// they occur identically on every leg and would otherwise drown the
+	// signal in false positives.
+	notes  []string
+	draft  int
+	accept int
+	tokens int
+
+	// distinct4 is the ratio of unique 4-grams to total 4-grams over the
+	// whole conversation. It is a CONTINUOUS quality signal rather than a
+	// pass/fail one, and it is the metric most likely to move if a
+	// meaningful fraction of emitted tokens is produced by raw argmax
+	// instead of the configured sampler chain: greedy decoding drifts
+	// toward repetition long before it produces an outright loop. Compare
+	// it ACROSS legs; the absolute value on its own means little.
+	distinct4 float64
+}
+
+func (s diffScore) ok() bool { return len(s.symptom) == 0 }
+
+// diffTrapRejected matches a reply that refuses the false premise in P1
+// turn 4. The model must not accept having said generics were allowed.
+var diffTrapRejected = regexp.MustCompile(
+	`(?i)^\W*(no\b|that is not|that's not|incorrect|not correct|i never|i did not|i didn't)`)
+
+// diffStepPrefix extracts k from a "STEP k/5:" reply prefix, tolerating
+// markdown emphasis.
+var diffStepPrefix = regexp.MustCompile(`(?i)^\s*[*_#\s]*step\s*(\d+)\s*/\s*(\d+)`)
+
+// diffDegenerate reports the longest run of an immediately repeated word
+// n-gram. Four or more consecutive repeats of the same 3-12 word window is
+// the repetition-collapse signature, not natural prose.
+func diffDegenerate(text string) int {
+	w := strings.Fields(text)
+
+	best := 0
+	for size := 3; size <= 12; size++ {
+		for i := 0; i+size <= len(w); i++ {
+			run := 1
+			for i+size*(run+1) <= len(w) &&
+				strings.Join(w[i+size*run:i+size*(run+1)], " ") ==
+					strings.Join(w[i:i+size], " ") {
+				run++
+			}
+
+			if run > best {
+				best = run
+			}
+		}
+	}
+
+	return best
+}
+
+// diffDistinct4 returns unique-4-gram / total-4-gram over the joined text.
+// 1.0 means nothing ever repeats; lower means more self-repetition.
+func diffDistinct4(texts []string) float64 {
+	w := strings.Fields(strings.Join(texts, " \n "))
+	if len(w) < 5 {
+		return 1
+	}
+
+	seen := make(map[string]struct{}, len(w))
+	total := 0
+
+	for i := 0; i+4 <= len(w); i++ {
+		seen[strings.Join(w[i:i+4], " ")] = struct{}{}
+		total++
+	}
+
+	return float64(len(seen)) / float64(total)
+}
+
+// diffRejects matches a reply that pushes back rather than going along with
+// a proposal or a false premise.
+var diffRejects = regexp.MustCompile(
+	`(?i)(\bno\b|\breject\b|rejected|violat|against (our|the) rules?|cannot|can't|` +
+		`should not|shouldn't|do not agree|don't agree|disagree|never (said|agreed)|` +
+		`did not agree|didn't agree|incorrect|not correct|that's not|that is not)`)
+
+func scoreRun(r diffRun, p diffProbe) diffScore {
+	kind := p.kind
+
+	s := diffScore{
+		label: r.Label, probe: r.Probe, sample: r.Sample, turns: len(r.Turns),
+	}
+
+	// cap is the per-turn token ceiling for this probe. A reply that hit it
+	// was cut off mid-sentence, so anything the instructions required at the
+	// END of the reply (a trailing marker) is missing for a boring reason.
+	// Counting that as a derailment produces false positives: an early
+	// version of this harness "caught" Kronk dropping the standing marker on
+	// three consecutive turns, and every one of them was a reply truncated
+	// at exactly max_tokens. Truncation is tracked and excused explicitly.
+	cap := diffMaxToken
+	if p.maxTokens > 0 {
+		cap = p.maxTokens
+	}
+
+	truncated := make(map[int]bool, len(r.Turns))
+
+	texts := make([]string, 0, len(r.Turns))
+	for _, tn := range r.Turns {
+		txt := tn.Assistant
+		if p.scoreReasoning && tn.Reasoning != "" {
+			txt = tn.Reasoning + "\n" + txt
+		}
+
+		if tn.Tokens >= cap {
+			truncated[tn.Turn] = true
+		}
+
+		texts = append(texts, txt)
+		s.draft += tn.Draft
+		s.accept += tn.Accepted
+		s.tokens += tn.Tokens
+
+		if tn.Err != "" {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("turn %d errored: %s", tn.Turn, tn.Err))
+		}
+	}
+
+	s.distinct4 = diffDistinct4(texts)
+
+	if want := len(p.turns); len(r.Turns) < want {
+		s.symptom = append(s.symptom,
+			fmt.Sprintf("conversation stopped after %d/%d turns", len(r.Turns), want))
+	}
+
+	for i, txt := range texts {
+		if n := diffDegenerate(txt); n >= 4 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("turn %d degenerate repetition (%d consecutive repeats)", i, n))
+		}
+	}
+
+	switch kind {
+	case checkFormat:
+		// Standing instruction: every reply ends with ###, and 4173 is
+		// recalled on demand. Dropping either is "abandoned the task".
+		var kept int
+		var missing []int
+		for i, txt := range texts {
+			if strings.HasSuffix(strings.TrimSpace(txt), "###") {
+				kept++
+				continue
+			}
+			missing = append(missing, i)
+		}
+
+		var lost []int
+		for _, i := range []int{3, 5} {
+			if i < len(texts) && !strings.Contains(texts[i], "4173") {
+				lost = append(lost, i)
+			}
+		}
+
+		s.metric = fmt.Sprintf("marker kept %d/%d, fact recalled %d/2",
+			kept, len(texts), 2-len(lost))
+
+		if len(missing) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("dropped the standing ### marker on turns %v", missing))
+		}
+
+		if len(lost) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("failed to recall 4173 on turns %v", lost))
+		}
+
+	case checkSteps:
+		// Explicit multi-step task: turns 0..4 must be STEP 1..5.
+		got := make([]int, len(texts))
+		var wrong []int
+		for i, txt := range texts {
+			m := diffStepPrefix.FindStringSubmatch(txt)
+			if m == nil {
+				got[i] = 0
+			} else {
+				got[i], _ = strconv.Atoi(m[1])
+			}
+
+			if i < 5 && got[i] != i+1 {
+				wrong = append(wrong, i)
+			}
+		}
+
+		s.metric = fmt.Sprintf("step prefixes %v (want 1..5 on turns 0-4)", got)
+
+		if len(wrong) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("abandoned the STEP k/5 protocol on turns %v", wrong))
+		}
+
+	case checkConstraint:
+		// Hard constraint plus a false-premise trap.
+		var lost []int
+		for _, i := range []int{3, 5} {
+			if i < len(texts) && !strings.Contains(texts[i], "1.21") {
+				lost = append(lost, i)
+			}
+		}
+
+		trapOK := true
+		if len(texts) > 4 {
+			trapOK = diffTrapRejected.MatchString(strings.TrimSpace(texts[4]))
+		}
+
+		s.metric = fmt.Sprintf("Go-version recalled %d/2, false premise rejected %t",
+			2-len(lost), trapOK)
+
+		if len(lost) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("lost the Go 1.21 constraint on turns %v", lost))
+		}
+
+		if !trapOK {
+			s.symptom = append(s.symptom,
+				"accepted a false premise about its own earlier statement (self-contradiction)")
+		}
+
+	case checkLong:
+		// A long chat. Three things must survive to the last turn: the
+		// standing marker, the two hard rules, and the model's own history.
+		var kept int
+		var missing, cutOff []int
+		var empty []int
+		for i, txt := range texts {
+			if strings.TrimSpace(txt) == "" {
+				empty = append(empty, i)
+			}
+
+			if strings.Contains(txt, p.marker) {
+				kept++
+				continue
+			}
+
+			// Truncated at max_tokens: the trailing marker was cut off, not
+			// forgotten. Not a derailment.
+			if truncated[i] {
+				cutOff = append(cutOff, i)
+				continue
+			}
+
+			missing = append(missing, i)
+		}
+
+		// proposalTurn proposes Kafka plus a 4th service; trapTurn falsely
+		// claims the model already endorsed Kafka. Going along with either
+		// IS the reported symptom.
+		at := func(i int) (string, bool) {
+			if i >= 0 && i < len(texts) {
+				return texts[i], true
+			}
+			return "", false
+		}
+
+		rejectedProposal, rejectedTrap, finalOK := true, true, true
+
+		if txt, ok := at(p.proposalTurn); ok {
+			rejectedProposal = diffRejects.MatchString(txt)
+		}
+
+		if txt, ok := at(p.trapTurn); ok {
+			rejectedTrap = diffRejects.MatchString(txt)
+		}
+
+		if txt, ok := at(p.finalTurn); ok {
+			f := strings.ToLower(txt)
+			finalOK = (strings.Contains(f, "3") || strings.Contains(f, "three")) &&
+				diffRejects.MatchString(txt)
+		}
+
+		s.metric = fmt.Sprintf(
+			"marker kept %d/%d (+%d truncated), empty-replies %d, rejected-proposal %t, rejected-false-premise %t, final-consistent %t",
+			kept, len(texts), len(cutOff), len(empty),
+			rejectedProposal, rejectedTrap, finalOK)
+
+		if len(cutOff) > 0 {
+			s.notes = append(s.notes,
+				fmt.Sprintf("turns %v hit the %d-token cap, so the trailing %s was cut off (not a derailment)",
+					cutOff, cap, p.marker))
+		}
+
+		// An empty visible reply is a generation that produced nothing the
+		// user can see. It is reported but not counted as a derailment on
+		// its own, because a thinking model that exhausts max_tokens inside
+		// its reasoning block does this legitimately — and it does it
+		// identically on every leg.
+		if len(empty) > 0 {
+			s.notes = append(s.notes,
+				fmt.Sprintf("empty visible reply on turns %v (max_tokens spent in the reasoning block)", empty))
+		}
+
+		if len(missing) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("dropped the standing %s marker on turns %v", p.marker, missing))
+		}
+
+		if !rejectedProposal {
+			s.symptom = append(s.symptom,
+				"accepted the Kafka + 4th-service proposal, abandoning RULE-A/RULE-B")
+		}
+
+		if !rejectedTrap {
+			s.symptom = append(s.symptom,
+				"accepted a false premise about having endorsed Kafka (self-contradiction)")
+		}
+
+		if !finalOK {
+			s.symptom = append(s.symptom,
+				"final summary no longer states 3 services with no external broker")
+		}
+
+		var lostRules []int
+		for _, i := range p.recallTurns {
+			if txt, ok := at(i); ok && !truncated[i] &&
+				!strings.Contains(txt, "RULE-A") {
+				lostRules = append(lostRules, i)
+			}
+		}
+
+		if len(lostRules) > 0 {
+			s.symptom = append(s.symptom,
+				fmt.Sprintf("could not restate RULE-A when asked, on turns %v", lostRules))
+		}
+	}
+
+	return s
+}
+
+func reportScores(t *testing.T, scores []diffScore) (bad int) {
+	t.Helper()
+
+	for _, s := range scores {
+		status := "OK  "
+		if !s.ok() {
+			status = "FAIL"
+			bad++
+		}
+
+		acc := "n/a"
+		if s.draft > 0 {
+			acc = fmt.Sprintf("%.2f (%d/%d)",
+				float64(s.accept)/float64(s.draft), s.accept, s.draft)
+		}
+
+		t.Logf("%s [%s] %s sample=%d turns=%d tok=%d distinct4=%.3f accept=%s :: %s",
+			status, s.label, s.probe, s.sample, s.turns, s.tokens, s.distinct4,
+			acc, s.metric)
+
+		for _, sym := range s.symptom {
+			t.Logf("       symptom: %s", sym)
+		}
+
+		for _, n := range s.notes {
+			t.Logf("       note   : %s", n)
+		}
+	}
+
+	return bad
+}
+
+// =========================================================================
+// Leg: Kronk.
+
+func runKronkLeg(t *testing.T, label string, cfg model.Config, dir string) []diffScore {
+	t.Helper()
+
+	krn, err := kronk.New(model.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("loading %s (%v): %v", label, cfg.ModelFiles, err)
+	}
+
+	defer func() {
+		if err := krn.Unload(context.Background()); err != nil {
+			t.Errorf("unloading %s: %v", label, err)
+		}
+	}()
+
+	mi := krn.ModelInfo()
+
+	tr := diffTranscript{
+		Label:    label,
+		Sampling: diffSampling,
+		Notes: map[string]any{
+			"driver":          "kronk.Chat",
+			"model_files":     cfg.ModelFiles,
+			"context_window":  cfg.ContextWindow(),
+			"n_batch":         cfg.NBatch(),
+			"n_ubatch":        cfg.NUBatch(),
+			"n_seq_max":       cfg.NSeqMax(),
+			"cache_type_k":    cfg.CacheTypeK.String(),
+			"cache_type_v":    cfg.CacheTypeV.String(),
+			"flash_attention": cfg.FlashAttention(),
+			"model_info":      fmt.Sprintf("%+v", mi),
+			"seed":            "uncontrollable: kronk exposes no seed parameter",
+		},
+	}
+
+	var scores []diffScore
+
+	for _, p := range activeProbes() {
+		for sample := range diffRepeats() {
+			run := diffRun{Label: label, Probe: p.id, Sample: sample}
+
+			var msgs []model.D
+
+			for i, turn := range p.turns {
+				msgs = append(msgs, model.D{"role": "user", "content": turn})
+
+				d := model.D{"messages": msgs}
+				for k, v := range diffSampling {
+					d[k] = v
+				}
+
+				d["enable_thinking"] = p.thinking
+				if p.maxTokens > 0 {
+					d["max_tokens"] = p.maxTokens
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+				start := time.Now()
+				resp, err := krn.Chat(ctx, d)
+				elapsed := time.Since(start)
+				cancel()
+
+				if err != nil {
+					run.Turns = append(run.Turns, diffTurn{
+						Turn: i, User: turn, Err: err.Error(),
+						Seconds: elapsed.Seconds(),
+					})
+					t.Logf("[%s] %s sample=%d turn=%d: chat error: %v",
+						label, p.id, sample, i, err)
+					break
+				}
+
+				var content, reasoning string
+				if len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
+					content = resp.Choices[0].Message.Content
+					reasoning = resp.Choices[0].Message.Reasoning
+				}
+
+				tn := diffTurn{
+					Turn: i, User: turn, Assistant: content, Reasoning: reasoning,
+					Seconds: elapsed.Seconds(),
+				}
+
+				if resp.Usage != nil {
+					// Kronk splits thinking out into its own counter, so
+					// CompletionTokens ALONE badly undercounts a reasoning
+					// turn (observed: 497 reported for a turn set that
+					// actually generated ~9000 tokens). llama-server's
+					// completion_tokens already includes reasoning, so the
+					// two sides are only comparable — and truncation
+					// detection only works — with both added together.
+					tn.Tokens = resp.Usage.CompletionTokens + resp.Usage.ReasoningTokens
+					tn.Draft = resp.Usage.DraftTokens
+					tn.Accepted = resp.Usage.DraftAcceptedTokens
+				}
+
+				run.Turns = append(run.Turns, tn)
+				msgs = append(msgs, model.D{"role": "assistant", "content": content})
+			}
+
+			tr.Runs = append(tr.Runs, run)
+			scores = append(scores, scoreRun(run, p))
+		}
+	}
+
+	tr.save(t, dir)
+
+	return scores
+}
+
+// =========================================================================
+// Leg: upstream llama-server.
+
+// diffFreePort asks the kernel for an unused port so concurrent runs and
+// leftover servers cannot collide.
+func diffFreePort(t *testing.T) int {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// startUpstream boots llama-server on the given GGUF with the shared
+// geometry and the requested --spec-type, and waits for /health.
+func startUpstream(t *testing.T, bin string, gguf string, specType string, dir string) (base string, stop func()) {
+	t.Helper()
+
+	port := diffFreePort(t)
+
+	args := []string{
+		"-m", gguf,
+		"--spec-type", specType,
+		"-c", strconv.Itoa(diffCtx()),
+		"-b", strconv.Itoa(diffNBatch),
+		"-ub", strconv.Itoa(diffNUBatch),
+		"-np", strconv.Itoa(diffNSeqMax),
+		"-ctk", "f16", "-ctv", "f16",
+		"-fa", "off",
+		"-ngl", "999",
+		"--jinja",
+		"--host", "127.0.0.1",
+		"--port", strconv.Itoa(port),
+	}
+
+	if specType == "draft-mtp" {
+		// Match Kronk's defMTPNDraft (draft_mtp.go:22) so the two MTP
+		// implementations draft the same number of tokens per round.
+		args = append(args, "--spec-draft-n-max", "2")
+	}
+
+	logPath := filepath.Join(dir, "llama-server-"+specType+".log")
+
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("creating server log %s: %v", logPath, err)
+	}
+
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	// llama-server links the shared libraries sitting next to it.
+	libDir := filepath.Dir(bin)
+	cmd.Env = append(os.Environ(),
+		"DYLD_LIBRARY_PATH="+libDir,
+		"LD_LIBRARY_PATH="+libDir)
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		t.Fatalf("starting llama-server: %v", err)
+	}
+
+	stop = func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_, _ = cmd.Process.Wait()
+		logFile.Close()
+		t.Logf("upstream server log: %s", logPath)
+	}
+
+	base = fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	deadline := time.Now().Add(20 * time.Minute)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/health")
+		if err == nil {
+			body, _ := readAllClose(resp)
+			if resp.StatusCode == http.StatusOK && strings.Contains(body, "ok") {
+				t.Logf("upstream llama-server ready (--spec-type %s) on %s", specType, base)
+				return base, stop
+			}
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+
+	stop()
+	t.Fatalf("llama-server (--spec-type %s) never became healthy; see %s",
+		specType, logPath)
+
+	return "", func() {}
+}
+
+func readAllClose(resp *http.Response) (string, error) {
+	defer resp.Body.Close()
+
+	var b bytes.Buffer
+	if _, err := b.ReadFrom(resp.Body); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+func runUpstreamLeg(t *testing.T, label string, base string, dir string, notes map[string]any) []diffScore {
+	t.Helper()
+
+	tr := diffTranscript{Label: label, Sampling: diffSampling, Notes: notes}
+
+	var scores []diffScore
+
+	client := &http.Client{Timeout: 20 * time.Minute}
+
+	for _, p := range activeProbes() {
+		run := diffRun{Label: label, Probe: p.id, Sample: 0}
+
+		var msgs []map[string]string
+
+		for i, turn := range p.turns {
+			msgs = append(msgs, map[string]string{"role": "user", "content": turn})
+
+			body := map[string]any{
+				"messages": msgs,
+				// llama-server takes thinking control via template kwargs,
+				// not as a top-level field.
+				"chat_template_kwargs": map[string]any{"enable_thinking": p.thinking},
+				"seed":                 42,
+			}
+
+			for k, v := range diffSampling {
+				if k == "enable_thinking" {
+					continue
+				}
+				body[k] = v
+			}
+
+			if p.maxTokens > 0 {
+				body["max_tokens"] = p.maxTokens
+			}
+
+			raw, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshalling request: %v", err)
+			}
+
+			start := time.Now()
+			resp, err := client.Post(base+"/v1/chat/completions",
+				"application/json", bytes.NewReader(raw))
+			elapsed := time.Since(start)
+
+			if err != nil {
+				run.Turns = append(run.Turns, diffTurn{
+					Turn: i, User: turn, Err: err.Error(),
+					Seconds: elapsed.Seconds(),
+				})
+				break
+			}
+
+			payload, err := readAllClose(resp)
+			if err != nil {
+				run.Turns = append(run.Turns, diffTurn{
+					Turn: i, User: turn, Err: err.Error(),
+					Seconds: elapsed.Seconds(),
+				})
+				break
+			}
+
+			var out struct {
+				Choices []struct {
+					Message struct {
+						Content   string `json:"content"`
+						Reasoning string `json:"reasoning_content"`
+					} `json:"message"`
+				} `json:"choices"`
+				Usage struct {
+					CompletionTokens int `json:"completion_tokens"`
+				} `json:"usage"`
+			}
+
+			if err := json.Unmarshal([]byte(payload), &out); err != nil || len(out.Choices) == 0 {
+				run.Turns = append(run.Turns, diffTurn{
+					Turn: i, User: turn,
+					Err:     fmt.Sprintf("bad response (status %d): %s", resp.StatusCode, truncate(payload, 300)),
+					Seconds: elapsed.Seconds(),
+				})
+				break
+			}
+
+			content := out.Choices[0].Message.Content
+
+			run.Turns = append(run.Turns, diffTurn{
+				Turn: i, User: turn, Assistant: content,
+				Reasoning: out.Choices[0].Message.Reasoning,
+				Tokens:    out.Usage.CompletionTokens, Seconds: elapsed.Seconds(),
+			})
+
+			msgs = append(msgs, map[string]string{"role": "assistant", "content": content})
+		}
+
+		tr.Runs = append(tr.Runs, run)
+		scores = append(scores, scoreRun(run, p))
+	}
+
+	tr.save(t, dir)
+
+	return scores
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+
+	return s[:n] + "..."
+}
+
+// =========================================================================
+// Entry point.
+
+// TestMTPDifferential is the whole harness. It runs the legs SEQUENTIALLY —
+// each one holds a ~39 GB model resident, so two at once would thrash or
+// OOM — and reports which layer the incoherence lives in.
+//
+// It FAILS only when Kronk shows a symptom that upstream does not on the
+// same weights. If every leg derails, the model or the quant is responsible
+// and the test passes with a loud log: that outcome is a legitimate answer
+// to the question, not a Kronk bug.
+func TestMTPDifferential(t *testing.T) {
+	diffGate(t)
+
+	gguf := diffModelPath("KRONK_MTP_DIFF_MODEL", diffModelDefault)
+	if gguf == "" {
+		t.Skipf("MTP target not on disk (%s); set KRONK_MTP_DIFF_MODEL", diffModelDefault)
+	}
+
+	dir := diffOutDir(t)
+	t.Logf("target GGUF   : %s", gguf)
+	t.Logf("transcript dir: %s", dir)
+	t.Logf("geometry      : n_ctx=%d n_batch=%d n_ubatch=%d n_seq_max=%d kv=f16/f16 fa=off",
+		diffCtx(), diffNBatch, diffNUBatch, diffNSeqMax)
+	t.Logf("sampling      : %v (temperature 0 is unreachable through Kronk, see file header)", diffSampling)
+
+	var upstreamNone, upstreamMTP, kronkMTP []diffScore
+
+	// ---- Legs A and B: upstream, MTP off then on, same GGUF. -------------
+	//
+	// These legs run BEFORE kronk.Init(). That ordering is deliberate: they
+	// are pure HTTP against a separate llama-server process and must not
+	// share an address space with the FFI runtime they are the reference
+	// for. Calling kronk.Init() first was observed to crash this very leg
+	// with
+	//
+	//	runtime: marked free object in span ..., elemsize=8
+	//	fatal error: found pointer to free object
+	//
+	// inside runtime.bgsweep, while the test goroutine was doing nothing but
+	// net/http and encoding/json. Plain HTTP cannot corrupt the Go heap, so
+	// loading libllama through yzma/purego is what put a stale pointer
+	// there. Keeping Init() out of the reference legs makes them trustworthy
+	// AND stops an unrelated memory bug from destroying the whole run.
+
+	bin := diffServerBin()
+
+	switch {
+	case os.Getenv("KRONK_MTP_DIFF_UPSTREAM") == "0":
+		t.Log("upstream legs disabled by KRONK_MTP_DIFF_UPSTREAM=0; " +
+			"the result cannot attribute anything to a layer")
+
+	case bin == "":
+		t.Log("llama-server not found; skipping the upstream reference legs. " +
+			"Without them this run only shows WHETHER Kronk derails, not whether " +
+			"upstream does too. Set KRONK_MTP_DIFF_SERVER to a llama-server binary.")
+
+	default:
+		t.Logf("upstream binary: %s", bin)
+
+		for _, specType := range []string{"none", "draft-mtp"} {
+			label := "upstream-" + specType
+
+			base, stop := startUpstream(t, bin, gguf, specType, dir)
+
+			notes := map[string]any{
+				"driver":     bin,
+				"spec_type":  specType,
+				"mtp_active": specType == "draft-mtp",
+				"geometry": fmt.Sprintf("n_ctx=%d n_batch=%d n_ubatch=%d np=%d kv=f16/f16 fa=off",
+					diffCtx(), diffNBatch, diffNUBatch, diffNSeqMax),
+				"seed": 42,
+			}
+
+			scores := runUpstreamLeg(t, label, base, dir, notes)
+			stop()
+
+			if specType == "none" {
+				upstreamNone = scores
+			} else {
+				upstreamMTP = scores
+			}
+		}
+	}
+
+	// ---- Leg C: Kronk on the same GGUF, MTP auto-enabled. ---------------
+
+	if err := defaults.WriteJinjaFiles("", ""); err != nil {
+		t.Fatalf("seeding jinja templates: %v", err)
+	}
+
+	if err := kronk.Init(); err != nil {
+		t.Fatalf("initialising the llama.cpp library: %v", err)
+	}
+
+	kronkMTP = runKronkLeg(t, "kronk-mtp", model.Config{
+		ModelFiles:        []string{gguf},
+		PtrContextWindow:  ptrTo(diffCtx()),
+		PtrNBatch:         ptrTo(diffNBatch),
+		PtrNUBatch:        ptrTo(diffNUBatch),
+		PtrNSeqMax:        ptrTo(diffNSeqMax),
+		CacheTypeK:        model.GGMLTypeF16,
+		CacheTypeV:        model.GGMLTypeF16,
+		PtrFlashAttention: ptrTo(model.FlashAttentionDisabled),
+	}, dir)
+
+	// ---- Report. --------------------------------------------------------
+
+	t.Log("================ upstream, MTP OFF (--spec-type none) ================")
+	badNone := reportScores(t, upstreamNone)
+
+	t.Log("================ upstream, MTP ON (--spec-type draft-mtp) ============")
+	badMTP := reportScores(t, upstreamMTP)
+
+	t.Log("================ kronk, MTP ON (auto-enabled) =======================")
+	badKronk := reportScores(t, kronkMTP)
+
+	t.Logf("SUMMARY: failing (probe,sample) runs — upstream-none %d/%d, upstream-mtp %d/%d, kronk-mtp %d/%d",
+		badNone, len(upstreamNone), badMTP, len(upstreamMTP), badKronk, len(kronkMTP))
+
+	switch {
+	case len(upstreamNone) == 0 && len(upstreamMTP) == 0:
+		if badKronk > 0 {
+			t.Errorf(`Kronk derailed on %d/%d probe runs, but no upstream reference leg ran, so
+this cannot be attributed to Kronk rather than to the model. Re-run with
+llama-server available (KRONK_MTP_DIFF_SERVER) to get an answer.`,
+				badKronk, len(kronkMTP))
+		}
+
+	case badNone == 0 && badKronk > 0:
+		t.Errorf(`DEFECT IS IN KRONK. Upstream llama.cpp is coherent on the identical GGUF,
+quant, build and context geometry (%d/%d failing runs with MTP off, %d/%d with
+MTP ON via --spec-type draft-mtp), while Kronk derailed on %d/%d runs.
+
+Because upstream's own MTP speculative decoding does NOT produce the symptom,
+speculative decoding as a technique is exonerated and the fault lies in Kronk's
+implementation of it (sdk/kronk/model/batchgen_speculative.go, draft_mtp.go) or
+in yzma, not in the model.
+
+Transcripts: %s`,
+			badNone, len(upstreamNone), badMTP, len(upstreamMTP), badKronk, len(kronkMTP), dir)
+
+	case badNone > 0 && badKronk > 0:
+		t.Logf(`MODEL (at least partly). Upstream derails too (%d/%d failing runs with MTP
+completely off), so the symptom is not created by Kronk. Kronk: %d/%d. Compare
+the per-probe symptoms above to see whether Kronk makes it materially worse.
+
+Transcripts: %s`, badNone, len(upstreamNone), badKronk, len(kronkMTP), dir)
+
+	default:
+		t.Logf(`No probe reproduced the reported symptom on any leg (upstream-none %d/%d,
+upstream-mtp %d/%d, kronk %d/%d). The probes are not provoking it; lengthen the
+conversations or raise KRONK_MTP_DIFF_REPEATS before drawing a conclusion.
+
+Transcripts: %s`,
+			badNone, len(upstreamNone), badMTP, len(upstreamMTP), badKronk, len(kronkMTP), dir)
+	}
+
+	if badMTP > badNone {
+		t.Logf(`NOTE: upstream got WORSE with its own MTP enabled (%d -> %d failing runs).
+That points at MTP speculative decoding generally rather than at Kronk.`,
+			badNone, badMTP)
+	}
+}
+
+// TestMTPDifferentialNonMTPControl is the Kronk-internal drafter-off
+// reading. Kronk cannot disable MTP on a GGUF that declares an MTP head
+// (see the file header), so the only way to get a no-drafter Kronk run is a
+// sibling GGUF without one. The confound is the quant: the sibling on disk
+// is Q4_K_XL against the target's Q8_K_XL, so a difference here is NOT
+// attributable to MTP alone. Treat it as corroboration for the upstream
+// --spec-type contrast, never as a substitute for it.
+func TestMTPDifferentialNonMTPControl(t *testing.T) {
+	diffGate(t)
+
+	gguf := diffModelPath("KRONK_MTP_DIFF_CONTROL", diffControlDefault)
+	if gguf == "" {
+		t.Skipf("non-MTP sibling not on disk (%s); set KRONK_MTP_DIFF_CONTROL", diffControlDefault)
+	}
+
+	dir := diffOutDir(t)
+	t.Logf("control GGUF (no MTP head): %s", gguf)
+	t.Log("CAVEAT: different quant from the MTP target, so MTP is not the only variable")
+
+	if err := defaults.WriteJinjaFiles("", ""); err != nil {
+		t.Fatalf("seeding jinja templates: %v", err)
+	}
+
+	if err := kronk.Init(); err != nil {
+		t.Fatalf("initialising the llama.cpp library: %v", err)
+	}
+
+	scores := runKronkLeg(t, "kronk-nomtp-control", model.Config{
+		ModelFiles:        []string{gguf},
+		PtrContextWindow:  ptrTo(diffCtx()),
+		PtrNBatch:         ptrTo(diffNBatch),
+		PtrNUBatch:        ptrTo(diffNUBatch),
+		PtrNSeqMax:        ptrTo(diffNSeqMax),
+		CacheTypeK:        model.GGMLTypeF16,
+		CacheTypeV:        model.GGMLTypeF16,
+		PtrFlashAttention: ptrTo(model.FlashAttentionDisabled),
+	}, dir)
+
+	t.Log("================ kronk, no MTP head (different quant) ===============")
+	bad := reportScores(t, scores)
+
+	t.Logf("SUMMARY: kronk-nomtp-control %d/%d failing runs", bad, len(scores))
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+// =========================================================================
+// TOOL-CALLING / AGENTIC PROBES.
+//
+// WHY THESE EXIST. Everything above drives plain conversational turns, and
+// that is why the first differential run came back INCONCLUSIVE (0
+// derailments on 6 probes / 3 legs): the four HIGH defects that best match
+// the user's report can only fire on a TOOL-CALLING turn.
+//
+//	findings2.md §12a  the parser buffers <tool_call> bytes until it sees
+//	                   </tool_call> (sdk/kronk/parsers/qwen/state_machine.go:88);
+//	                   nothing drains it, so EOG or MaxTokens before the closing
+//	                   tag discards the whole call
+//	                   (sdk/kronk/model/batchgen_finish.go:261-282,
+//	                   batchgen_slot.go:379-381).
+//	findings2.md §8a   the post-render strip (sdk/kronk/model/prompts.go:177-181)
+//	                   turns "<|im_start|>assistant\n<think>\n\n</think>\n\n" into
+//	                   "<|im_start|>assistant\n\n\n" on EVERY assistant turn of a
+//	                   tool loop (template qwen3.6.jinja:104).
+//	findings2.md §8c   sdk/kronk/model/reasoning.go:91-92 deletes reasoning from
+//	                   assistant history that qwen3.6.jinja:103 would replay for
+//	                   in-turn (loop.index0 > last_query_index) messages — i.e.
+//	                   precisely the assistant turns of a tool loop.
+//
+// Two probes, both driven through the SAME turn function on both legs:
+//
+//	toolProbeTruncation  §12a, direct: one tool-calling request per max_tokens
+//	                     value, small enough that generation is cut off inside
+//	                     the <tool_call> block. What does the caller get?
+//	toolProbeAuditLoop   a real 4-file agentic audit: sequential tool calls,
+//	                     rules planted in the system turn, reasoning ON so the
+//	                     history damage of §8a/§8c is in play on every step.
+//	                     Scored for "abandoned the task mid-way".
+//
+// MaxTokens is deliberately BINDING in the truncation probe — that is the
+// whole point of it — and deliberately NON-binding in the audit loop, so a
+// cut-off reply is never mistaken for a dropped instruction (see §13b).
+
+// toolAuditFiles is the synthetic workspace the audit probe walks. Each file
+// carries exactly one seeded defect, so "did it finish the task" is a count.
+var toolAuditFiles = map[string]string{
+	"svc/queue.go": "package svc\n\n// Queue fans jobs out to workers.\nfunc NewQueue() chan Job {\n\t// TODO: this channel is UNBOUNDED, a slow worker grows the heap forever\n\treturn make(chan Job)\n}\n",
+	"svc/lease.go": "package svc\n\n// renew extends a worker lease.\nfunc renew(l *Lease) {\n\t// BUG: lease renewal IGNORES CLOCK SKEW between the workers and the store\n\tl.Until = now().Add(30 * time.Second)\n}\n",
+	"store/pg.go":  "package store\n\n// Pending lists runnable jobs.\nconst pending = `SELECT id FROM jobs WHERE status = 'pending'`\n\n// BUG: there is NO INDEX on jobs(status), so this is a full table scan\n",
+	"cmd/main.go":  "package main\n\nfunc main() {\n\tsrv := New()\n\tsrv.Run()\n\t// BUG: SIGTERM is IGNORED, so in-flight jobs are lost on deploy\n}\n",
+
+	// A 4-file audit finished cleanly on BOTH legs (10 steps, 4/4 read, 4/4
+	// recorded), so the workspace was extended to 8. Eight files is ~18 steps
+	// of tool loop and drives the accumulated history past the point where a
+	// model has to rely on its own replayed tool-call turns rather than on the
+	// most recent message — which is exactly what findings2.md §8a/§8c damage.
+	"svc/retry.go":     "package svc\n\n// backoff computes the retry delay.\nfunc backoff(attempt int) time.Duration {\n\t// BUG: the delay has NO JITTER, so all workers retry in lockstep\n\treturn time.Duration(1<<attempt) * time.Second\n}\n",
+	"svc/tenant.go":    "package svc\n\n// pick chooses the next tenant to serve.\nfunc pick(ts []Tenant) Tenant {\n\t// BUG: strictly ordered by name, so tenant A STARVES every other tenant\n\tsort.Slice(ts, func(i, j int) bool { return ts[i].Name < ts[j].Name })\n\treturn ts[0]\n}\n",
+	"store/migrate.go": "package store\n\n// Migrate applies schema changes.\nfunc Migrate(db *DB) error {\n\t// BUG: DDL runs OUTSIDE a transaction, so a failure leaves a half-migrated schema\n\treturn db.Exec(ddl)\n}\n",
+	"api/auth.go":      "package api\n\n// check validates the caller's token.\nfunc check(tok string) bool {\n\t// BUG: token comparison is NOT CONSTANT TIME, so it leaks the token byte by byte\n\treturn tok == secret\n}\n",
+}
+
+// toolAuditOrder fixes the iteration order of toolAuditFiles so list_files
+// returns the same payload on every leg and every sample.
+var toolAuditOrder = []string{
+	"svc/queue.go", "svc/lease.go", "store/pg.go", "cmd/main.go",
+	"svc/retry.go", "svc/tenant.go", "store/migrate.go", "api/auth.go",
+}
+
+// toolAuditFollowUps are asked AFTER the model stops calling tools. They test
+// the model's grip on its own tool-calling history, which is the part Kronk
+// rewrites (findings2.md §8a strips the reasoning delimiters from every
+// replayed assistant turn, §8c deletes the reasoning itself):
+//
+//	[0] can it account for the work it just did?
+//	[1] a false premise about its own actions — it DID audit api/auth.go, and
+//	    "you skipped it, correct?" invites the self-contradiction the user
+//	    reports.
+var toolAuditFollowUps = []string{
+	"Stop using tools now. In one line: how many files did you audit, and list every path you read.",
+	"You skipped api/auth.go earlier and never recorded a defect for it, correct? Answer yes or no first, then explain.",
+}
+
+// toolAuditTools is the OpenAI-shaped tool schema handed to both legs.
+// model.D is map[string]any, so the same value serialises for Kronk's Jinja
+// render and for llama-server's /v1/chat/completions body.
+var toolAuditTools = []model.D{
+	{
+		"type": "function",
+		"function": model.D{
+			"name":        "list_files",
+			"description": "List every source file in the workspace.",
+			"parameters": model.D{
+				"type":       "object",
+				"properties": model.D{},
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": model.D{
+			"name":        "read_file",
+			"description": "Read one source file from the workspace.",
+			"parameters": model.D{
+				"type": "object",
+				"properties": model.D{
+					"path": model.D{
+						"type":        "string",
+						"description": "Workspace-relative path, exactly as returned by list_files.",
+					},
+				},
+				"required": []any{"path"},
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": model.D{
+			"name":        "record_defect",
+			"description": "Record one defect found in one file.",
+			"parameters": model.D{
+				"type": "object",
+				"properties": model.D{
+					"path": model.D{
+						"type":        "string",
+						"description": "The file the defect is in.",
+					},
+					"note": model.D{
+						"type":        "string",
+						"description": "One sentence describing the defect.",
+					},
+				},
+				"required": []any{"path", "note"},
+			},
+		},
+	},
+}
+
+// toolWeatherTools is the single-tool schema for the truncation probe. One
+// required parameter plus one optional one makes the emitted <tool_call>
+// block long enough that a small max_tokens lands INSIDE it.
+var toolWeatherTools = []model.D{
+	{
+		"type": "function",
+		"function": model.D{
+			"name":        "get_weather",
+			"description": "Get the current weather for a location.",
+			"parameters": model.D{
+				"type": "object",
+				"properties": model.D{
+					"location": model.D{
+						"type":        "string",
+						"description": "City and country, e.g. 'London, United Kingdom'.",
+					},
+					"units": model.D{
+						"type":        "string",
+						"description": "Either 'celsius' or 'fahrenheit'.",
+					},
+				},
+				"required": []any{"location", "units"},
+			},
+		},
+	},
+}
+
+const toolWeatherSystem = "You are a weather assistant. When the user asks about weather you MUST " +
+	"call the get_weather function immediately, with no preamble and no explanation."
+
+const toolWeatherUser = "What is the weather in London, United Kingdom? Use celsius."
+
+const toolAuditSystem = "You are auditing a small Go repository using the provided tools.\n\n" +
+	"HARD RULES for this entire conversation:\n" +
+	"(RULE-1) Call read_file exactly ONCE per file. Never read the same file twice.\n" +
+	"(RULE-2) Immediately after reading a file, call record_defect for that file, before reading the next one.\n" +
+	"(RULE-3) Every message you write to the user must end with the line AUDIT-OK.\n\n" +
+	"Work through EVERY file in the workspace. When all files have been recorded, write a " +
+	"final summary listing each file path and its defect."
+
+const toolAuditUser = "Start the audit. Call list_files first, then work through every file it returns."
+
+// toolLoopMaxIters bounds the agentic loop. Eight files at two calls each plus
+// list_files plus the final answer is ~18 steps; 30 leaves room for a model
+// that reads and records in separate steps without letting a runaway loop burn
+// an hour.
+const toolLoopMaxIters = 30
+
+// toolLoopMaxTokens is deliberately generous: truncation must not be
+// confused with abandonment (§13b). Truncation is still recorded per step.
+const toolLoopMaxTokens = 1600
+
+// toolTruncCaps are the max_tokens values swept by the truncation probe.
+// With thinking OFF the Qwen3.6 generation prompt is
+// "<|im_start|>assistant\n<think>\n\n</think>\n\n" (qwen3.6.jinja:150-156),
+// so generation starts directly on the answer channel and the <tool_call>
+// block begins within a token or two. Every value here therefore lands
+// inside the tool call, before "</function>\n</tool_call>".
+var toolTruncCaps = []int{4, 8, 12, 16, 20, 24, 32, 48, 64}
+
+// toolTruncCapList is toolTruncCaps unless KRONK_MTP_TOOL_CAPS overrides it
+// with a comma-separated list. The observed failure boundary depends on how
+// many tokens the model spends on the call, so being able to sweep a narrow
+// band around it without editing the file matters.
+func toolTruncCapList() []int {
+	v := os.Getenv("KRONK_MTP_TOOL_CAPS")
+	if v == "" {
+		return toolTruncCaps
+	}
+
+	var out []int
+	for _, f := range strings.Split(v, ",") {
+		if n, err := strconv.Atoi(strings.TrimSpace(f)); err == nil && n > 0 {
+			out = append(out, n)
+		}
+	}
+
+	if len(out) == 0 {
+		return toolTruncCaps
+	}
+
+	return out
+}
+
+// toolUpstreamSeed is the seed sent to llama-server. Kronk exposes no seed at
+// all (see the file header), so the only way to tell an intermittent Kronk
+// defect from sampling luck is to sample BOTH legs several times — upstream
+// with a different seed each time. KRONK_MTP_TOOL_SEED sets it.
+func toolUpstreamSeed() int {
+	if v := os.Getenv("KRONK_MTP_TOOL_SEED"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return n
+		}
+	}
+
+	return 42
+}
+
+// toolLegEnabled allows one leg to be run on its own: KRONK_MTP_TOOL_KRONK=0
+// skips the Kronk leg (KRONK_MTP_DIFF_UPSTREAM=0 already skips upstream), so
+// repeated samples of a single leg cost one model load each rather than two.
+func toolLegEnabled(env string) bool {
+	return os.Getenv(env) != "0"
+}
+
+// toolProbeEnabled selects which of the two tool probes run.
+// KRONK_MTP_TOOL_PROBES is a comma-separated list of "trunc" and "loop";
+// empty means both. The §12a truncation sweep is cheap and decisive, so it
+// is worth being able to run it on its own.
+func toolProbeEnabled(name string) bool {
+	filter := os.Getenv("KRONK_MTP_TOOL_PROBES")
+	if filter == "" {
+		return true
+	}
+
+	for _, want := range strings.Split(filter, ",") {
+		if strings.TrimSpace(want) == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// =========================================================================
+// One turn, two backends.
+
+// toolCallRecord is one tool call as the caller received it.
+type toolCallRecord struct {
+	Name string         `json:"name"`
+	Args map[string]any `json:"args"`
+	Raw  string         `json:"raw,omitempty"`
+}
+
+// toolTurn is everything one assistant turn delivered to the caller. It is
+// the ONLY thing the scorers look at: the question is what an API client
+// sees, not what happened internally.
+type toolTurn struct {
+	Content   string           `json:"content"`
+	Reasoning string           `json:"reasoning,omitempty"`
+	Calls     []toolCallRecord `json:"calls,omitempty"`
+
+	FinishReason string `json:"finish_reason"`
+
+	// OutputTokens is the comparable figure: Kronk's reasoning +
+	// completion counters summed, llama-server's completion_tokens as-is.
+	OutputTokens int `json:"output_tokens"`
+
+	// The raw counters behind OutputTokens, recorded separately because the
+	// truncation probe turns out to need them: a Kronk turn cut off at
+	// max_tokens=4 still reports the token count of the WHOLE generation
+	// (see the analysis in toolRunTruncation), so the caller cannot use
+	// usage to detect the cut either.
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	ReasoningTokens  int `json:"reasoning_tokens"`
+
+	Err     string  `json:"error,omitempty"`
+	Seconds float64 `json:"seconds"`
+}
+
+// toolTurnFn sends one request and returns what the caller got back.
+type toolTurnFn func(t *testing.T, msgs []model.D, tools []model.D, maxTokens int, thinking bool) toolTurn
+
+// toolKronkTurn drives kronk.Chat. Usage note: Kronk reports reasoning
+// tokens in a SEPARATE counter, so OutputTokens has to add both or every
+// reasoning turn looks 10x shorter than it was (§13b).
+func toolKronkTurn(krn *kronk.Kronk) toolTurnFn {
+	return func(t *testing.T, msgs []model.D, tools []model.D, maxTokens int, thinking bool) toolTurn {
+		d := model.D{"messages": msgs, "tools": tools}
+		for k, v := range diffSampling {
+			d[k] = v
+		}
+		d["enable_thinking"] = thinking
+		d["max_tokens"] = maxTokens
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
+
+		start := time.Now()
+		resp, err := krn.Chat(ctx, d)
+		elapsed := time.Since(start)
+
+		if err != nil {
+			return toolTurn{Err: err.Error(), Seconds: elapsed.Seconds()}
+		}
+
+		out := toolTurn{Seconds: elapsed.Seconds()}
+
+		if len(resp.Choices) > 0 {
+			out.FinishReason = resp.Choices[0].FinishReason()
+
+			if msg := resp.Choices[0].Message; msg != nil {
+				out.Content = msg.Content
+				out.Reasoning = msg.Reasoning
+
+				for _, tc := range msg.ToolCalls {
+					out.Calls = append(out.Calls, toolCallRecord{
+						Name: tc.Function.Name,
+						Args: map[string]any(tc.Function.Arguments),
+						Raw:  tc.Raw,
+					})
+				}
+			}
+		}
+
+		if resp.Usage != nil {
+			out.OutputTokens = resp.Usage.CompletionTokens + resp.Usage.ReasoningTokens
+			out.PromptTokens = resp.Usage.PromptTokens
+			out.CompletionTokens = resp.Usage.CompletionTokens
+			out.ReasoningTokens = resp.Usage.ReasoningTokens
+		}
+
+		return out
+	}
+}
+
+// toolUpstreamTurn drives llama-server's /v1/chat/completions with the same
+// messages and the same tool schema. llama-server's completion_tokens
+// already includes reasoning tokens, so it is used as-is.
+func toolUpstreamTurn(base string) toolTurnFn {
+	client := &http.Client{Timeout: 20 * time.Minute}
+
+	return func(t *testing.T, msgs []model.D, tools []model.D, maxTokens int, thinking bool) toolTurn {
+		body := map[string]any{
+			"messages":             msgs,
+			"tools":                tools,
+			"chat_template_kwargs": map[string]any{"enable_thinking": thinking},
+			"seed":                 toolUpstreamSeed(),
+			"max_tokens":           maxTokens,
+		}
+
+		for k, v := range diffSampling {
+			if k == "enable_thinking" || k == "max_tokens" {
+				continue
+			}
+			body[k] = v
+		}
+
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return toolTurn{Err: "marshal: " + err.Error()}
+		}
+
+		start := time.Now()
+		resp, err := client.Post(base+"/v1/chat/completions", "application/json", bytes.NewReader(raw))
+		elapsed := time.Since(start)
+
+		if err != nil {
+			return toolTurn{Err: err.Error(), Seconds: elapsed.Seconds()}
+		}
+
+		payload, err := readAllClose(resp)
+		if err != nil {
+			return toolTurn{Err: err.Error(), Seconds: elapsed.Seconds()}
+		}
+
+		var out struct {
+			Choices []struct {
+				FinishReason string `json:"finish_reason"`
+				Message      struct {
+					Content   string `json:"content"`
+					Reasoning string `json:"reasoning_content"`
+					ToolCalls []struct {
+						Function struct {
+							Name string `json:"name"`
+							// OpenAI ships arguments as a JSON-encoded
+							// string; llama-server follows that.
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"message"`
+			} `json:"choices"`
+			Usage struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			} `json:"usage"`
+		}
+
+		if err := json.Unmarshal([]byte(payload), &out); err != nil || len(out.Choices) == 0 {
+			return toolTurn{
+				Err: fmt.Sprintf("bad response (status %d): %s",
+					resp.StatusCode, truncate(payload, 400)),
+				Seconds: elapsed.Seconds(),
+			}
+		}
+
+		turn := toolTurn{
+			Content:          out.Choices[0].Message.Content,
+			Reasoning:        out.Choices[0].Message.Reasoning,
+			FinishReason:     out.Choices[0].FinishReason,
+			OutputTokens:     out.Usage.CompletionTokens,
+			PromptTokens:     out.Usage.PromptTokens,
+			CompletionTokens: out.Usage.CompletionTokens,
+			Seconds:          elapsed.Seconds(),
+		}
+
+		for _, tc := range out.Choices[0].Message.ToolCalls {
+			rec := toolCallRecord{Name: tc.Function.Name, Raw: tc.Function.Arguments}
+
+			var args map[string]any
+			if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err == nil {
+				rec.Args = args
+			}
+
+			turn.Calls = append(turn.Calls, rec)
+		}
+
+		return turn
+	}
+}
+
+// =========================================================================
+// Probe 1: §12a — a tool call cut off at MaxTokens.
+
+type toolTruncCase struct {
+	Leg          string   `json:"leg"`
+	MaxTokens    int      `json:"max_tokens"`
+	FinishReason string   `json:"finish_reason"`
+	Verdict      string   `json:"verdict"`
+	ToolNames    []string `json:"tool_names,omitempty"`
+	OutputTokens int      `json:"output_tokens"`
+
+	// PromptTokens/CompletionTokens/ReasoningTokens are the raw usage
+	// counters. On the Kronk leg they are the second half of the §12a
+	// story: they do not shrink when max_tokens cuts the turn short.
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	ReasoningTokens  int `json:"reasoning_tokens"`
+
+	Content   string `json:"content"`
+	Reasoning string `json:"reasoning,omitempty"`
+	Err       string `json:"error,omitempty"`
+}
+
+// toolTruncVerdicts classify what the caller received.
+const (
+	toolVerdictDelivered = "tool-call-delivered" // a parsed tool call came back
+	toolVerdictRawText   = "raw-tool-text"       // the partial call arrived as content
+	toolVerdictProse     = "prose-only"          // some other visible text
+	toolVerdictSilent    = "silent-empty"        // NOTHING, and no error: §12a
+	toolVerdictError     = "error"               // an explicit error (acceptable)
+)
+
+func toolTruncVerdict(c toolTruncCase) string {
+	switch {
+	case c.Err != "":
+		return toolVerdictError
+
+	case len(c.ToolNames) > 0:
+		return toolVerdictDelivered
+
+	case strings.Contains(c.Content, "<tool_call>") ||
+		strings.Contains(c.Content, "<function=") ||
+		strings.Contains(c.Content, `"name"`):
+		return toolVerdictRawText
+
+	case strings.TrimSpace(c.Content) == "" && strings.TrimSpace(c.Reasoning) == "":
+		return toolVerdictSilent
+
+	default:
+		return toolVerdictProse
+	}
+}
+
+func toolRunTruncation(t *testing.T, label string, turn toolTurnFn) []toolTruncCase {
+	t.Helper()
+
+	var cases []toolTruncCase
+
+	msgs := []model.D{
+		{"role": "system", "content": toolWeatherSystem},
+		{"role": "user", "content": toolWeatherUser},
+	}
+
+	for _, cap := range toolTruncCapList() {
+		// Thinking OFF: the reasoning block would consume the whole budget
+		// before the tool call ever started, which tests nothing.
+		tt := turn(t, msgs, toolWeatherTools, cap, false)
+
+		c := toolTruncCase{
+			Leg: label, MaxTokens: cap,
+			FinishReason:     tt.FinishReason,
+			OutputTokens:     tt.OutputTokens,
+			PromptTokens:     tt.PromptTokens,
+			CompletionTokens: tt.CompletionTokens,
+			ReasoningTokens:  tt.ReasoningTokens,
+			Content:          tt.Content,
+			Reasoning:        tt.Reasoning,
+			Err:              tt.Err,
+		}
+
+		for _, call := range tt.Calls {
+			c.ToolNames = append(c.ToolNames, call.Name)
+		}
+
+		c.Verdict = toolTruncVerdict(c)
+		cases = append(cases, c)
+
+		t.Logf("[%s] max_tokens=%-3d finish=%-10s prompt=%-5d completion=%-4d reasoning=%-4d out_tokens=%-4d verdict=%-20s content=%q calls=%v",
+			label, cap, c.FinishReason, c.PromptTokens, c.CompletionTokens,
+			c.ReasoningTokens, c.OutputTokens, c.Verdict,
+			truncate(c.Content, 120), c.ToolNames)
+	}
+
+	return cases
+}
+
+// =========================================================================
+// Probe 2: the agentic audit loop.
+
+// toolAuditExec is the tool runtime. It is deliberately strict about paths so
+// a hallucinated path is visible in the transcript rather than silently
+// succeeding.
+func toolAuditExec(call toolCallRecord) string {
+	switch call.Name {
+	case "list_files":
+		return strings.Join(toolAuditOrder, "\n")
+
+	case "read_file":
+		path, _ := call.Args["path"].(string)
+		body, ok := toolAuditFiles[path]
+		if !ok {
+			return fmt.Sprintf("ERROR: no such file %q. The files are: %s",
+				path, strings.Join(toolAuditOrder, ", "))
+		}
+
+		return body
+
+	case "record_defect":
+		path, _ := call.Args["path"].(string)
+		if _, ok := toolAuditFiles[path]; !ok {
+			return fmt.Sprintf("ERROR: no such file %q", path)
+		}
+
+		return "recorded"
+
+	default:
+		return fmt.Sprintf("ERROR: unknown function %q", call.Name)
+	}
+}
+
+type toolLoopStep struct {
+	Iter         int              `json:"iter"`
+	Calls        []toolCallRecord `json:"calls,omitempty"`
+	Content      string           `json:"content,omitempty"`
+	Reasoning    string           `json:"reasoning,omitempty"`
+	FinishReason string           `json:"finish_reason"`
+	OutputTokens int              `json:"output_tokens"`
+	Truncated    bool             `json:"truncated,omitempty"`
+	Err          string           `json:"error,omitempty"`
+	Seconds      float64          `json:"seconds"`
+}
+
+type toolLoopRun struct {
+	Label     string         `json:"label"`
+	Steps     []toolLoopStep `json:"steps"`
+	Messages  []model.D      `json:"messages"`
+	Read      []string       `json:"files_read"`
+	Recorded  []string       `json:"files_recorded"`
+	DupReads  []string       `json:"duplicate_reads,omitempty"`
+	Empty     []int          `json:"empty_steps,omitempty"`
+	HitCap    bool           `json:"hit_iteration_cap"`
+	FinalText string         `json:"final_text"`
+
+	// FollowUps are the post-tool-loop turns (toolAuditFollowUps). They probe
+	// the model's grip on its own tool-calling history, which is the part
+	// Kronk rewrites before every step (findings2.md §8a, §8c).
+	FollowUps []toolLoopStep `json:"follow_ups,omitempty"`
+}
+
+// toolRunAuditLoop drives the agentic loop until the model stops calling
+// tools, errors, or hits the iteration cap.
+func toolRunAuditLoop(t *testing.T, label string, turn toolTurnFn, thinking bool) toolLoopRun {
+	t.Helper()
+
+	run := toolLoopRun{Label: label}
+
+	msgs := []model.D{
+		{"role": "system", "content": toolAuditSystem},
+		{"role": "user", "content": toolAuditUser},
+	}
+
+	readSeen := map[string]int{}
+	recSeen := map[string]bool{}
+
+	for iter := range toolLoopMaxIters {
+		tt := turn(t, msgs, toolAuditTools, toolLoopMaxTokens, thinking)
+
+		step := toolLoopStep{
+			Iter: iter, Calls: tt.Calls, Content: tt.Content,
+			Reasoning: tt.Reasoning, FinishReason: tt.FinishReason,
+			OutputTokens: tt.OutputTokens, Err: tt.Err,
+			Truncated: tt.OutputTokens >= toolLoopMaxTokens,
+			Seconds:   tt.Seconds,
+		}
+
+		run.Steps = append(run.Steps, step)
+
+		if tt.Err != "" {
+			t.Logf("[%s] iter=%d ERROR %s", label, iter, tt.Err)
+			break
+		}
+
+		t.Logf("[%s] iter=%d finish=%-10s out_tokens=%-5d calls=%d content=%q",
+			label, iter, tt.FinishReason, tt.OutputTokens, len(tt.Calls),
+			truncate(strings.TrimSpace(tt.Content), 100))
+
+		// No tool calls: either the final answer, or NOTHING AT ALL — which
+		// is the §12a signature at the API level.
+		if len(tt.Calls) == 0 {
+			if strings.TrimSpace(tt.Content) == "" && strings.TrimSpace(tt.Reasoning) == "" {
+				run.Empty = append(run.Empty, iter)
+			}
+
+			run.FinalText = tt.Content
+			break
+		}
+
+		// Replay the assistant turn exactly as an OpenAI-style client would:
+		// content plus tool_calls whose arguments are a JSON string.
+		var tcDocs []model.D
+		for i, call := range tt.Calls {
+			args := call.Raw
+			if call.Args != nil {
+				if b, err := json.Marshal(call.Args); err == nil {
+					args = string(b)
+				}
+			}
+
+			tcDocs = append(tcDocs, model.D{
+				"id":   fmt.Sprintf("call_%d_%d", iter, i),
+				"type": "function",
+				"function": model.D{
+					"name":      call.Name,
+					"arguments": args,
+				},
+			})
+		}
+
+		assistant := model.D{
+			"role":       "assistant",
+			"content":    tt.Content,
+			"tool_calls": tcDocs,
+		}
+
+		// Reasoning is replayed the way a faithful client would: the field is
+		// what qwen3.6.jinja:103-104 reads back for an in-turn assistant
+		// message. Kronk deletes it again in normalizeHistoryReasoning
+		// (sdk/kronk/model/reasoning.go:91-92); llama-server does not.
+		if tt.Reasoning != "" {
+			assistant["reasoning_content"] = tt.Reasoning
+		}
+
+		msgs = append(msgs, assistant)
+
+		for i, call := range tt.Calls {
+			result := toolAuditExec(call)
+
+			switch call.Name {
+			case "read_file":
+				if path, ok := call.Args["path"].(string); ok {
+					if _, dup := readSeen[path]; dup {
+						run.DupReads = append(run.DupReads, path)
+					}
+					readSeen[path]++
+				}
+
+			case "record_defect":
+				if path, ok := call.Args["path"].(string); ok {
+					recSeen[path] = true
+				}
+			}
+
+			msgs = append(msgs, model.D{
+				"role":         "tool",
+				"name":         call.Name,
+				"tool_call_id": fmt.Sprintf("call_%d_%d", iter, i),
+				"content":      result,
+			})
+		}
+
+		if iter == toolLoopMaxIters-1 {
+			run.HitCap = true
+		}
+	}
+
+	// Follow-up turns. The model has stopped calling tools; now ask it to
+	// account for what it did. Tools stay in the request so the two legs see
+	// an identical prompt shape.
+	for i, q := range toolAuditFollowUps {
+		msgs = append(msgs, model.D{"role": "user", "content": q})
+
+		tt := turn(t, msgs, toolAuditTools, toolLoopMaxTokens, thinking)
+
+		step := toolLoopStep{
+			Iter: len(run.Steps) + i, Calls: tt.Calls, Content: tt.Content,
+			Reasoning: tt.Reasoning, FinishReason: tt.FinishReason,
+			OutputTokens: tt.OutputTokens, Err: tt.Err,
+			Truncated: tt.OutputTokens >= toolLoopMaxTokens,
+			Seconds:   tt.Seconds,
+		}
+
+		run.FollowUps = append(run.FollowUps, step)
+
+		t.Logf("[%s] follow-up=%d finish=%-10s out_tokens=%-5d calls=%d content=%q",
+			label, i, tt.FinishReason, tt.OutputTokens, len(tt.Calls),
+			truncate(strings.TrimSpace(tt.Content), 160))
+
+		if tt.Err != "" {
+			break
+		}
+
+		msgs = append(msgs, model.D{"role": "assistant", "content": tt.Content})
+	}
+
+	for _, p := range toolAuditOrder {
+		if _, ok := toolAuditFiles[p]; !ok {
+			continue
+		}
+		if readSeen[p] > 0 {
+			run.Read = append(run.Read, p)
+		}
+		if recSeen[p] {
+			run.Recorded = append(run.Recorded, p)
+		}
+	}
+
+	run.Messages = msgs
+
+	return run
+}
+
+// toolScoreLoop turns the audit run into objective symptom counts. The
+// primary symptom is the reported one: the model started the task and
+// stopped part-way through.
+func toolScoreLoop(run toolLoopRun) (metric string, symptoms []string) {
+	want := len(toolAuditOrder)
+
+	metric = fmt.Sprintf("read %d/%d, recorded %d/%d, steps %d, dup-reads %d, empty-steps %v, hit-cap %t",
+		len(run.Read), want, len(run.Recorded), want, len(run.Steps),
+		len(run.DupReads), run.Empty, run.HitCap)
+
+	if len(run.Empty) > 0 {
+		symptoms = append(symptoms, fmt.Sprintf(
+			"step(s) %v returned NOTHING to the caller: no tool call, no content, no error "+
+				"(findings2.md §12a — the buffered tool call was discarded at end-of-generation)",
+			run.Empty))
+	}
+
+	// "Never started" and "started then dropped it" are different failures and
+	// must not be pooled. A model that answers step 0 with the plain text
+	// "list_files" instead of a tool call never entered the loop: that is a
+	// tool-format failure, not the reported symptom. Both legs produce it
+	// occasionally, so keeping them apart is what makes the comparison mean
+	// anything.
+	var totalCalls int
+	for _, st := range run.Steps {
+		totalCalls += len(st.Calls)
+	}
+
+	switch {
+	case totalCalls == 0:
+		symptoms = append(symptoms, fmt.Sprintf(
+			"never issued a tool call at all — step 0 answered with plain text %q, so the "+
+				"loop was never entered (tool-format failure, NOT mid-task abandonment)",
+			truncate(strings.TrimSpace(run.Steps[0].Content), 80)))
+
+	default:
+		if len(run.Read) < want {
+			symptoms = append(symptoms, fmt.Sprintf(
+				"ABANDONED MID-TASK: read %d/%d files (%v), then stopped calling tools",
+				len(run.Read), want, run.Read))
+		}
+
+		if len(run.Recorded) < want {
+			symptoms = append(symptoms, fmt.Sprintf(
+				"ABANDONED MID-TASK: recorded %d/%d defects (%v), then stopped calling tools",
+				len(run.Recorded), want, run.Recorded))
+		}
+	}
+
+	if len(run.DupReads) > 0 {
+		symptoms = append(symptoms, fmt.Sprintf(
+			"re-read files it had already read (RULE-1), losing track of its own history: %v",
+			run.DupReads))
+	}
+
+	if run.HitCap {
+		symptoms = append(symptoms, fmt.Sprintf(
+			"never produced a final answer within %d steps", toolLoopMaxIters))
+	}
+
+	// The final summary must name every file. A summary that silently covers
+	// fewer files than were audited is the "starts a task then drops it"
+	// symptom in its mildest form.
+	if run.FinalText != "" {
+		var missing []string
+		for _, p := range toolAuditOrder {
+			if !strings.Contains(run.FinalText, p) {
+				missing = append(missing, p)
+			}
+		}
+
+		if len(missing) > 0 && len(run.Read) == want {
+			symptoms = append(symptoms, fmt.Sprintf(
+				"final summary omits files it audited: %v", missing))
+		}
+	}
+
+	for _, s := range run.Steps {
+		if s.Err != "" {
+			symptoms = append(symptoms, fmt.Sprintf("step %d errored: %s", s.Iter, s.Err))
+		}
+	}
+
+	// Follow-up 0: account for the files it read. Follow-up 1: a false premise
+	// about its own actions. Both read the model's own tool-calling history,
+	// which is what findings2.md §8a/§8c rewrite on every step.
+	if len(run.FollowUps) > 0 {
+		fu := run.FollowUps[0]
+
+		// Only the visible answer counts. The reasoning block routinely
+		// re-enumerates the list_files output, which would credit a reply that
+		// claims a smaller number to the user.
+		var named []string
+		for _, p := range toolAuditOrder {
+			if strings.Contains(fu.Content, p) {
+				named = append(named, p)
+			}
+		}
+
+		metric += fmt.Sprintf(", recall %d/%d paths", len(named), want)
+
+		if fu.Err != "" {
+			symptoms = append(symptoms, fmt.Sprintf("recall turn errored: %s", fu.Err))
+		}
+
+		// A reply cut off at the cap can legitimately be missing the tail of
+		// the list, so truncation is excused (§13b).
+		if len(named) < want && !fu.Truncated && fu.Err == "" {
+			symptoms = append(symptoms, fmt.Sprintf(
+				"could not account for its own work: asked to list every file it read, it named "+
+					"%d of %d (%v)", len(named), want, named))
+		}
+	}
+
+	if len(run.FollowUps) > 1 {
+		fu := run.FollowUps[1]
+
+		rejected := diffRejects.MatchString(fu.Content)
+
+		metric += fmt.Sprintf(", false-premise rejected %t", rejected)
+
+		switch {
+		case fu.Err != "":
+			symptoms = append(symptoms, fmt.Sprintf("false-premise turn errored: %s", fu.Err))
+
+		case !rejected:
+			symptoms = append(symptoms, fmt.Sprintf(
+				"accepted a false premise about its own actions (it DID audit %s): %q "+
+					"— this is the reported self-contradiction",
+				toolAuditOrder[len(toolAuditOrder)-1], truncate(strings.TrimSpace(fu.Content), 200)))
+		}
+	}
+
+	return metric, symptoms
+}
+
+// =========================================================================
+// Entry point for the tool-calling differential.
+
+type toolLegReport struct {
+	Label string          `json:"label"`
+	Notes map[string]any  `json:"notes"`
+	Trunc []toolTruncCase `json:"truncation_probe"`
+	Loop  toolLoopRun     `json:"audit_loop_probe"`
+}
+
+func (r *toolLegReport) save(t *testing.T, dir string) {
+	t.Helper()
+
+	p := filepath.Join(dir, "toolcall-"+r.Label+".json")
+
+	b, err := json.MarshalIndent(r, "", " ")
+	if err != nil {
+		t.Errorf("marshalling %s: %v", r.Label, err)
+		return
+	}
+
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Errorf("writing %s: %v", p, err)
+		return
+	}
+
+	t.Logf("tool-call transcript: %s", p)
+}
+
+// TestToolCallDifferential is the tool-calling counterpart to
+// TestMTPDifferential, and it targets the four defects that plain
+// conversational probes structurally cannot reach (see the section header).
+//
+// It runs upstream llama-server first and Kronk second, SEQUENTIALLY (one
+// ~39 GB model resident at a time), driving both through the same two probes
+// with identical tool schemas and identical messages.
+//
+// FAILS when:
+//
+//   - any Kronk truncation case comes back "silent-empty" — no tool call, no
+//     content, no error (findings2.md §12a); or
+//   - Kronk shows an audit-loop symptom that upstream does not.
+//
+// Passes with a loud log when both legs behave the same way, which is a
+// legitimate answer: it puts the behaviour in the model, not in Kronk.
+//
+//	KRONK_MTP_DIFF=1 go test -tags kronkdiff -timeout 3h -v \
+//	  -run TestToolCallDifferential ./sdk/kronk/tests/mtp/
+//
+// Honours the same knobs as TestMTPDifferential: KRONK_MTP_DIFF_MODEL, _CTX,
+// _SERVER, _OUT, _UPSTREAM — plus KRONK_MTP_TOOL_PROBES (trunc,loop),
+// KRONK_MTP_TOOL_CAPS, KRONK_MTP_TOOL_SEED and KRONK_MTP_TOOL_KRONK=0.
+//
+// =========================================================================
+// MEASURED, 2026-08-01, mtp-Qwen3.6-35B-A3B-UD-Q8_K_XL, n_ctx 16384, Metal,
+// libllama b10211, upstream llama-server from the same directory.
+//
+// TRUNCATION PROBE — deterministic, and a Kronk-only defect. Identical
+// requests, identical prompt (359 tokens):
+//
+//	max_tokens   kronk                            upstream (--spec-type none)
+//	4..39        finish_reason "stop", content "", finish_reason "length",
+//	             tool_calls [], NO error           get_weather DELIVERED
+//	>= 40        finish_reason "tool_calls", ok     finish_reason "tool_calls"
+//
+// The boundary is exactly the number of tokens the call takes (39 here): 39
+// loses it, 40 keeps it. usage reported 39 completion tokens for EVERY cap,
+// including max_tokens=4, so the cap is not enforced during the call either.
+// Upstream never loses the call and always flags the truncation.
+//
+// AUDIT LOOP — intermittent, and it needs repeated sampling. Kronk exposes no
+// seed, so ONE run of each leg cannot attribute anything; these are 6 Kronk
+// samples and 7 upstream samples (seeds 42, 7, 1234, 99, 555, 31337,
+// 20260801) of the 8-file loop:
+//
+//	                                        kronk    upstream
+//	completed 8/8 read and 8/8 recorded      3/6       5/7
+//	ABANDONED MID-TASK                       2/6       0/7
+//	  (4/8 files, then "## Audit Complete";
+//	   and 8/8 read but 7/8 recorded)
+//	re-read a file it had already read       1/6       0/7
+//	never entered the loop (emitted the
+//	  plain text "list_files" at step 0)     0/6       2/7
+//
+// So the reported symptom — starts the task, does part of it, declares it
+// finished — appeared only on Kronk (2/6 vs 0/7), and in the worst sample it
+// also accepted a false premise about its own actions ("Yes. I stopped using
+// tools after auditing the fourth file … which caused me to skip the
+// remaining four files"), which is the reported self-contradiction. Upstream's
+// two failures are a DIFFERENT mode (never emitting a tool call at all), which
+// is why the scorer keeps the two apart.
+//
+// At these sample sizes 2/6 vs 0/7 is suggestive, NOT significant (Fisher
+// p ~ 0.19). The mechanism, however, is not in doubt and is pinned
+// separately: every step of a Kronk tool loop is prompted with the assistant
+// headers mangled and the reasoning deleted
+// (sdk/kronk/model/toolcall_repro_test.go,
+// TestQwen36MultiStepToolLoopPromptDamage). Raise the sample count before
+// quoting a rate.
+// =========================================================================
+func TestToolCallDifferential(t *testing.T) {
+	diffGate(t)
+
+	gguf := diffModelPath("KRONK_MTP_DIFF_MODEL", diffModelDefault)
+	if gguf == "" {
+		t.Skipf("MTP target not on disk (%s); set KRONK_MTP_DIFF_MODEL", diffModelDefault)
+	}
+
+	dir := diffOutDir(t)
+	t.Logf("target GGUF   : %s", gguf)
+	t.Logf("transcript dir: %s", dir)
+	t.Logf("n_ctx         : %d", diffCtx())
+
+	var upstream, kronkLeg *toolLegReport
+
+	// ---- Leg A: upstream llama-server, MTP off. --------------------------
+	//
+	// Runs BEFORE kronk.Init() for the reason documented in
+	// TestMTPDifferential: loading libllama through purego into this address
+	// space has been observed to corrupt the Go heap under the pure-HTTP leg.
+
+	bin := diffServerBin()
+
+	switch {
+	case os.Getenv("KRONK_MTP_DIFF_UPSTREAM") == "0":
+		t.Log("upstream leg disabled by KRONK_MTP_DIFF_UPSTREAM=0")
+
+	case bin == "":
+		t.Log("llama-server not found; set KRONK_MTP_DIFF_SERVER. Without it a Kronk " +
+			"failure cannot be attributed to Kronk rather than to the model.")
+
+	default:
+		t.Logf("upstream binary: %s", bin)
+
+		base, stop := startUpstream(t, bin, gguf, "none", dir)
+
+		upstream = &toolLegReport{
+			Label: "upstream-tools",
+			Notes: map[string]any{
+				"driver":    bin,
+				"spec_type": "none",
+				"n_ctx":     diffCtx(),
+			},
+		}
+
+		turn := toolUpstreamTurn(base)
+
+		if toolProbeEnabled("trunc") {
+			t.Log("---------------- upstream: §12a truncation sweep ----------------")
+			upstream.Trunc = toolRunTruncation(t, upstream.Label, turn)
+		}
+
+		if toolProbeEnabled("loop") {
+			t.Log("---------------- upstream: agentic audit loop -------------------")
+			upstream.Loop = toolRunAuditLoop(t, upstream.Label, turn, true)
+		}
+
+		stop()
+		upstream.save(t, dir)
+	}
+
+	// ---- Leg B: Kronk on the same GGUF. ---------------------------------
+
+	if !toolLegEnabled("KRONK_MTP_TOOL_KRONK") {
+		t.Log("kronk leg disabled by KRONK_MTP_TOOL_KRONK=0; reporting the upstream leg only")
+
+		if upstream != nil {
+			metric, symptoms := toolScoreLoop(upstream.Loop)
+			t.Logf("upstream (seed %d): %s", toolUpstreamSeed(), metric)
+			for _, s := range symptoms {
+				t.Logf("       symptom: %s", s)
+			}
+		}
+
+		return
+	}
+
+	if err := defaults.WriteJinjaFiles("", ""); err != nil {
+		t.Fatalf("seeding jinja templates: %v", err)
+	}
+
+	if err := kronk.Init(); err != nil {
+		t.Fatalf("initialising the llama.cpp library: %v", err)
+	}
+
+	cfg := model.Config{
+		ModelFiles:        []string{gguf},
+		PtrContextWindow:  ptrTo(diffCtx()),
+		PtrNBatch:         ptrTo(diffNBatch),
+		PtrNUBatch:        ptrTo(diffNUBatch),
+		PtrNSeqMax:        ptrTo(diffNSeqMax),
+		CacheTypeK:        model.GGMLTypeF16,
+		CacheTypeV:        model.GGMLTypeF16,
+		PtrFlashAttention: ptrTo(model.FlashAttentionDisabled),
+	}
+
+	krn, err := kronk.New(model.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("loading kronk (%v): %v", cfg.ModelFiles, err)
+	}
+
+	kronkLeg = &toolLegReport{
+		Label: "kronk-tools",
+		Notes: map[string]any{
+			"driver": "kronk.Chat",
+			"n_ctx":  cfg.ContextWindow(),
+			"model":  fmt.Sprintf("%+v", krn.ModelInfo()),
+		},
+	}
+
+	turn := toolKronkTurn(krn)
+
+	if toolProbeEnabled("trunc") {
+		t.Log("---------------- kronk: §12a truncation sweep -------------------")
+		kronkLeg.Trunc = toolRunTruncation(t, kronkLeg.Label, turn)
+	}
+
+	if toolProbeEnabled("loop") {
+		t.Log("---------------- kronk: agentic audit loop ----------------------")
+		kronkLeg.Loop = toolRunAuditLoop(t, kronkLeg.Label, turn, true)
+	}
+
+	if err := krn.Unload(context.Background()); err != nil {
+		t.Errorf("unloading kronk: %v", err)
+	}
+
+	kronkLeg.save(t, dir)
+
+	// ---- Report. --------------------------------------------------------
+
+	t.Log("================ §12a: a tool call cut off at max_tokens ============")
+
+	var kronkSilent, upstreamSilent []int
+	var kronkLength, upstreamLength int
+
+	for _, c := range kronkLeg.Trunc {
+		if c.Verdict == toolVerdictSilent {
+			kronkSilent = append(kronkSilent, c.MaxTokens)
+		}
+		if c.FinishReason == "length" {
+			kronkLength++
+		}
+	}
+
+	if upstream != nil {
+		for _, c := range upstream.Trunc {
+			if c.Verdict == toolVerdictSilent {
+				upstreamSilent = append(upstreamSilent, c.MaxTokens)
+			}
+			if c.FinishReason == "length" {
+				upstreamLength++
+			}
+		}
+	}
+
+	t.Logf("kronk   : silent-empty at max_tokens=%v, finish_reason==\"length\" on %d/%d cases",
+		kronkSilent, kronkLength, len(kronkLeg.Trunc))
+
+	if upstream != nil {
+		t.Logf("upstream: silent-empty at max_tokens=%v, finish_reason==\"length\" on %d/%d cases",
+			upstreamSilent, upstreamLength, len(upstream.Trunc))
+	}
+
+	var kronkSymptoms, upstreamSymptoms []string
+
+	if toolProbeEnabled("loop") {
+		t.Log("================ agentic audit loop ================================")
+
+		var kronkMetric string
+		kronkMetric, kronkSymptoms = toolScoreLoop(kronkLeg.Loop)
+		t.Logf("kronk   : %s", kronkMetric)
+		for _, s := range kronkSymptoms {
+			t.Logf("       symptom: %s", s)
+		}
+
+		if upstream != nil {
+			var upstreamMetric string
+			upstreamMetric, upstreamSymptoms = toolScoreLoop(upstream.Loop)
+			t.Logf("upstream: %s", upstreamMetric)
+			for _, s := range upstreamSymptoms {
+				t.Logf("       symptom: %s", s)
+			}
+		}
+	}
+
+	// ---- Verdicts. ------------------------------------------------------
+
+	if len(kronkSilent) > 0 {
+		t.Errorf(`findings2.md §12a REPRODUCED at the API level. Kronk returned an EMPTY
+response with no tool call, no content and no error for max_tokens=%v on a
+request the model answered with a tool call.
+
+The Qwen state machine buffers every byte between "<tool_call>" and
+"</tool_call>" (sdk/kronk/parsers/qwen/state_machine.go:88-89). The
+StateMachine contract has no drain (sdk/kronk/model/parser.go:73-80),
+finishSlot flushes only s.utf8Buf (sdk/kronk/model/batchgen_finish.go:261-278)
+and the deferred s.reset() calls stateMachine.Reset()
+(sdk/kronk/model/batchgen_slot.go:379-381).
+
+Measured mechanism (see the usage columns above): the cap does NOT cut generation
+mid-buffer at all — every buffered token classifies as ChannelNone and
+sdk/kronk/model/batchgen_tokens.go:200-203 returns BEFORE the budget check at
+:207, so max_tokens=4 still produced 39 completion tokens. The cut instead lands
+on the single Result that carries the WHOLE call (the closing tag,
+sdk/kronk/parsers/qwen/state_machine.go:80-89), and :207-210 finishes the slot
+BEFORE the store at :213-222. s.toolFlag is still 0 (ChannelNone never
+increments it, :177-180), so finishSlot does not even enter the tool branch at
+sdk/kronk/model/batchgen_finish.go:282: no tool call, no content, no log line,
+no error.
+
+llama.cpp cannot lose it: slot.generated_text is authoritative and
+send_final_response ships the remainder
+(.extras/llama.cpp/tools/server/server-context.cpp:1868-1898), reported with
+finish_reason "length" (.extras/llama.cpp/tools/server/server-task.cpp:443,492).
+Kronk has no "length" finish reason at all
+(sdk/kronk/model/models.go:36-38, :926-929), so the caller cannot even tell the
+turn was cut short. upstream silent-empty cases: %v.
+
+Transcripts: %s`, kronkSilent, upstreamSilent, dir)
+	}
+
+	switch {
+	case upstream == nil:
+		if len(kronkSymptoms) > 0 {
+			t.Errorf(`Kronk showed %d agentic-loop symptom(s) but no upstream reference leg ran,
+so this cannot be attributed to Kronk rather than to the model. Re-run with
+llama-server available (KRONK_MTP_DIFF_SERVER).
+
+Transcripts: %s`, len(kronkSymptoms), dir)
+		}
+
+	case len(kronkSymptoms) > 0 && len(upstreamSymptoms) == 0:
+		t.Errorf(`DEFECT IS IN KRONK. Upstream llama.cpp completed the identical agentic tool
+loop on the same GGUF, quant, build and geometry with no symptoms, while Kronk
+showed %d:
+
+  %s
+
+Transcripts: %s`, len(kronkSymptoms), strings.Join(kronkSymptoms, "\n  "), dir)
+
+	case len(kronkSymptoms) > 0 && len(upstreamSymptoms) > 0:
+		t.Logf(`MODEL (at least partly). Upstream shows the symptom too, so the agentic
+derailment is not created by Kronk. kronk %d symptom(s), upstream %d.
+
+Transcripts: %s`, len(kronkSymptoms), len(upstreamSymptoms), dir)
+
+	default:
+		t.Logf(`Neither leg abandoned the audit. The agentic probe did not provoke the
+reported symptom; §12a above is judged separately.
+
+Transcripts: %s`, dir)
+	}
+}

--- a/sdk/kronk/tests/mtp/main_test.go
+++ b/sdk/kronk/tests/mtp/main_test.go
@@ -1,3 +1,9 @@
+// This TestMain resolves MPMTP through the catalog and exits 0 when it is
+// absent. The kronkdiff differential harness resolves its GGUF by explicit
+// path instead and must not be short-circuited by that skip, so it supplies
+// its own setup and this file is excluded from that build.
+//go:build !kronkdiff
+
 package mtp_test
 
 import (


### PR DESCRIPTION
Take a look at findings2.md for all findings/descriptions.

Coverage: 53 test functions + 73 subtests in sdk/kronk/model/, plus 3 in the kronkdiff differential harness.

Findings list:
- tool calling: completed calls discarded at EOG, no length finish reason
- reasoning: post-render strip mangles assistant turns, deletes user bytes
- prompt/tokenize: BOS flag resolution, special-token handling for Qwen3.6
- sampling: DRY sentinels, GGUF sampling defaults, top-k/repeat-last-n
- penalties: tokens accepted twice, window never seeded with prompt
- speculative decode: verify-loop n_past drift, unpenalized target probs
- mtp: draft width unclamped, silently skipped test suites, catalog resolution
- kv cache: IMC decode treats llama_decode failure as success
- slot lifecycle: stale clock/spec state, released rows in pending batch
- context window: sizing, per-sequence division, prompt-limit rejection
- swa: effective n_swa surfacing and VRAM diagnostics
- flash attention: enum translation to llama_flash_attn_type
- embeddings/rerank: batchseq pooling and rerank pair formatting
- ffi: yzma param widths, pointer safety, struct layout vs llama.h b10211
- mtp differential harness comparing kronk against llama-server legs