### PR TITLE
fix(docker): move model_config.yaml to models/ dir under BASE_PATH

### DIFF
--- a/DockerHub.md
+++ b/DockerHub.md
@@ -246,13 +246,13 @@ Models, libraries, catalog data, and API keys are all stored under `/kronk`. Nam
 
 ## Environment Variables
 
-| Variable                       | Default                        | Description                                                                          |
-| ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------ |
-| `KRONK_DOWNLOAD_ENABLED`       | `false`                        | Allow model/library downloads from the browser UI (disabled by default for security) |
-| `KRONK_WEB_API_HOST`           | `0.0.0.0:11435`                | API bind address                                                                     |
-| `KRONK_WEB_DEBUG_HOST`         | `:11445`                       | Debug server bind address                                                            |
-| `KRONK_POOL_MODEL_CONFIG_FILE` | `/etc/kronk/model_config.yaml` | Path to model configuration file                                                     |
-| `KRONK_BASE_PATH`              | `/kronk`                       | Base path for all Kronk data                                                         |
+| Variable                       | Default                           | Description                                                                          |
+| ------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------ |
+| `KRONK_DOWNLOAD_ENABLED`       | `false`                           | Allow model/library downloads from the browser UI (disabled by default for security) |
+| `KRONK_WEB_API_HOST`           | `0.0.0.0:11435`                   | API bind address                                                                     |
+| `KRONK_WEB_DEBUG_HOST`         | `:11445`                          | Debug server bind address                                                            |
+| `KRONK_POOL_MODEL_CONFIG_FILE` | `/kronk/models/model_config.yaml` | Path to model configuration file                                                     |
+| `KRONK_BASE_PATH`              | `/kronk`                          | Base path for all Kronk data                                                         |
 
 ---
 

--- a/zarf/docker/kronk/Dockerfile
+++ b/zarf/docker/kronk/Dockerfile
@@ -932,7 +932,7 @@ COPY --from=bucky-libs-fetcher /kronk/bucky-libraries /kronk/bucky-libraries
 
 # Default model config — overridable by bind-mounting another file at the
 # path referenced by KRONK_POOL_MODEL_CONFIG_FILE below.
-COPY zarf/kms/model_config.yaml /etc/kronk/model_config.yaml
+COPY zarf/kms/model_config.yaml /kronk/models/model_config.yaml
 
 # Persistent state lives under /kronk. Models are huge and must be mounted;
 # libraries are baked above; catalog/keys/logs land under /kronk too. All
@@ -952,7 +952,7 @@ ENV KRONK_BASE_PATH=/kronk \
     KRONK_WEB_API_HOST=0.0.0.0:11435 \
     KRONK_DOWNLOAD_ENABLED=false \
     KRONK_INSECURE_LOGGING=false \
-    KRONK_POOL_MODEL_CONFIG_FILE=/etc/kronk/model_config.yaml
+    KRONK_POOL_MODEL_CONFIG_FILE=/kronk/models/model_config.yaml
 
 # Note on KRONK_DOWNLOAD_ENABLED: defaults to `false` for a security-
 # conscious production posture (no outbound model fetches from the
@@ -1119,7 +1119,7 @@ COPY --from=bucky-libs-fetcher /kronk/bucky-libraries /kronk/bucky-libraries
 
 # Default model config — overridable by bind-mounting another file at the
 # path referenced by KRONK_POOL_MODEL_CONFIG_FILE below.
-COPY zarf/kms/model_config.yaml /etc/kronk/model_config.yaml
+COPY zarf/kms/model_config.yaml /kronk/models/model_config.yaml
 
 # `bucky-models` is the whisper.cpp model root (see runtime stage above).
 RUN mkdir -p /kronk/models /kronk/bucky-models /kronk/catalog /kronk/keys \
@@ -1139,7 +1139,7 @@ ENV KRONK_BASE_PATH=/kronk \
     KRONK_WEB_API_HOST=0.0.0.0:11435 \
     KRONK_DOWNLOAD_ENABLED=false \
     KRONK_INSECURE_LOGGING=false \
-    KRONK_POOL_MODEL_CONFIG_FILE=/etc/kronk/model_config.yaml \
+    KRONK_POOL_MODEL_CONFIG_FILE=/kronk/models/model_config.yaml \
     KRONK_PROCESSOR=cuda
 
 # See note on KRONK_DOWNLOAD_ENABLED in the default runtime stage.

--- a/zarf/docker/kronk/Dockerfile
+++ b/zarf/docker/kronk/Dockerfile
@@ -930,8 +930,8 @@ COPY --from=libs-fetcher /kronk/libraries /kronk/libraries
 # side — and falls through to KRONK_BUCKY_LIB_PATH when set.
 COPY --from=bucky-libs-fetcher /kronk/bucky-libraries /kronk/bucky-libraries
 
-# Default model config — overridable by bind-mounting another file at the
-# path referenced by KRONK_POOL_MODEL_CONFIG_FILE below.
+# Default model config, at the location kronk uses natively. A named volume
+# on /kronk seeds from the image; a bind mount shadows this file.
 COPY zarf/kms/model_config.yaml /kronk/models/model_config.yaml
 
 # Persistent state lives under /kronk. Models are huge and must be mounted;
@@ -941,7 +941,7 @@ COPY zarf/kms/model_config.yaml /kronk/models/model_config.yaml
 # whisper.cpp model root (default `~/.kronk/bucky-models/` per
 # sdk/tools/bucky/models/models.go).
 RUN mkdir -p /kronk/models /kronk/bucky-models /kronk/catalog /kronk/keys \
- && chown -R kronk:kronk /kronk /etc/kronk
+ && chown -R kronk:kronk /kronk
 
 USER kronk:kronk
 
@@ -1117,13 +1117,13 @@ COPY --from=libs-fetcher /kronk/libraries /kronk/libraries
 # can transcribe on Jetson out of the box.
 COPY --from=bucky-libs-fetcher /kronk/bucky-libraries /kronk/bucky-libraries
 
-# Default model config — overridable by bind-mounting another file at the
-# path referenced by KRONK_POOL_MODEL_CONFIG_FILE below.
+# Default model config, at the location kronk uses natively. A named volume
+# on /kronk seeds from the image; a bind mount shadows this file.
 COPY zarf/kms/model_config.yaml /kronk/models/model_config.yaml
 
 # `bucky-models` is the whisper.cpp model root (see runtime stage above).
 RUN mkdir -p /kronk/models /kronk/bucky-models /kronk/catalog /kronk/keys \
- && chown -R kronk:kronk /kronk /etc/kronk
+ && chown -R kronk:kronk /kronk
 
 USER kronk:kronk
 


### PR DESCRIPTION
The model config was placed at /etc/kronk/model_config.yaml, outside the KRONK_BASE_PATH (/kronk) where models and other runtime data live. Move it to /kronk/models/model_config.yaml so it stays on the same volume mount as the downloaded models and honors the config map semantics discussed in #762.