### PR TITLE
docs(ci): drop two stale claims from the runner comments

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -117,10 +117,8 @@ jobs:
       - name: Set up Kronk
         uses: ./.github/actions/setup-kronk
 
-      # The `gpu`-tier lines, on top of the base set setup-kronk pulled. Cold-
-      # pull hazard on macOS: its two runners share one models directory and
-      # kronk has no cross-process lock, so overlapping cold pulls can lose the
-      # rename race.
+      # The `gpu`-tier lines, on top of the base set setup-kronk pulled. Every
+      # runner has its own models directory, so a cold pull has no peer.
       - name: Download GPU-only test models
         run: ./.github/scripts/pull-models.sh .github/test-models.txt gpu
 

--- a/sdk/kronk/tests/draft/suite_test.go
+++ b/sdk/kronk/tests/draft/suite_test.go
@@ -49,7 +49,8 @@ func TestSuite(t *testing.T) {
 		// for the classic drafter path to be considered exercised. Runs
 		// before WithModel's unload cleanup, so the model is still loaded.
 		t.Run("DraftAcceptance", func(t *testing.T) {
-			// A HIP defect: llama_decode never populates the sampled
+			// A HIP defect (https://github.com/ggml-org/llama.cpp/issues/28513):
+			// llama_decode never populates the sampled
 			// candidates, so every draft distribution is empty and
 			// classic.Verify cannot accept. Deterministic on ROCm, and it
 			// survived the runtime upgrade — accepted=0 on every request in

--- a/sdk/kronk/tests/draft/suite_test.go
+++ b/sdk/kronk/tests/draft/suite_test.go
@@ -49,7 +49,7 @@ func TestSuite(t *testing.T) {
 		// for the classic drafter path to be considered exercised. Runs
 		// before WithModel's unload cleanup, so the model is still loaded.
 		t.Run("DraftAcceptance", func(t *testing.T) {
-			// upstream.md's defect: llama_decode never populates the sampled
+			// A HIP defect: llama_decode never populates the sampled
 			// candidates, so every draft distribution is empty and
 			// classic.Verify cannot accept. Deterministic on ROCm, and it
 			// survived the runtime upgrade — accepted=0 on every request in
@@ -59,8 +59,8 @@ func TestSuite(t *testing.T) {
 			//   7.2.4  run 33929435557  draft=28 accepted=0
 			//   10.0   run 33931520320  draft=31 accepted=0, draft=29 accepted=0
 			//
-			// Unlike upstream2.md's batch defect this one never passes, so a
-			// single green ROCm run here is enough to retire the skip.
+			// Unlike the shared-batch defect in qwen3's batch suite this one
+			// never passes, so a single green ROCm run retires the skip.
 			// On Metal, check the reported GPU family first: below Apple7 ggml
 			// refuses SOFT_MAX/CUMSUM/SUM (ggml-metal-device.m:1214-1234).
 			testlib.SkipOnBackends(t, "llama_decode does not populate sampled candidates, so every draft distribution is empty", "rocm")

--- a/sdk/kronk/tests/gemma4mtp/suite_test.go
+++ b/sdk/kronk/tests/gemma4mtp/suite_test.go
@@ -41,8 +41,8 @@ func TestSuite(t *testing.T) {
 // per-slot pre-norm capture, and fixed-position drafting under contention.
 // Single-slot behavior remains covered by TestSuite above.
 func TestSuiteMultiSlot(t *testing.T) {
-	// Two sequences sharing one decode batch come back with corrupted logits on
-	// ROCm — upstream2.md, same as sdk/kronk/tests/qwen3's batch suite.
+	// Two sequences sharing one llama_decode batch come back with corrupted
+	// logits on HIP, as in sdk/kronk/tests/qwen3's batch suite.
 	testlib.SkipOnBackends(t, "two sequences sharing one decode batch come back with corrupted logits", "rocm")
 
 	testlib.WithModel(t, testlib.CfgGemma4MTPChatMultiSlot(), func(t *testing.T, krn *kronk.Kronk) {

--- a/sdk/kronk/tests/gemma4mtp/suite_test.go
+++ b/sdk/kronk/tests/gemma4mtp/suite_test.go
@@ -42,7 +42,7 @@ func TestSuite(t *testing.T) {
 // Single-slot behavior remains covered by TestSuite above.
 func TestSuiteMultiSlot(t *testing.T) {
 	// Two sequences sharing one llama_decode batch come back with corrupted
-	// logits on HIP, as in sdk/kronk/tests/qwen3's batch suite.
+	// logits on HIP: https://github.com/ggml-org/llama.cpp/issues/28537
 	testlib.SkipOnBackends(t, "two sequences sharing one decode batch come back with corrupted logits", "rocm")
 
 	testlib.WithModel(t, testlib.CfgGemma4MTPChatMultiSlot(), func(t *testing.T, krn *kronk.Kronk) {

--- a/sdk/kronk/tests/mtp/suite_test.go
+++ b/sdk/kronk/tests/mtp/suite_test.go
@@ -40,8 +40,8 @@ func TestSuite(t *testing.T) {
 // cap, and the post-verify mirror across multiple active spec slots.
 // Single-slot behavior remains covered by TestSuite above.
 func TestSuiteMultiSlot(t *testing.T) {
-	// Two sequences sharing one decode batch come back with corrupted logits on
-	// ROCm — upstream2.md, same as sdk/kronk/tests/qwen3's batch suite.
+	// Two sequences sharing one llama_decode batch come back with corrupted
+	// logits on HIP, as in sdk/kronk/tests/qwen3's batch suite.
 	testlib.SkipOnBackends(t, "two sequences sharing one decode batch come back with corrupted logits", "rocm")
 
 	testlib.WithModel(t, testlib.CfgMTPChatMultiSlot(), func(t *testing.T, krn *kronk.Kronk) {

--- a/sdk/kronk/tests/mtp/suite_test.go
+++ b/sdk/kronk/tests/mtp/suite_test.go
@@ -41,7 +41,7 @@ func TestSuite(t *testing.T) {
 // Single-slot behavior remains covered by TestSuite above.
 func TestSuiteMultiSlot(t *testing.T) {
 	// Two sequences sharing one llama_decode batch come back with corrupted
-	// logits on HIP, as in sdk/kronk/tests/qwen3's batch suite.
+	// logits on HIP: https://github.com/ggml-org/llama.cpp/issues/28537
 	testlib.SkipOnBackends(t, "two sequences sharing one decode batch come back with corrupted logits", "rocm")
 
 	testlib.WithModel(t, testlib.CfgMTPChatMultiSlot(), func(t *testing.T, krn *kronk.Kronk) {

--- a/sdk/kronk/tests/qwen3/batch_test.go
+++ b/sdk/kronk/tests/qwen3/batch_test.go
@@ -16,6 +16,7 @@ func Test_BatchChatConcurrent(t *testing.T) {
 	// This is the only suite that decodes two sequences concurrently, and on
 	// ROCm it hits a HIP defect: two sequences sharing one llama_decode batch
 	// come back with corrupted logits, which leaves a message empty.
+	// https://github.com/ggml-org/llama.cpp/issues/28537
 	//
 	// Confirmed across two ROCm major versions at llama.cpp b10798, so the
 	// runtime is not what carries it:

--- a/sdk/kronk/tests/qwen3/batch_test.go
+++ b/sdk/kronk/tests/qwen3/batch_test.go
@@ -14,8 +14,8 @@ import (
 
 func Test_BatchChatConcurrent(t *testing.T) {
 	// This is the only suite that decodes two sequences concurrently, and on
-	// ROCm it hits upstream2.md's defect: two sequences sharing one decode
-	// batch come back with corrupted logits, which leaves a message empty.
+	// ROCm it hits a HIP defect: two sequences sharing one llama_decode batch
+	// come back with corrupted logits, which leaves a message empty.
 	//
 	// Confirmed across two ROCm major versions at llama.cpp b10798, so the
 	// runtime is not what carries it:

--- a/sdk/kronk/tests/testlib/testlib.go
+++ b/sdk/kronk/tests/testlib/testlib.go
@@ -96,8 +96,9 @@ func Setup() {
 	// loads, so this is the first moment the executing backend is knowable.
 	fmt.Println("processor        :", Processor())
 
-	// On HIP a sequence sharing a llama_decode batch with another comes back
-	// with corrupted logits, which breaks every suite that fans out below.
+	// A sequence sharing a llama_decode batch with another comes back with
+	// corrupted logits on HIP, breaking every suite that fans out below:
+	// https://github.com/ggml-org/llama.cpp/issues/28537
 	if Processor() == "rocm" {
 		Goroutines = 1
 		fmt.Println("goroutines       : 1 (rocm)")

--- a/sdk/kronk/tests/testlib/testlib.go
+++ b/sdk/kronk/tests/testlib/testlib.go
@@ -96,8 +96,8 @@ func Setup() {
 	// loads, so this is the first moment the executing backend is knowable.
 	fmt.Println("processor        :", Processor())
 
-	// ROCm returns corrupted logits when two sequences share one decode batch
-	// (upstream2.md), which breaks every suite that fans out below.
+	// On HIP a sequence sharing a llama_decode batch with another comes back
+	// with corrupted logits, which breaks every suite that fans out below.
 	if Processor() == "rocm" {
 		Goroutines = 1
 		fmt.Println("goroutines       : 1 (rocm)")


### PR DESCRIPTION
Follow-up to #915, review comments only — no behaviour change.

- `gpu.yml` still said the two macOS runners share one models directory and warned about a cold-pull rename race. Each runner has had its own directory since #915, and a runner takes one job at a time, so there is no peer to race.
- The ROCm skips pointed at `upstream.md` / `upstream2.md`, untracked local notes — a dangling reference for anyone else reading the code. Each now cites the filed issue:
  - ggml-org/llama.cpp#28513 — the backend sampler probe never populates the sampled candidates, so every draft distribution is empty (`TestSuite/DraftAcceptance`).
  - ggml-org/llama.cpp#28537 — on HIP, a sequence sharing a `llama_decode()` batch with another gets corrupted logits (`Test_BatchChatConcurrent`, both `TestSuiteMultiSlot`s, and the ROCm fan-out pin in `testlib.Setup`).

#915's description was corrected in place for the same two claims, plus the `GOBIN` and concurrent-pull bullets that the PR itself later reverted.