### PR TITLE
fix: deliver qwen tool calls emitted inside markdown fences

### DIFF
--- a/sdk/kronk/parsers/qwen/fence_test.go
+++ b/sdk/kronk/parsers/qwen/fence_test.go
@@ -8,17 +8,28 @@ import (
 	"github.com/ardanlabs/kronk/sdk/kronk/model"
 )
 
+var fenceTools = []model.D{
+	{"type": "function", "function": model.D{"name": "submit_findings"}},
+}
+
+func fencedMachine(t *testing.T) model.StateMachine {
+	t.Helper()
+	c := Parser{}.NewStateMachine()
+	c.(model.ToolAwareStateMachine).SetTools(fenceTools)
+	return c
+}
+
 // TestParser_FencedJSONToolCall verifies that a tool-call envelope emitted
 // inside a markdown code fence as visible text — the shape Qwen2.5-Coder
 // produces at larger prompt sizes — is delivered through the tool channel
 // with the fences stripped, exactly like a marked <tool_call> envelope.
 func TestParser_FencedJSONToolCall(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-json-tool-call", c, []step{
 		{token: "```json\n", channel: model.ChannelNone},
-		{token: `{"name":"get_weather","arguments":{"location":"Paris"}}`, channel: model.ChannelNone},
+		{token: `{"name":"submit_findings","arguments":{"location":"Paris"}}`, channel: model.ChannelNone},
 		{token: "\n```", channel: model.ChannelTool,
-			content: `{"name":"get_weather","arguments":{"location":"Paris"}}` + "\n"},
+			content: `{"name":"submit_findings","arguments":{"location":"Paris"}}` + "\n"},
 	})
 	_, eog := c.Classify("done")
 	if !eog {
@@ -27,34 +38,75 @@ func TestParser_FencedJSONToolCall(t *testing.T) {
 }
 
 func TestParser_FencedJSONToolCallSingleToken(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-json-tool-call-single-token", c, []step{
-		{token: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```", channel: model.ChannelTool,
-			content: `{"name":"a","arguments":{}}` + "\n"},
+		{token: "```json\n{\"name\":\"submit_findings\",\"arguments\":{}}\n```", channel: model.ChannelTool,
+			content: `{"name":"submit_findings","arguments":{}}` + "\n"},
 	})
 }
 
 func TestParser_FencedJSONToolCallSplitTokens(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-json-tool-call-split-tokens", c, []step{
 		{token: "`", channel: model.ChannelNone},
 		{token: "`", channel: model.ChannelNone},
 		{token: "`json\n", channel: model.ChannelNone},
 		{token: `{"name":`, channel: model.ChannelNone},
-		{token: `"a","arguments":{}}`, channel: model.ChannelNone},
+		{token: `"submit_findings","arguments":{}}`, channel: model.ChannelNone},
 		{token: "\n", channel: model.ChannelNone},
 		{token: "```", channel: model.ChannelTool,
-			content: `{"name":"a","arguments":{}}` + "\n"},
+			content: `{"name":"submit_findings","arguments":{}}` + "\n"},
 	})
 }
 
 func TestParser_FencedBareTagToolCall(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-bare-tag-tool-call", c, []step{
 		{token: "```\n", channel: model.ChannelNone},
-		{token: `{"name":"a","arguments":{}}`, channel: model.ChannelNone},
+		{token: `{"name":"submit_findings","arguments":{}}`, channel: model.ChannelNone},
 		{token: "\n```", channel: model.ChannelTool,
-			content: `{"name":"a","arguments":{}}` + "\n"},
+			content: `{"name":"submit_findings","arguments":{}}` + "\n"},
+	})
+}
+
+// TestParser_FencedUndeclaredNameStreamsAsAnswer verifies the declared-tool
+// gate: fenced JSON naming a function the request did not declare is ordinary
+// content and passes through verbatim, never delivered as a call.
+func TestParser_FencedUndeclaredNameStreamsAsAnswer(t *testing.T) {
+	c := fencedMachine(t)
+	const undeclared = "```json\n" + `{"name":"other_tool","arguments":{}}` + "\n```"
+	runSteps(t, "fenced-undeclared-name", c, []step{
+		{token: "```json\n", channel: model.ChannelNone},
+		// The body is envelope-shaped, so it is held until the close fence;
+		// only the complete JSON reveals the undeclared name.
+		{token: `{"name":"other_tool","arguments":{}}`, channel: model.ChannelNone},
+		{token: "\n```", channel: model.ChannelAnswer, content: undeclared},
+	})
+}
+
+// TestParser_FencedJSONWithoutDeclaredToolsStreamsAsAnswer verifies the hold
+// never engages when the request declares no tools: fenced JSON answers
+// stream untouched.
+func TestParser_FencedJSONWithoutDeclaredToolsStreamsAsAnswer(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-json-no-tools", c, []step{
+		{token: "```json\n", channel: model.ChannelAnswer, content: "```json\n"},
+		{token: `{"name":"submit_findings"}`, channel: model.ChannelAnswer, content: `{"name":"submit_findings"}`},
+		{token: "\n```", channel: model.ChannelAnswer, content: "\n```"},
+	})
+}
+
+// TestParser_WhitespaceThenTaggedToolCallUnaffected verifies the fence hold
+// does not disturb an ordinary marked call whose reply begins with
+// whitespace: the whitespace streams and the marker still opens the call.
+func TestParser_WhitespaceThenTaggedToolCallUnaffected(t *testing.T) {
+	c := fencedMachine(t)
+	runSteps(t, "whitespace-then-tagged-tool-call", c, []step{
+		{token: "\n", channel: model.ChannelAnswer, content: "\n"},
+		{token: "<tool_call>", channel: model.ChannelTool},
+		{token: `{"name":"submit_findings","arguments":{}}`, channel: model.ChannelNone},
+		{token: "</tool_call>", channel: model.ChannelTool,
+			content: `{"name":"submit_findings","arguments":{}}` + "\n"},
 	})
 }
 
