### PR TITLE
single-line download progress for model pull

### DIFF
--- a/cmd/kronk/kronk/model/pull/progress.go
+++ b/cmd/kronk/kronk/model/pull/progress.go
@@ -1,0 +1,196 @@
+package pull
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ardanlabs/kronk/cmd/server/app/domain/toolapp"
+)
+
+// A progress line is rewritten in place, so it has to fit the terminal or the
+// wrapped remainder is left behind on screen. 80 columns is the width every
+// terminal provides.
+const (
+	maxLineWidth = 80
+	minSrcWidth  = 16
+	linePrefix   = "Downloading "
+)
+
+const (
+	mb = 1000 * 1000
+	gb = 1000 * mb
+)
+
+// widestETA is the longest estimate that can be rendered. The line is laid out
+// against it so the file name keeps its width for the whole download.
+const widestETA = "99h59m"
+
+// progressPrinter renders a model pull stream. Consecutive progress updates
+// for the same file rewrite a single line; a different file starts a new one.
+// Any other status message is written on its own line.
+type progressPrinter struct {
+	w       io.Writer
+	rewrite bool
+	src     string
+	open    bool
+}
+
+// newProgressPrinter constructs a printer that writes to w. With rewrite set
+// to false every update lands on its own line, since a carriage return means
+// nothing once the output is redirected to a file or a pipe.
+func newProgressPrinter(w io.Writer, rewrite bool) *progressPrinter {
+	return &progressPrinter{
+		w:       w,
+		rewrite: rewrite,
+	}
+}
+
+// print writes a single stream update.
+func (p *progressPrinter) print(pr toolapp.PullResponse) {
+	if pr.Progress == nil {
+		p.close()
+
+		if status := strings.TrimSpace(strings.TrimPrefix(pr.Status, "\r\x1b[K")); status != "" {
+			fmt.Fprintln(p.w, status)
+		}
+
+		return
+	}
+
+	line := progressLine(*pr.Progress)
+
+	if !p.rewrite {
+		fmt.Fprintln(p.w, line)
+		return
+	}
+
+	if pr.Progress.Src != p.src {
+		p.close()
+		p.src = pr.Progress.Src
+	}
+
+	fmt.Fprintf(p.w, "\r\x1b[K%s", line)
+	p.open = true
+
+	// The file is done, so keep the last line and move on to the next one.
+	if pr.Progress.Complete {
+		p.close()
+	}
+}
+
+// close terminates a progress line still held open on screen.
+func (p *progressPrinter) close() {
+	if !p.open {
+		return
+	}
+
+	fmt.Fprintln(p.w)
+	p.open = false
+}
+
+// progressLine formats one progress update:
+//
+//	Downloading …8-27B-UD-Q4_K_M.gguf   45.2%   7.4/16.5 GB  29.85 MB/s  ETA 5m02s
+func progressLine(pg toolapp.PullProgress) string {
+	unit := unitFor(pg.TotalBytes)
+
+	// The total stays unknown until the response header lands.
+	if pg.TotalBytes <= 0 {
+		unit = unitFor(pg.CurrentBytes)
+		stats := fmt.Sprintf("%s %s  %6.2f MB/s", sizeText(pg.CurrentBytes, unit), unit, pg.MBPerSec)
+
+		return layout(pg.Src, stats, stats)
+	}
+
+	total := sizeText(pg.TotalBytes, unit)
+
+	// The size is padded to the width of the total and the rate to its widest
+	// value, so the columns hold still while the numbers move.
+	stats := fmt.Sprintf("%5.1f%%  %*s/%s %s  %6.2f MB/s",
+		float64(pg.CurrentBytes)/float64(pg.TotalBytes)*100,
+		len(total), sizeText(pg.CurrentBytes, unit), total, unit,
+		pg.MBPerSec)
+
+	// The estimate is the only variable width field and it sits last, where
+	// the erase-to-end-of-line takes care of the leftovers.
+	widest := fmt.Sprintf("%s  ETA %s", stats, widestETA)
+
+	if left := eta(pg); left != "" {
+		stats = fmt.Sprintf("%s  ETA %s", stats, left)
+	}
+
+	return layout(pg.Src, stats, widest)
+}
+
+// layout joins the file name and the stats into a line sized for the terminal.
+// The name is measured against the widest form the stats can take so it does
+// not change width from one update to the next.
+func layout(src string, stats string, widest string) string {
+	return fmt.Sprintf("%s%s  %s", linePrefix, srcName(src, maxLineWidth-len(linePrefix)-2-len(widest)), stats)
+}
+
+// eta estimates the time left from the transfer rate reported for this update.
+func eta(pg toolapp.PullProgress) string {
+	if pg.Complete || pg.MBPerSec <= 0 || pg.CurrentBytes >= pg.TotalBytes {
+		return ""
+	}
+
+	secs := float64(pg.TotalBytes-pg.CurrentBytes) / (pg.MBPerSec * mb)
+
+	d := time.Duration(secs * float64(time.Second))
+
+	switch {
+	case d >= 100*time.Hour:
+		return widestETA
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%02dm", int(d/time.Hour), int(d/time.Minute)%60)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d/time.Second)%60)
+	default:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+}
+
+// unitFor picks the unit that keeps a size readable.
+func unitFor(bytes int64) string {
+	if bytes >= gb {
+		return "GB"
+	}
+
+	return "MB"
+}
+
+// sizeText renders bytes in the given unit, leaving the unit itself out so a
+// pair of sizes can share one.
+func sizeText(bytes int64, unit string) string {
+	if unit == "GB" {
+		return fmt.Sprintf("%.1f", float64(bytes)/gb)
+	}
+
+	return fmt.Sprintf("%d", bytes/mb)
+}
+
+// srcName shortens a file name from the front so the tail — where the
+// quantization and the extension live — stays visible.
+func srcName(src string, width int) string {
+	if width < minSrcWidth {
+		width = minSrcWidth
+	}
+
+	name := []rune(src)
+	if len(name) <= width {
+		return src
+	}
+
+	return "…" + string(name[len(name)-width+1:])
+}
+
+// isTerminal reports whether f is attached to a terminal, which is what makes
+// an in-place line rewrite meaningful.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/kronk/kronk/model/pull/progress_test.go
+++ b/cmd/kronk/kronk/model/pull/progress_test.go
@@ -1,0 +1,171 @@
+package pull
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ardanlabs/kronk/cmd/server/app/domain/toolapp"
+)
+
+func TestProgressPrinterRewritesSameFile(t *testing.T) {
+	var buf bytes.Buffer
+	prt := newProgressPrinter(&buf, true)
+
+	prt.print(toolapp.PullResponse{Status: "download-model: model-url[x] file[1/2]"})
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 100_000_000, TotalBytes: 400_000_000, MBPerSec: 25}})
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 200_000_000, TotalBytes: 400_000_000, MBPerSec: 25}})
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "mmproj.gguf", CurrentBytes: 10_000_000, TotalBytes: 20_000_000, MBPerSec: 10}})
+	prt.close()
+
+	got := buf.String()
+
+	if strings.Count(got, "\r\x1b[K") != 3 {
+		t.Errorf("carriage returns: got %d, want 3\n%q", strings.Count(got, "\r\x1b[K"), got)
+	}
+
+	// One line per file: the model line closed when mmproj started, and the
+	// mmproj line closed by the printer. The status message adds its own.
+	if lines := strings.Count(got, "\n"); lines != 3 {
+		t.Errorf("lines: got %d, want 3\n%q", lines, got)
+	}
+
+	if !strings.Contains(got, " 50.0%") {
+		t.Errorf("percentage missing from %q", got)
+	}
+}
+
+func TestProgressPrinterCompleteClosesLine(t *testing.T) {
+	var buf bytes.Buffer
+	prt := newProgressPrinter(&buf, true)
+
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 400_000_000, TotalBytes: 400_000_000, MBPerSec: 25, Complete: true}})
+
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("completed file must close its line: %q", buf.String())
+	}
+
+	// The line is already closed, so the printer must not add a second break.
+	prt.close()
+
+	if strings.Count(buf.String(), "\n") != 1 {
+		t.Errorf("lines: got %d, want 1\n%q", strings.Count(buf.String(), "\n"), buf.String())
+	}
+}
+
+func TestProgressPrinterWithoutRewrite(t *testing.T) {
+	var buf bytes.Buffer
+	prt := newProgressPrinter(&buf, false)
+
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 100_000_000, TotalBytes: 400_000_000, MBPerSec: 25}})
+	prt.print(toolapp.PullResponse{Progress: &toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 200_000_000, TotalBytes: 400_000_000, MBPerSec: 25}})
+	prt.close()
+
+	got := buf.String()
+
+	if strings.Contains(got, "\r") {
+		t.Errorf("redirected output must not rewrite lines: %q", got)
+	}
+
+	if lines := strings.Count(got, "\n"); lines != 2 {
+		t.Errorf("lines: got %d, want 2\n%q", lines, got)
+	}
+}
+
+func TestProgressLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress toolapp.PullProgress
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "percent and eta",
+			progress: toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 1_000_000_000, TotalBytes: 16_464_000_000, MBPerSec: 30},
+			contains: []string{"Downloading model.gguf", "6.1%", "1.0/16.5 GB", "30.00 MB/s", "ETA 8m35s"},
+		},
+		{
+			name:     "hours left",
+			progress: toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 1_000_000_000, TotalBytes: 16_464_000_000, MBPerSec: 1},
+			contains: []string{"ETA 4h17m"},
+		},
+		{
+			name:     "complete has no eta",
+			progress: toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 400_000_000, TotalBytes: 400_000_000, MBPerSec: 30, Complete: true},
+			contains: []string{"100.0%", "400/400 MB"},
+			excludes: []string{"ETA"},
+		},
+		{
+			name:     "unknown total",
+			progress: toolapp.PullProgress{Src: "model.gguf", CurrentBytes: 100_000_000, MBPerSec: 30},
+			contains: []string{"100 MB", "30.00 MB/s"},
+			excludes: []string{"%", "ETA"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := progressLine(test.progress)
+
+			for _, want := range test.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("got %q, want it to contain %q", got, want)
+				}
+			}
+
+			for _, unwanted := range test.excludes {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("got %q, want it to exclude %q", got, unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestProgressLineKeepsColumnsStable(t *testing.T) {
+	src := "Qwen3.8-27B-UD-Q4_K_M-00001-of-00009.gguf"
+
+	updates := []toolapp.PullProgress{
+		{Src: src, CurrentBytes: 100_000_000, TotalBytes: 16_464_000_000, MBPerSec: 9.5},
+		{Src: src, CurrentBytes: 7_440_000_000, TotalBytes: 16_464_000_000, MBPerSec: 129.85},
+		{Src: src, CurrentBytes: 16_464_000_000, TotalBytes: 16_464_000_000, MBPerSec: 29.85, Complete: true},
+	}
+
+	var pct, rate int
+	for i, pg := range updates {
+		got := progressLine(pg)
+
+		// The columns must land on the same offset across updates or the
+		// rewritten line jitters on screen.
+		gotPct := strings.Index(got, "%")
+		gotRate := strings.Index(got, " MB/s")
+
+		if i == 0 {
+			pct, rate = gotPct, gotRate
+			continue
+		}
+
+		if gotPct != pct || gotRate != rate {
+			t.Errorf("columns: got %d/%d, want %d/%d\n%q", gotPct, gotRate, pct, rate, got)
+		}
+	}
+}
+
+func TestProgressLineFitsTerminal(t *testing.T) {
+	pg := toolapp.PullProgress{
+		Src:          "Qwen3.8-27B-UD-Q4_K_M-with-a-really-long-file-name-00001-of-00009.gguf",
+		CurrentBytes: 7_440_000_000,
+		TotalBytes:   16_464_000_000,
+		MBPerSec:     29.85,
+	}
+
+	got := progressLine(pg)
+
+	if width := len([]rune(got)); width > maxLineWidth {
+		t.Errorf("width: got %d, want at most %d\n%q", width, maxLineWidth, got)
+	}
+
+	if !strings.Contains(got, "00001-of-00009.gguf") {
+		t.Errorf("the tail of the file name must survive truncation: %q", got)
+	}
+}

--- a/cmd/kronk/kronk/model/pull/pull.go
+++ b/cmd/kronk/kronk/model/pull/pull.go
@@ -40,14 +40,16 @@ func runWeb(ctx context.Context, source string, projURL string, mtpURL string) e
 		return fmt.Errorf("do: unable to download model: %w", err)
 	}
 
+	prt := newProgressPrinter(os.Stdout, isTerminal(os.Stdout))
+
 	var lastStatus string
 	var downloaded bool
 	for ver := range ch {
-		fmt.Print(ver.Status)
+		prt.print(ver)
 		lastStatus = ver.Status
 		downloaded = downloaded || ver.Downloaded || ver.Status == "downloaded"
 	}
-	fmt.Println()
+	prt.close()
 
 	if err := <-errCh; err != nil {
 		return fmt.Errorf("download stream: %w", err)


### PR DESCRIPTION
## What's Changed
The model pull client rendered every progress event from the model server as another chunk of text, because the server strips the carriage return sequence before streaming the status, so a 16 GB download scrolled hundreds of concatenated lines. 

The client now renders the structured progress payload instead of the pre-formatted status text: consecutive updates for the same file rewrite a single line in place, a different file starts a new line, and every line reports percentage, transferred and total size, transfer rate, and the estimated time left. 

Column widths are laid out against the widest form the stats can take so the line holds still between updates, and the file name is shortened from the front to keep the line within 80 columns, since an in-place rewrite that wraps leaves fragments behind on screen. 

When stdout is not a terminal the updates fall back to one line each, and any other status message
keeps its own line. 

New unit tests cover the rewrite behavior, file transitions, redirected output, and line formatting.

## Current
<img width="1723" height="1014" alt="Screenshot 2026-08-28 at 13 48 22" src="https://github.com/user-attachments/assets/a26ad595-35cf-4ed4-94ed-2cfb5115ea04" />

## Proposed
<img width="1417" height="63" alt="Screenshot 2026-08-28 at 13 50 40" src="https://github.com/user-attachments/assets/772ef712-63a0-4281-8243-cb4217dcf603" />