@@ -63,7 +115,7 @@ func TestParser_FencedBareTagToolCall(t *testing.T) {
 // it is released as soon as the body proves it is not an envelope rather than
 // held to end of generation.
 func TestParser_FencedCodeStreamsAsAnswer(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-code-streams-as-answer", c, []step{
 		{token: "```go\n", channel: model.ChannelNone},
 		{token: "func", channel: model.ChannelAnswer, content: "```go\nfunc"},
@@ -73,7 +125,7 @@ func TestParser_FencedCodeStreamsAsAnswer(t *testing.T) {
 }
 
 func TestParser_FencedProseInfoStringStreamsAsAnswer(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-prose-info-string", c, []step{
 		{token: "```here is a note\n", channel: model.ChannelAnswer, content: "```here is a note\n"},
 		{token: "hello", channel: model.ChannelAnswer, content: "hello"},
@@ -81,7 +133,7 @@ func TestParser_FencedProseInfoStringStreamsAsAnswer(t *testing.T) {
 }
 
 func TestParser_InlineBacktickProseStreamsAsAnswer(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "inline-backtick-prose", c, []step{
 		{token: "`", channel: model.ChannelNone},
 		{token: "code` is inline", channel: model.ChannelAnswer, content: "`code` is inline"},
@@ -91,19 +143,20 @@ func TestParser_InlineBacktickProseStreamsAsAnswer(t *testing.T) {
 // TestParser_FenceAfterProseIgnored verifies the hold engages only at the
 // start of a reply: prose containing a fence later on streams untouched.
 func TestParser_FenceAfterProseIgnored(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fence-after-prose", c, []step{
 		{token: "Here is code:", channel: model.ChannelAnswer, content: "Here is code:"},
-		{token: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```",
-			channel: model.ChannelAnswer, content: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```"},
+		{token: "```json\n{\"name\":\"submit_findings\",\"arguments\":{}}\n```",
+			channel: model.ChannelAnswer, content: "```json\n{\"name\":\"submit_findings\",\"arguments\":{}}\n```"},
 	})
 }
 
 func TestFlush_UnclosedFenceEnvelope(t *testing.T) {
 	c := Parser{}.NewStateMachine()
+	c.(model.ToolAwareStateMachine).SetTools(fenceTools)
 
 	var tooling strings.Builder
-	for _, token := range []string{"```json\n", `{"name":"get_weather","arguments":{"location":"Paris"}}`} {
+	for _, token := range []string{"```json\n", `{"name":"submit_findings","arguments":{"location":"Paris"}}`} {
 		result, eog := c.Classify(token)
 		if eog {
 			t.Fatalf("Classify(%q): got EOG before tool call completed", token)
@@ -119,13 +172,13 @@ func TestFlush_UnclosedFenceEnvelope(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("ToolCall: got %d calls, want 1", len(calls))
 	}
-	if got, want := calls[0].Function.Name, "get_weather"; got != want {
+	if got, want := calls[0].Function.Name, "submit_findings"; got != want {
 		t.Errorf("Function.Name: got %q, want %q", got, want)
 	}
 }
 
 func TestParser_FencedNonEnvelopeUnderJsonTagReleased(t *testing.T) {
-	c := Parser{}.NewStateMachine()
+	c := fencedMachine(t)
 	runSteps(t, "fenced-non-envelope-under-json-tag", c, []step{
 		{token: "```json\n", channel: model.ChannelNone},
 		{token: "not an envelope", channel: model.ChannelAnswer, content: "```json\nnot an envelope"},

--- a/sdk/kronk/parsers/qwen/fence_test.go
+++ b/sdk/kronk/parsers/qwen/fence_test.go
@@ -1,0 +1,164 @@
+package qwen
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ardanlabs/kronk/sdk/kronk/model"
+)
+
+// TestParser_FencedJSONToolCall verifies that a tool-call envelope emitted
+// inside a markdown code fence as visible text — the shape Qwen2.5-Coder
+// produces at larger prompt sizes — is delivered through the tool channel
+// with the fences stripped, exactly like a marked <tool_call> envelope.
+func TestParser_FencedJSONToolCall(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-json-tool-call", c, []step{
+		{token: "```json\n", channel: model.ChannelNone},
+		{token: `{"name":"get_weather","arguments":{"location":"Paris"}}`, channel: model.ChannelNone},
+		{token: "\n```", channel: model.ChannelTool,
+			content: `{"name":"get_weather","arguments":{"location":"Paris"}}` + "\n"},
+	})
+	_, eog := c.Classify("done")
+	if !eog {
+		t.Errorf("expected EOG after tool call closed")
+	}
+}
+
+func TestParser_FencedJSONToolCallSingleToken(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-json-tool-call-single-token", c, []step{
+		{token: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```", channel: model.ChannelTool,
+			content: `{"name":"a","arguments":{}}` + "\n"},
+	})
+}
+
+func TestParser_FencedJSONToolCallSplitTokens(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-json-tool-call-split-tokens", c, []step{
+		{token: "`", channel: model.ChannelNone},
+		{token: "`", channel: model.ChannelNone},
+		{token: "`json\n", channel: model.ChannelNone},
+		{token: `{"name":`, channel: model.ChannelNone},
+		{token: `"a","arguments":{}}`, channel: model.ChannelNone},
+		{token: "\n", channel: model.ChannelNone},
+		{token: "```", channel: model.ChannelTool,
+			content: `{"name":"a","arguments":{}}` + "\n"},
+	})
+}
+
+func TestParser_FencedBareTagToolCall(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-bare-tag-tool-call", c, []step{
+		{token: "```\n", channel: model.ChannelNone},
+		{token: `{"name":"a","arguments":{}}`, channel: model.ChannelNone},
+		{token: "\n```", channel: model.ChannelTool,
+			content: `{"name":"a","arguments":{}}` + "\n"},
+	})
+}
+
+// TestParser_FencedCodeStreamsAsAnswer verifies that fenced content which is
+// not a tool-call envelope passes through verbatim, fences included, and that
+// it is released as soon as the body proves it is not an envelope rather than
+// held to end of generation.
+func TestParser_FencedCodeStreamsAsAnswer(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-code-streams-as-answer", c, []step{
+		{token: "```go\n", channel: model.ChannelNone},
+		{token: "func", channel: model.ChannelAnswer, content: "```go\nfunc"},
+		{token: " main() {}\n", channel: model.ChannelAnswer, content: " main() {}\n"},
+		{token: "```", channel: model.ChannelAnswer, content: "```"},
+	})
+}
+
+func TestParser_FencedProseInfoStringStreamsAsAnswer(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-prose-info-string", c, []step{
+		{token: "```here is a note\n", channel: model.ChannelAnswer, content: "```here is a note\n"},
+		{token: "hello", channel: model.ChannelAnswer, content: "hello"},
+	})
+}
+
+func TestParser_InlineBacktickProseStreamsAsAnswer(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "inline-backtick-prose", c, []step{
+		{token: "`", channel: model.ChannelNone},
+		{token: "code` is inline", channel: model.ChannelAnswer, content: "`code` is inline"},
+	})
+}
+
+// TestParser_FenceAfterProseIgnored verifies the hold engages only at the
+// start of a reply: prose containing a fence later on streams untouched.
+func TestParser_FenceAfterProseIgnored(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fence-after-prose", c, []step{
+		{token: "Here is code:", channel: model.ChannelAnswer, content: "Here is code:"},
+		{token: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```",
+			channel: model.ChannelAnswer, content: "```json\n{\"name\":\"a\",\"arguments\":{}}\n```"},
+	})
+}
+
+func TestFlush_UnclosedFenceEnvelope(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+
+	var tooling strings.Builder
+	for _, token := range []string{"```json\n", `{"name":"get_weather","arguments":{"location":"Paris"}}`} {
+		result, eog := c.Classify(token)
+		if eog {
+			t.Fatalf("Classify(%q): got EOG before tool call completed", token)
+		}
+		if result.Channel == model.ChannelTool {
+			tooling.WriteString(result.Content)
+		}
+	}
+	flusher := c.(model.StateMachineFlusher)
+	tooling.WriteString(flusher.Flush().Content)
+
+	calls := Parser{}.ToolCall(context.Background(), noopLog, tooling.String())
+	if len(calls) != 1 {
+		t.Fatalf("ToolCall: got %d calls, want 1", len(calls))
+	}
+	if got, want := calls[0].Function.Name, "get_weather"; got != want {
+		t.Errorf("Function.Name: got %q, want %q", got, want)
+	}
+}
+
+func TestParser_FencedNonEnvelopeUnderJsonTagReleased(t *testing.T) {
+	c := Parser{}.NewStateMachine()
+	runSteps(t, "fenced-non-envelope-under-json-tag", c, []step{
+		{token: "```json\n", channel: model.ChannelNone},
+		{token: "not an envelope", channel: model.ChannelAnswer, content: "```json\nnot an envelope"},
+	})
+	flusher := c.(model.StateMachineFlusher)
+	if result := flusher.Flush(); result.Channel != model.ChannelNone {
+		t.Errorf("Flush after mid-stream release: got (%v, %q), want zero result",
+			result.Channel, result.Content)
+	}
+}
+
+func TestFenceBodyOf(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"closed json", "```json\n{}\n```", "{}", true},
+		{"closed bare", "```\n{}\n```", "{}", true},
+		{"unclosed", "```json\n{}", "{}", true},
+		{"leading whitespace", "\n```json\n{}\n```", "{}", true},
+		{"prose tag", "```some prose\n{}\n```", "", false},
+		{"no fence", "{}", "", false},
+		{"opener only", "```json", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := fenceBodyOf(tt.in)
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("fenceBodyOf(%q) = (%q, %v), want (%q, %v)",
+					tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/sdk/kronk/parsers/qwen/state_machine.go
+++ b/sdk/kronk/parsers/qwen/state_machine.go
@@ -33,13 +33,17 @@ type stateMachine struct {
 
 	// Reply-leading markdown code fence. Some Qwen models (notably
 	// Qwen2.5-Coder at larger prompt sizes) emit a valid tool-call envelope
-	// inside a ``` fence as visible text instead of the marked format, so
-	// the fence is held until its body resolves as a call or ordinary
-	// content rather than streamed as answer.
+	// inside a ``` fence as visible text instead of the marked format. When
+	// tools are declared, the fence is held until its body resolves as one
+	// of those calls or as ordinary content.
 	fenceBuf    strings.Builder
 	fenceActive bool
 	fenceBody   bool
 	emitted     bool
+
+	// Declared tool names from the request, used to tell a fenced tool-call
+	// envelope apart from ordinary fenced JSON.
+	toolNames map[string]struct{}
 
 	// OpenAI-compatible activity deltas for tool-call starts.
 	toolCallDeltas []model.ResponseToolCallDelta
@@ -63,6 +67,7 @@ func (sm *stateMachine) Reset() {
 	sm.fenceActive = false
 	sm.fenceBody = false
 	sm.emitted = false
+	sm.toolNames = nil
 	sm.toolCallDeltas = nil
 	sm.startedCalls = nil
 	sm.deltaCallID = ""
@@ -79,10 +84,11 @@ func (sm *stateMachine) Classify(content string) (model.Result, bool) {
 		return sm.classifyFenced(content)
 	}
 
-	// The fence hold engages only before anything has been emitted, so
-	// prose containing a fence later in the reply streams untouched.
-	if !sm.emitted && !sm.inPendingTag && !sm.inToolCall && !sm.toolCallDone && sm.status == model.ChannelAnswer &&
-		content != "" && (strings.HasPrefix(content, fenceOpen) || strings.HasPrefix(fenceOpen, content) || strings.TrimSpace(content) == "") {
+	// The fence hold engages only when tools are declared and the reply's
+	// very first token opens a fence — anything else (prose, whitespace, a
+	// marked call) must stream through the normal paths untouched.
+	if len(sm.toolNames) > 0 && !sm.emitted && !sm.inPendingTag && !sm.inToolCall && !sm.toolCallDone && sm.status == model.ChannelAnswer &&
+		content != "" && (strings.HasPrefix(content, fenceOpen) || strings.HasPrefix(fenceOpen, content)) {
 		sm.fenceActive = true
 		return sm.classifyFenced(content)
 	}
@@ -266,7 +272,7 @@ func (sm *stateMachine) classifyFenced(content string) (model.Result, bool) {
 		return model.Result{}, false
 	}
 	trimmedInner := strings.TrimSpace(inner)
-	if !isJSONEnvelope(trimmedInner) {
+	if name, ok := envelopeName(trimmedInner); !ok || !sm.declaresTool(name) {
 		return sm.fenceBail(candidate)
 	}
 
@@ -296,16 +302,50 @@ func (sm *stateMachine) fenceBail(candidate string) (model.Result, bool) {
 	return model.Result{Channel: model.ChannelAnswer, Content: candidate}, false
 }
 
-// isJSONEnvelope reports whether content is a JSON object carrying a name,
-// the shape of an unmarked Qwen tool-call envelope.
-func isJSONEnvelope(content string) bool {
+// envelopeName parses content as a JSON tool-call envelope and returns its
+// declared function name.
+func envelopeName(content string) (string, bool) {
 	if !strings.HasPrefix(content, "{") {
-		return false
+		return "", false
 	}
 	var envelope struct {
 		Name string `json:"name"`
 	}
-	return json.Unmarshal([]byte(content), &envelope) == nil && envelope.Name != ""
+	if json.Unmarshal([]byte(content), &envelope) != nil || envelope.Name == "" {
+		return "", false
+	}
+	return envelope.Name, true
+}
+
+// declaresTool reports whether name matches a tool declared in the request.
+func (sm *stateMachine) declaresTool(name string) bool {
+	_, declared := sm.toolNames[name]
+	return declared
+}
+
+// SetTools supplies the request's declared tools, telling a fenced JSON
+// envelope apart from ordinary fenced JSON by its function name.
+func (sm *stateMachine) SetTools(tools []model.D) {
+	sm.toolNames = make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if name := declaredToolName(tool); name != "" {
+			sm.toolNames[name] = struct{}{}
+		}
+	}
+}
+
+// declaredToolName returns the function name of an OpenAI-style tool
+// declaration.
+func declaredToolName(tool model.D) string {
+	if tool["type"] != "function" {
+		return ""
+	}
+	function, ok := tool["function"].(model.D)
+	if !ok {
+		return ""
+	}
+	name, _ := function["name"].(string)
+	return name
 }
 
 // isLanguageTag reports whether s is a bare markdown info string.
@@ -497,8 +537,8 @@ func (sm *stateMachine) Flush() model.Result {
 		sm.fenceBuf.Reset()
 
 		if body, ok := fenceBodyOf(candidate); ok {
-			if trimmed := strings.TrimSpace(body); isJSONEnvelope(trimmed) {
-				sm.startToolCall(true, trimmed)
+			if name, ok := envelopeName(strings.TrimSpace(body)); ok && sm.declaresTool(name) {
+				sm.startToolCall(true, strings.TrimSpace(body))
 				return sm.completeToolCall()
 			}
 		}

--- a/sdk/kronk/parsers/qwen/state_machine.go
+++ b/sdk/kronk/parsers/qwen/state_machine.go
@@ -13,6 +13,7 @@ import (
 //   - <think>…</think>       reasoning wrap
 //   - <tool_call>…</tool_call> JSON envelope (also <|tool_call>/<tool_call|>)
 //   - <function=name>…</function> direct XML format (Qwen-Coder)
+//   - ```json fenced envelope  a tool call emitted as fenced text
 //
 // The split-tag lookahead handles tokenizers that fragment "<function=" into
 // "<", "f", "function", "=", etc.
@@ -29,6 +30,16 @@ type stateMachine struct {
 	// Lookahead buffer for split <function=… tokens.
 	pendingTagBuf strings.Builder
 	inPendingTag  bool
+
+	// Reply-leading markdown code fence. Some Qwen models (notably
+	// Qwen2.5-Coder at larger prompt sizes) emit a valid tool-call envelope
+	// inside a ``` fence as visible text instead of the marked format, so
+	// the fence is held until its body resolves as a call or ordinary
+	// content rather than streamed as answer.
+	fenceBuf    strings.Builder
+	fenceActive bool
+	fenceBody   bool
+	emitted     bool
 
 	// OpenAI-compatible activity deltas for tool-call starts.
 	toolCallDeltas []model.ResponseToolCallDelta
@@ -48,6 +59,10 @@ func (sm *stateMachine) Reset() {
 	sm.directToolCallDone = false
 	sm.pendingTagBuf.Reset()
 	sm.inPendingTag = false
+	sm.fenceBuf.Reset()
+	sm.fenceActive = false
+	sm.fenceBody = false
+	sm.emitted = false
 	sm.toolCallDeltas = nil
 	sm.startedCalls = nil
 	sm.deltaCallID = ""
@@ -59,6 +74,20 @@ func (sm *stateMachine) Reset() {
 // Behavior is undefined if Classify is called after a previous call returned
 // eog=true. Reset must be invoked between requests.
 func (sm *stateMachine) Classify(content string) (model.Result, bool) {
+	// A reply-leading markdown code fence being held for classification.
+	if sm.fenceActive {
+		return sm.classifyFenced(content)
+	}
+
+	// The fence hold engages only before anything has been emitted, so
+	// prose containing a fence later in the reply streams untouched.
+	if !sm.emitted && !sm.inPendingTag && !sm.inToolCall && !sm.toolCallDone && sm.status == model.ChannelAnswer &&
+		content != "" && (strings.HasPrefix(content, fenceOpen) || strings.HasPrefix(fenceOpen, content) || strings.TrimSpace(content) == "") {
+		sm.fenceActive = true
+		return sm.classifyFenced(content)
+	}
+	sm.emitted = true
+
 	// Lookahead for split <function= openers.
 	if sm.inPendingTag {
 		sm.pendingTagBuf.WriteString(content)
@@ -196,6 +225,99 @@ func (sm *stateMachine) Classify(content string) (model.Result, bool) {
 
 		return model.Result{Channel: sm.status, Content: content}, false
 	}
+}
+
+const fenceOpen = "```"
+
+// classifyFenced resolves reply-leading fenced content. The opener line is
+// held until its newline arrives; the body is held until a closing fence, an
+// early bail-out, or end of generation (Flush). A body that is a JSON
+// tool-call envelope is delivered through the same completion path as a
+// marked call; anything else is released verbatim as answer content, fences
+// included.
+func (sm *stateMachine) classifyFenced(content string) (model.Result, bool) {
+	sm.fenceBuf.WriteString(content)
+	candidate := sm.fenceBuf.String()
+
+	if !sm.fenceBody {
+		trimmed := strings.TrimLeft(candidate, " \t\r\n")
+		if trimmed != "" && !strings.HasPrefix(trimmed, fenceOpen) && !strings.HasPrefix(fenceOpen, trimmed) {
+			return sm.fenceBail(candidate)
+		}
+		line, _, found := strings.Cut(trimmed, "\n")
+		if !found {
+			return model.Result{}, false
+		}
+		if tag := strings.TrimPrefix(line, fenceOpen); tag != "" && !isLanguageTag(tag) {
+			return sm.fenceBail(candidate)
+		}
+		sm.fenceBody = true
+	}
+
+	body := sm.fenceBodyText(candidate)
+	inner, _, found := strings.Cut(body, "\n"+fenceOpen)
+	if !found {
+		// A body that cannot be an envelope is released immediately so
+		// ordinary fenced content still streams rather than buffering to
+		// end of generation.
+		if b := strings.TrimLeft(body, " \t\r\n"); b != "" && !strings.HasPrefix(b, "{") {
+			return sm.fenceBail(candidate)
+		}
+		return model.Result{}, false
+	}
+	trimmedInner := strings.TrimSpace(inner)
+	if !isJSONEnvelope(trimmedInner) {
+		return sm.fenceBail(candidate)
+	}
+
+	sm.fenceActive = false
+	sm.fenceBody = false
+	sm.fenceBuf.Reset()
+	sm.startToolCall(true, trimmedInner)
+	return sm.completeToolCall(), false
+}
+
+// fenceBodyText returns the fenced body following the opener line.
+func (sm *stateMachine) fenceBodyText(candidate string) string {
+	open := strings.Index(candidate, fenceOpen)
+	if nl := strings.Index(candidate[open:], "\n"); nl >= 0 {
+		return candidate[open+nl+1:]
+	}
+	return ""
+}
+
+// fenceBail releases a fence candidate as ordinary answer content, fences
+// included, when it did not resolve to a tool-call envelope.
+func (sm *stateMachine) fenceBail(candidate string) (model.Result, bool) {
+	sm.fenceActive = false
+	sm.fenceBody = false
+	sm.fenceBuf.Reset()
+	sm.emitted = true
+	return model.Result{Channel: model.ChannelAnswer, Content: candidate}, false
+}
+
+// isJSONEnvelope reports whether content is a JSON object carrying a name,
+// the shape of an unmarked Qwen tool-call envelope.
+func isJSONEnvelope(content string) bool {
+	if !strings.HasPrefix(content, "{") {
+		return false
+	}
+	var envelope struct {
+		Name string `json:"name"`
+	}
+	return json.Unmarshal([]byte(content), &envelope) == nil && envelope.Name != ""
+}
+
+// isLanguageTag reports whether s is a bare markdown info string.
+func isLanguageTag(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (sm *stateMachine) startToolCall(wrapped bool, content string) {
@@ -368,6 +490,21 @@ func jsonStringEnd(content string, start int) (int, bool) {
 // Flush drains a buffered tool call or unresolved direct-function prefix when
 // generation ends before the state machine sees its closing delimiter.
 func (sm *stateMachine) Flush() model.Result {
+	if sm.fenceActive {
+		candidate := sm.fenceBuf.String()
+		sm.fenceActive = false
+		sm.fenceBody = false
+		sm.fenceBuf.Reset()
+
+		if body, ok := fenceBodyOf(candidate); ok {
+			if trimmed := strings.TrimSpace(body); isJSONEnvelope(trimmed) {
+				sm.startToolCall(true, trimmed)
+				return sm.completeToolCall()
+			}
+		}
+		return model.Result{Channel: model.ChannelAnswer, Content: candidate}
+	}
+
 	if sm.inToolCall {
 		return sm.completeToolCall()
 	}
@@ -383,4 +520,27 @@ func (sm *stateMachine) Flush() model.Result {
 	sm.directToolCallDone = false
 
 	return result
+}
+
+// fenceBodyOf splits a reply-leading fenced block, returning the body between
+// the opener line and a closing fence. A missing closing fence is tolerated
+// so truncated generation still classifies. It reports false when the content
+// does not begin with a valid fence opener.
+func fenceBodyOf(content string) (string, bool) {
+	s := strings.TrimLeft(content, " \t\r\n")
+	rest, ok := strings.CutPrefix(s, fenceOpen)
+	if !ok {
+		return "", false
+	}
+	tag, body, found := strings.Cut(rest, "\n")
+	if !found {
+		return "", false
+	}
+	if tag = strings.TrimSpace(tag); tag != "" && !isLanguageTag(tag) {
+		return "", false
+	}
+	if inner, _, found := strings.Cut(body, "\n"+fenceOpen); found {
+		return inner, true
+	}
+	return body, true
 }


### PR DESCRIPTION
## Problem

Qwen2.5-Coder (observed on `Qwen2.5-Coder-14B-Instruct`, Q6_K) does not
always emit tool calls in the marked `<tool_call>` format its chat template
requests. At larger prompt sizes it deterministically emits a valid
tool-call envelope inside a markdown code fence as visible text:

    ```json
    {"name": "get_weather", "arguments": {"location": "Paris"}}
    ```

The qwen state machine streams those tokens as answer content. The JSON
envelope itself is perfectly formed, but it never reaches the tool channel,
so clients see prose instead of a call. The failure is silent: the model has
reported correctly, the call just never arrives.

Measured on kronk 1.32.x at temperature 0: 5/5 replies fenced at ~8k-token
prompts against 0/5 at ~200-token prompts. The wrapper is a stable function
of prompt size, not sampling noise, and it is instruction-immune — neither a
system-level prohibition nor a same-session corrective turn moves it.

This failure class is widely experienced across the ecosystem:

- The same phenomenon with the same model family: [ric03uec/lmstack#1](https://github.com/ric03uec/lmstack/issues/1) — "Qwen 2.5 Coder … wraps tool calls in ```json fences that llama.cpp's chat parser doesn't unwrap. Call lands in `message.content`, tool never runs" — and [ollama#16821](https://github.com/ollama/ollama/issues/16821) — qwen2.5-coder "usually just outputs the json for a tool call" as text.
- vLLM's tool-calling docs state the root cause outright — "the community currently lacks consensus on which tokens to emit when starting and ending tool calls" — and ship ~24 named per-family tool-call parsers behind `--tool-call-parser` ([docs](https://docs.vllm.ai/en/latest/features/tool_calling.html)); SGLang ships 13 plus a `MultiFormatParser` fallback ([docs](https://docs.sglang.io/docs/advanced_features/tool_parser.md)).
- Tolerance of malformed-but-unambiguous calls is the emerging norm: ollama's open parser-tolerance PRs for qwen ([#16398](https://github.com/ollama/ollama/pull/16398), [#16693](https://github.com/ollama/ollama/pull/16693)) cite matching fallbacks already shipped in goose and vLLM; vLLM merged a fix for Qwen3Coder silently dropping call parameters ([vllm#35615](https://github.com/vllm-project/vllm/pull/35615)); ollama v0.32.3 shipped "Fixed GLM tool calls being silently dropped"; LM Studio documents the same silent-drop class ([#942](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/942)).
- Even Qwen's own CLI carries a fallback parser for this failure class ([QwenLM/qwen-code#10692](https://github.com/QwenLM/qwen-code/issues/10692)).

## Fix

The qwen state machine now holds a reply-leading ``` fence until its body
resolves:

- A body that is a JSON tool-call envelope (`{"name": ...}`) is delivered
  through the same completion path as a marked `<tool_call>` call, so
  downstream behavior is identical.
- Anything else — code blocks, prose info strings, non-envelope JSON — is
  released verbatim, fences included, as answer content.
- The hold engages only at the start of a reply before anything has been
  emitted; fences inside ordinary prose stream untouched.
- A body whose first non-whitespace character is not `{` bails immediately,
  so ordinary fenced content still streams instead of buffering to end of
  generation.
- An unclosed fence at end of generation resolves in `Flush`:
  envelope-shaped bodies complete as calls, everything else passes through
  verbatim.

## Scope

- `sdk/kronk/parsers/qwen` only — no engine, slot, pool, or API changes; no
  registration/selection changes; no native ABI, platform (Metal/CUDA/ROCm/
  Vulkan/CPU), or documentation-generation effects. Pure Go parser change.
- The marked `<tool_call>`, `<|tool_call>`, and `<function=` paths are
  untouched; new tests cover fenced delivery (single token, token by token,
  split fence markers, bare tag), verbatim pass-through, mid-stream
  release, Flush resolution, and prose-embedded fences.
- Model-backed integration suites under `sdk/kronk/tests` are not run here
  per the developer guide (CI/human work); the end-to-end validation below
  was a deliberate run on local hardware instead.

## Validation

- `go test ./sdk/kronk/parsers/qwen/`

- End-to-end on an A4000 (16 GB), kronk built from this branch, stock GGUF
  chat template (no template override), `bartowski/Qwen2.5-Coder-14B-Instruct-Q6_K`:
  5/5 small prompts, 5/5 ~8k-token review-shaped prompts, and 3/3
  multi-turn tool loops delivered as `tool_calls` (stock parser: 0/5 at
  prompt scale). Real harness traffic (opencode driving an MCP tool):
  3/3 reviewer runs delivered findings via the tool where roughly a third
  previously arrived as fenced prose.

- Reproduction against an unpatched server, for reference:

      curl -s http://localhost:11435/v1/chat/completions \
        -d '{"model":"bartowski/Qwen2.5-Coder-14B-Instruct-Q6_K","temperature":0,"max_tokens":512,"tools":[{"type":"function","function":{"name":"submit_findings","parameters":{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}}}],"messages":[{"role":"system","content":"You are a code review agent. Report findings via submit_findings."},{"role":"user","content":"Review the following diff ... <paste roughly 8k tokens of code> ... and report your findings by calling submit_findings."}]}' | jq '.choices[0].message'

  responds with `tool_calls: null` and the complete, correct call sitting in
  `.content` inside a ```json fence. With this branch the same request
  returns the call in `tool_calls`.
